### PR TITLE
Docker build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 # in order to easy exprort images built to "external" world 
 FROM debian:jessie
 
-RUN apt-get update &&\
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' | tee -a /etc/apt/sources.list &&\
+    apt-get update &&\
     apt-get install -y \
       vim \
       git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update &&\
       bison \
       libperl-dev \
       libnfnetlink-dev \
+      python3-git \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR ~

--- a/scripts/copy-image
+++ b/scripts/copy-image
@@ -4,4 +4,4 @@ BUILD_DIR=$(scripts/query-json build/build-config.json build_dir)
 BUILD_ARCH=$(scripts/query-json build/build-config.json architecture)
 VERSION=$(cat $BUILD_DIR/version)
 
-ln -nsf $BUILD_DIR/live-image-$BUILD_ARCH.hybrid.iso $BUILD_DIR/vyos-$VERSION-$BUILD_ARCH.iso
+ln -rnsf $BUILD_DIR/live-image-$BUILD_ARCH.hybrid.iso $BUILD_DIR/vyos-$VERSION-$BUILD_ARCH.iso

--- a/scripts/copy-image
+++ b/scripts/copy-image
@@ -4,4 +4,7 @@ BUILD_DIR=$(scripts/query-json build/build-config.json build_dir)
 BUILD_ARCH=$(scripts/query-json build/build-config.json architecture)
 VERSION=$(cat $BUILD_DIR/version)
 
-ln -rnsf $BUILD_DIR/live-image-$BUILD_ARCH.hybrid.iso $BUILD_DIR/vyos-$VERSION-$BUILD_ARCH.iso
+ln -nsf $BUILD_DIR/live-image-$BUILD_ARCH.hybrid.iso $BUILD_DIR/vyos-$VERSION-$BUILD_ARCH.iso 
+[ -f $BUILD_DIR/vyos-$VERSION-$BUILD_ARCH.iso  ] || exit 1
+
+

--- a/scripts/copy-image
+++ b/scripts/copy-image
@@ -4,7 +4,6 @@ BUILD_DIR=$(scripts/query-json build/build-config.json build_dir)
 BUILD_ARCH=$(scripts/query-json build/build-config.json architecture)
 VERSION=$(cat $BUILD_DIR/version)
 
-ln -nsf $BUILD_DIR/live-image-$BUILD_ARCH.hybrid.iso $BUILD_DIR/vyos-$VERSION-$BUILD_ARCH.iso 
-[ -f $BUILD_DIR/vyos-$VERSION-$BUILD_ARCH.iso  ] || exit 1
+ln -rnsf $BUILD_DIR/live-image-$BUILD_ARCH.hybrid.iso $BUILD_DIR/vyos-$VERSION-$BUILD_ARCH.iso 
 
 


### PR DESCRIPTION
* added python3-git dependency to the builder container build
* made it so that if it builds in the container the output link is relative not absolute paths, which works 

[root@c7build1 workspace]# find -iname \*iso -ls
28077838 371712 -rw-r--r--   1 root     root     380633088 Aug 11 03:42 ./Build\ VYOS\ 1.2.0+/source/build/live-image-amd64.hybrid.iso
93752035    0 lrwxrwxrwx   1 root     root           41 Aug 11 03:44 ./Build\ VYOS\ 1.2.0+/source/build/vyos-999.201808110259-amd64.iso -**> /sourc**e/build/live-image-amd64.hybrid
.iso
