### PR TITLE
VyOS Kernel Update v4.4.95

### DIFF
--- a/scripts/live-build-config
+++ b/scripts/live-build-config
@@ -36,7 +36,7 @@ lb config noauto \
         --architectures {{architecture}} \
         --bootappend-live "boot=live components hostname=vyos username=live nopersistence noautologin nonetworking union=overlay" \
         --linux-flavours {{architecture}}-vyos \
-        --linux-packages linux-image-4.4.47 \
+        --linux-packages linux-image-4.4.95 \
         --bootloader syslinux \
         --binary-images iso-hybrid \
         --debian-installer false \


### PR DESCRIPTION
* packages/vyos-kernel efe6504...0a84c7e (18):
  > Merge tag 'v4.4.95' into current
  > add virtio scsi to kernel as loadable module
  > remove Automatically generated lines
  > Enable intel QuickAssist Technology modules
  > dccp: fix freeing skb too early for IPV6_RECVPKTINFO
  > virtio_net: validate ethtool port setting and explain the user validation
  > ethtool: make validate_speed accept all speeds between 0 and INT_MAX
  > virtio_net: add ethtool support for set and get of settings
  > ethtool: add speed/duplex validation functions
  > add vyos x86_64 defconfig
  > Merge tag 'v4.4.47' into current