### PR TITLE
Script and Instructions for building all subpackages via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,24 @@ RUN apt-get install -y \
       libexpat1-dev \
       subversion
 
+# Packages needed for pmacct
+RUN apt-get install -y \
+      libpcap-dev \
+      libpq-dev \
+      libmysqlclient-dev \
+      libgeoip-dev \
+      librabbitmq-dev \
+      libjansson-dev \
+      librdkafka-dev \
+      libnetfilter-log-dev
+
+# Packages needed for vyos-keepalived
+RUN apt-get install -y \
+      libnl-3-dev \
+      libnl-genl-3-dev \
+      libpopt-dev \
+      libsnmp-dev
+
 # Update live-build
 RUN echo 'deb http://ftp.debian.org/debian stretch main' | tee -a /etc/apt/sources.list.d/stretch.list &&\
     apt-get update &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,14 @@ RUN apt-get install -y \
       libpopt-dev \
       libsnmp-dev
 
+# Pavkages needed for wireguard
+RUN apt-get install -y \
+      libmnl-dev
+
+# Packages needed for kernel
+RuN apt-get install -y \
+      libelf-dev
+
 # Update live-build
 RUN echo 'deb http://ftp.debian.org/debian stretch main' | tee -a /etc/apt/sources.list.d/stretch.list &&\
     apt-get update &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,29 @@ RUN apt-get install -y -t jessie-backports \
       libxml2-dev \
       pkg-config
 
+# Package needed for mdns-repeater
+RUN apt-get install -y -t jessie-backports \
+      dh-systemd
+
+# Packages needed for vyatta-bash
+RUN apt-get install -y \
+      libncurses5-dev \
+      locales
+
+# Packages needed for vyatta-cfg
+RUN apt-get install -y \
+      libboost-filesystem-dev
+
+# Packages needed for vyatta-iproute
+RUN apt-get install -y \
+      libatm1-dev \
+      libdb-dev
+
+# Packages needed for vyatta-webgui
+RUN apt-get install -y \
+      libexpat1-dev \
+      subversion
+
 # Update live-build
 RUN echo 'deb http://ftp.debian.org/debian stretch main' | tee -a /etc/apt/sources.list.d/stretch.list &&\
     apt-get update &&\

--- a/README.md
+++ b/README.md
@@ -195,10 +195,7 @@ NOTE: vyos-strongswan will only compile on a linux system, running on osx or win
 
 Packages that are known to not build using this procedure:
 ```
-pmacct          - Unmet build dependencies: libpcap-dev libpq-dev libmysqlclient-dev libgeoip-dev librabbitmq-dev libjansson-dev librdkafka-dev libnetfilter-log-dev
-vyatta-util     - dh_clean: mv -Tf debian/.debhelper/bucket/files/47da33933b3825049bbc04871747a9598ce90fd45a438b6a8a58b74bf6d73a4d.tmp config/config.guess returned exit code 1
-vyos-keepalived - Unmet build dependencies: libnl-3-dev libnl-genl-3-dev libpopt-dev libsnmp-dev
-
+vyatta-util     - Not needed anymore
 vyatta-quagga   - Not needed anymore 
 vyos-1x         - Unmet build dependencies: whois libvyosconfig0
 vyos-frr        - Alott of requirements, scary stuff...

--- a/README.md
+++ b/README.md
@@ -175,14 +175,22 @@ for dir in packages/*; do
 done
 ```
 ### Building packages
-Most packages can be built by using the vyos-builder docker container with the same parameters, the vyos-builder container should include all dependencies for compiling supported packages.
-The script `./scripts/build-docker-subpackages` is created to automate the process of building packages, just execute it in the root of vyos-build to start compilation on all supported packages that are checked out. 
+The script `./scripts/build-submodules` is created to automate the process of building packages, execute it in the root of `vyos-build` to start compilation on all supported packages that are checked out. 
+
+The easiest way to compile is with the `vyos-builder` docker container, it includes all dependencies for compiling supported packages.
+
+```bash
+$ docker run --rm -it -v $(pwd):/vyos -w /vyos \
+             --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
+             vyos-builder \
+             ./scripts/build-submodules
+```
 
 NOTE: Prior to executing this script you need to create/build the `vyos-builder` container and checkout all packages you want to compile. 
 
 ### Building one package
-the script above runs a docker container for every build it does. this is also possible to do by hand using: 
-Ecevuted from the root directory of vyos-build
+the script above runs all package build inside a docker container, this is also possible to do by hand using: 
+Executed from the root directory of vyos-build
 ```bash
 $ docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/PACKAGENAME \
              --sysctl net.ipv6.conf.lo.disable_ipv6=0 \

--- a/README.md
+++ b/README.md
@@ -184,7 +184,10 @@ NOTE: Prior to executing this script you need to create/build the `vyos-builder`
 the script above runs a docker container for every build it does. this is also possible to do by hand using: 
 Ecevuted from the root directory of vyos-build
 ```bash
-$ docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/PACKAGENAME --sysctl net.ipv6.conf.lo.disable_ipv6=0 vyos-builder dpkg-buildpackage -uc -us -tc -b
+$ docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/PACKAGENAME \
+             --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
+             vyos-builder \
+             dpkg-buildpackage -uc -us -tc -b
 ```
 NOTE: `--sysctl net.ipv6.conf.lo.disable_ipv6=0` is only needed when building vyos-strongswan and can be ignored on other packages
 NOTE: Prior to executing this you need to checkout and update the submodules you want to recompile

--- a/scripts/build-docker-subpackages
+++ b/scripts/build-docker-subpackages
@@ -73,7 +73,6 @@ for PKG in mdns-repeater \
            vyos-strongswan \
            vyos-world \
            ; do
-  break;
   if [ -d "packages/$PKG/debian" ]; then
     status_start "Building package: $PKG"
     docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/$PKG \

--- a/scripts/build-docker-subpackages
+++ b/scripts/build-docker-subpackages
@@ -97,33 +97,49 @@ if [ -f "packages/vyos-kernel/Makefile" ]; then
                --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
                vyos-builder \
                bash -c '../../scripts/build-kernel' >packages/vyos-kernel.buildlog 2>&1
-      if [ $? -ne 0 ]; then
-      status_fail
-      error_msg "Failed to build package vyos-kernel, look in vyos-kernel.buildlog to examine the fault\n"
-    else
-      status_ok
-    fi
+  if [ $? -ne 0 ]; then
+    status_fail
+    error_msg "Failed to build package vyos-kernel, look in vyos-kernel.buildlog to examine the fault\n"
+  else
+    VERSION=$(grep "^VERSION" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
+    PATCHLEVEL=$(grep "^PATCHLEVEL" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
+    SUBLEVEL=$(grep "^SUBLEVEL" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
+    ARCH=$(dpkg --print-architecture)
+    sed -i.bak "s/--linux-packages .* \\\/--linux-packages linux-image-$VERSION\.$PATCHLEVEL\.$SUBLEVEL \\\/" scripts/live-build-config 
+    status_ok
+  fi
 else
   status_skip "No source for: vyos-kernel"
 fi
 
+
+
 # WIREGUARD
 if [ -d "packages/vyos-wireguard/debian" ]; then
-  status_start "Building package: vyos-wireguard"
   if [ -f "packages/vyos-kernel/Makefile" ]; then
-    docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/vyos-wireguard \
-               --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
-               vyos-builder \
-               bash -c 'KERNELDIR=/vyos/packages/vyos-kernel dpkg-buildpackage -uc -us -tc -b' >packages/vyos-wireguard.buildlog 2>&1
-    if [ $? -ne 0 ]; then
-      status_fail
-      error_msg "Failed to build package vyos-wireguard, look in vyos-wireguard.buildlog to examine the fault\n"
+    status_start "Building package: vyos-wireguard"
+    if  grep -q "KBUILD_OUTPUT" packages/vyos-kernel/Makefile; then
+      VERSION=$(grep "^VERSION" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
+      PATCHLEVEL=$(grep "^PATCHLEVEL" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
+      SUBLEVEL=$(grep "^SUBLEVEL" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
+      ARCH=$(dpkg --print-architecture)
+      echo "src/wireguard.ko /lib/modules/$VERSION.$PATCHLEVEL.$SUBLEVEL-$ARCH-vyos/extra" > packages/vyos-wireguard/debian/wireguard-modules.install
+      docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/vyos-wireguard \
+                 --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
+                 vyos-builder \
+                 bash -c 'KERNELDIR=/vyos/packages/vyos-kernel dpkg-buildpackage -uc -us -tc -b' >packages/vyos-wireguard.buildlog 2>&1
+      if [ $? -ne 0 ]; then
+        status_fail
+        error_msg "Failed to build package vyos-wireguard, look in vyos-wireguard.buildlog to examine the fault\n"
+      else
+        status_ok
+      fi
     else
-      status_ok
+      status_fail
+      error_msg "Failed to build package vyos-wireguard, no kernel source found\n"
     fi
   else
-    status_fail
-    error_msg "Failed to build package vyos-wireguard, no kernel source found\n"
+    seeor_msg "Something wrong with the kernel module?"
   fi
 else 
     status_skip "No source for: vyos-wireguard"

--- a/scripts/build-docker-subpackages
+++ b/scripts/build-docker-subpackages
@@ -1,0 +1,66 @@
+#!/bin/bash 
+#set -x
+if [ ! -d "packages" ]; then
+  echo "This script needs to be executed inside the top root of vyos-build"
+  exit 1
+fi
+
+echo "Cleaning up buildfiles..."
+rm -rf packages/*.deb
+rm -rf packages/*.changes
+echo "-----------------------------------------------------"
+
+for PKG in mdns-repeater \
+           pmacct \
+           udp-broadcast-relay \
+           vyatta-bash \
+           vyatta-cfg \
+           vyatta-cfg-firewall \
+           vyatta-cfg-op-pppoe \
+           vyatta-cfg-qos \
+           vyatta-cfg-quagga \
+           vyatta-cfg-system \
+           vyatta-cfg-vpn \
+           vyatta-cluster \
+           vyatta-config-mgmt \
+           vyatta-config-migrate \
+           vyatta-conntrack \
+           vyatta-conntrack-sync \
+           vyatta-eventwatch \
+           vyatta-iproute \
+           vyatta-ipv6-rtradv \
+           vyatta-lldp \
+           vyatta-nat \
+           vyatta-netflow \
+           vyatta-op \
+           vyatta-op-dhcp-server \
+           vyatta-op-firewall \
+           vyatta-op-qos \
+           vyatta-op-quagga \
+           vyatta-op-vpn \
+           vyatta-openvpn \
+           vyatta-ravpn \
+           vyatta-util \
+           vyatta-vrrp \
+           vyatta-wanloadbalance \
+           vyatta-webgui \
+           vyatta-webproxy \
+           vyatta-wireless \
+           vyatta-wirelessmodem \
+           vyatta-zone \
+           vyos-keepalived \
+           vyos-nhrp \
+           vyos-pppoe-server \
+           vyos-strongswan \
+           vyos-world \
+           ; do
+  if [ -d "packages/$PKG/debian" ]; then
+    echo "Building package: $PKG"
+    docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/$PKG --sysctl net.ipv6.conf.lo.disable_ipv6=0 vyos-builder dpkg-buildpackage -uc -us -tc -b >packages/$PKG.buildlog 2>&1
+    if [ $? -ne 0 ]; then
+      echo "FAILED to build package $PKG, look in $PKG.buildlog to examine the fault"
+    fi
+  else
+    echo "Did not find source for: $PKG"
+  fi
+done

--- a/scripts/build-docker-subpackages
+++ b/scripts/build-docker-subpackages
@@ -5,11 +5,31 @@ if [ ! -d "packages" ]; then
   exit 1
 fi
 
+status_start() {
+echo -ne "[    ] $1"
+}
+status_ok() {
+echo -ne "\r[\e[32m OK \e[39m]\n"
+}
+
+status_fail() {
+echo -ne "\r[\e[31mFAIL\e[39m]\n"
+}
+
+status_skip() {
+echo -ne "\r[SKIP] $1\n"
+}
+
+error_msg() {
+echo -ne "      $1\n"
+}
+
 echo "Cleaning up buildfiles..."
 rm -rf packages/*.deb
 rm -rf packages/*.changes
 echo "-----------------------------------------------------"
-
+echo "Starting build process for all packages"
+echo ""
 for PKG in mdns-repeater \
            pmacct \
            udp-broadcast-relay \
@@ -53,13 +73,59 @@ for PKG in mdns-repeater \
            vyos-strongswan \
            vyos-world \
            ; do
+  break;
   if [ -d "packages/$PKG/debian" ]; then
-    echo "Building package: $PKG"
-    docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/$PKG --sysctl net.ipv6.conf.lo.disable_ipv6=0 vyos-builder dpkg-buildpackage -uc -us -tc -b >packages/$PKG.buildlog 2>&1
+    status_start "Building package: $PKG"
+    docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/$PKG \
+               --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
+               vyos-builder \
+               dpkg-buildpackage -uc -us -tc -b >packages/$PKG.buildlog 2>&1
     if [ $? -ne 0 ]; then
-      echo "FAILED to build package $PKG, look in $PKG.buildlog to examine the fault"
+      status_fail
+      error_msg "Failed to build package $PKG, look in $PKG.buildlog to examine the fault\n"
+    else
+      status_ok
     fi
   else
-    echo "Did not find source for: $PKG"
+    status_skip "No source for: $PKG"
   fi
 done
+
+# KERNEL
+if [ -f "packages/vyos-kernel/Makefile" ]; then
+  status_start "Building-package: vyos-kernel"
+  docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/vyos-kernel \
+               --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
+               vyos-builder \
+               bash -c '../../scripts/build-kernel' >packages/vyos-kernel.buildlog 2>&1
+      if [ $? -ne 0 ]; then
+      status_fail
+      error_msg "Failed to build package vyos-kernel, look in vyos-kernel.buildlog to examine the fault\n"
+    else
+      status_ok
+    fi
+else
+  status_skip "No source for: vyos-kernel"
+fi
+
+# WIREGUARD
+if [ -d "packages/vyos-wireguard/debian" ]; then
+  status_start "Building package: vyos-wireguard"
+  if [ -f "packages/vyos-kernel/Makefile" ]; then
+    docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/vyos-wireguard \
+               --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
+               vyos-builder \
+               bash -c 'KERNELDIR=/vyos/packages/vyos-kernel dpkg-buildpackage -uc -us -tc -b' >packages/vyos-wireguard.buildlog 2>&1
+    if [ $? -ne 0 ]; then
+      status_fail
+      error_msg "Failed to build package vyos-wireguard, look in vyos-wireguard.buildlog to examine the fault\n"
+    else
+      status_ok
+    fi
+  else
+    status_fail
+    error_msg "Failed to build package vyos-wireguard, no kernel source found\n"
+  fi
+else 
+    status_skip "No source for: vyos-wireguard"
+fi

--- a/scripts/build-docker-subpackages
+++ b/scripts/build-docker-subpackages
@@ -40,7 +40,6 @@ for PKG in mdns-repeater \
            vyatta-op-vpn \
            vyatta-openvpn \
            vyatta-ravpn \
-           vyatta-util \
            vyatta-vrrp \
            vyatta-wanloadbalance \
            vyatta-webgui \

--- a/scripts/build-submodules
+++ b/scripts/build-submodules
@@ -5,6 +5,19 @@ if [ ! -d "packages" ]; then
   exit 1
 fi
 
+if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+  echo "Script for building all subpackages to vyos"
+  echo "Execute this sctipt from the root of the vyos-build directory"
+  echo ""
+  echo "This script could be executed from a Debian Jessie installation with all dependencies"
+  echo "or from the vyos-builder docker container"
+  echo "docker instructions"
+  echo "Build the container:"
+  echo "  docker build -t vyos-builder ." 
+  echo "Compile packages:"
+  echo "  docker run --rm -it -v $(pwd):/vyos -w /vyos --sysctl net.ipv6.conf.lo.disable_ipv6=0 vyos-builder scripts/build-docker-subpaclages"
+fi
+
 status_start() {
 echo -ne "[    ] $1"
 }
@@ -23,10 +36,13 @@ echo -ne "\r[SKIP] $1\n"
 error_msg() {
 echo -ne "      $1\n"
 }
+ROOTDIR="$(pwd)"
+PKGDIR="$(pwd)/packages"
 
 echo "Cleaning up buildfiles..."
-rm -rf packages/*.deb
-rm -rf packages/*.changes
+rm -rf $PKGDIR/*.deb
+rm -rf $PKGDIR/*.changes
+rm -rf $PKGDIR/*.buildlog
 echo "-----------------------------------------------------"
 echo "Starting build process for all packages"
 echo ""
@@ -75,16 +91,15 @@ for PKG in mdns-repeater \
            ; do
   if [ -d "packages/$PKG/debian" ]; then
     status_start "Building package: $PKG"
-    docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/$PKG \
-               --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
-               vyos-builder \
-               dpkg-buildpackage -uc -us -tc -b >packages/$PKG.buildlog 2>&1
+    pushd $PKGDIR/$PKG > /dev/null
+    dpkg-buildpackage -uc -us -tc -b >$PKGDIR/$PKG.buildlog 2>&1
     if [ $? -ne 0 ]; then
       status_fail
       error_msg "Failed to build package $PKG, look in $PKG.buildlog to examine the fault\n"
     else
       status_ok
     fi
+    popd > /dev/null
   else
     status_skip "No source for: $PKG"
   fi
@@ -93,21 +108,20 @@ done
 # KERNEL
 if [ -f "packages/vyos-kernel/Makefile" ]; then
   status_start "Building-package: vyos-kernel"
-  docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/vyos-kernel \
-               --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
-               vyos-builder \
-               bash -c '../../scripts/build-kernel' >packages/vyos-kernel.buildlog 2>&1
+  pushd packages/vyos-kernel > /dev/null
+  bash -c '../../scripts/build-kernel' >$PKGDIR/vyos-kernel.buildlog 2>&1
   if [ $? -ne 0 ]; then
     status_fail
     error_msg "Failed to build package vyos-kernel, look in vyos-kernel.buildlog to examine the fault\n"
   else
-    VERSION=$(grep "^VERSION" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
-    PATCHLEVEL=$(grep "^PATCHLEVEL" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
-    SUBLEVEL=$(grep "^SUBLEVEL" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
+    VERSION=$(grep "^VERSION" Makefile | grep -Eo '[0-9]{1,4}')
+    PATCHLEVEL=$(grep "^PATCHLEVEL" Makefile | grep -Eo '[0-9]{1,4}')
+    SUBLEVEL=$(grep "^SUBLEVEL" Makefile | grep -Eo '[0-9]{1,4}')
     ARCH=$(dpkg --print-architecture)
-    sed -i.bak "s/--linux-packages .* \\\/--linux-packages linux-image-$VERSION\.$PATCHLEVEL\.$SUBLEVEL \\\/" scripts/live-build-config 
+    sed -i.bak "s/--linux-packages .* \\\/--linux-packages linux-image-$VERSION\.$PATCHLEVEL\.$SUBLEVEL \\\/" $ROOTDIR/scripts/live-build-config 
     status_ok
   fi
+  popd > /dev/null
 else
   status_skip "No source for: vyos-kernel"
 fi
@@ -123,17 +137,16 @@ if [ -d "packages/vyos-wireguard/debian" ]; then
       PATCHLEVEL=$(grep "^PATCHLEVEL" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
       SUBLEVEL=$(grep "^SUBLEVEL" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
       ARCH=$(dpkg --print-architecture)
-      echo "src/wireguard.ko /lib/modules/$VERSION.$PATCHLEVEL.$SUBLEVEL-$ARCH-vyos/extra" > packages/vyos-wireguard/debian/wireguard-modules.install
-      docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/vyos-wireguard \
-                 --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
-                 vyos-builder \
-                 bash -c 'KERNELDIR=/vyos/packages/vyos-kernel dpkg-buildpackage -uc -us -tc -b' >packages/vyos-wireguard.buildlog 2>&1
+      pushd packages/vyos-wireguard > /dev/null
+      echo "src/wireguard.ko /lib/modules/$VERSION.$PATCHLEVEL.$SUBLEVEL-$ARCH-vyos/extra" > debian/wireguard-modules.install
+      bash -c 'KERNELDIR=/vyos/packages/vyos-kernel dpkg-buildpackage -uc -us -tc -b' >$PKGDIR/vyos-wireguard.buildlog 2>&1
       if [ $? -ne 0 ]; then
         status_fail
         error_msg "Failed to build package vyos-wireguard, look in vyos-wireguard.buildlog to examine the fault\n"
       else
         status_ok
       fi
+      popd > /dev/null
     else
       status_fail
       error_msg "Failed to build package vyos-wireguard, no kernel source found\n"


### PR DESCRIPTION
Based on the work i did in T1070 to build `vyos-strongswan` inside docker i've created a script and added instruction about compiling most of the submodules in vyos-build/packages.

After initial pull of all packages the `build-docker-subpackages` script will build almost all packages inside `vyos-build`. The `vyos-builder` docker container is also updated to be inline with all dependencies.

After compiling a new kernel package the `live-build-config` script is also updated to reflect the new version.  this is also done when the `vyos-wireguard` package is built.

I've not added a phabricator ticket on this PR, just let me know if its required and i'll add it.