### PR TITLE
T1120: Add rootdelay=5 by default in grub.cfg

### DIFF
--- a/data/live-build-config/includes.chroot/opt/vyatta/etc/grub/default-union-grub-entry
+++ b/data/live-build-config/includes.chroot/opt/vyatta/etc/grub/default-union-grub-entry
@@ -1,20 +1,20 @@
 menuentry "VyOS  (KVM console)" {
-        linux /boot//vmlinuz boot=live quiet vyos-union=/boot/ console=ttyS0,9600 console=tty0
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 vyos-union=/boot/ console=ttyS0,9600 console=tty0
         initrd /boot//initrd.img
 }
 
 menuentry "VyOS  (Serial console)" {
-        linux /boot//vmlinuz boot=live quiet vyos-union=/boot/ console=tty0 console=ttyS0,9600
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 vyos-union=/boot/ console=tty0 console=ttyS0,9600
         initrd /boot//initrd.img
 }
 
 menuentry "Lost password change  (KVM console)" {
-        linux /boot//vmlinuz boot=live quiet vyos-union=/boot/ console=ttyS0,9600 console=tty0 init=/opt/vyatta/sbin/standalone_root_pw_reset
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 vyos-union=/boot/ console=ttyS0,9600 console=tty0 init=/opt/vyatta/sbin/standalone_root_pw_reset
         initrd /boot//initrd.img
 }
 
 menuentry "Lost password change  (Serial console)" {
-        linux /boot//vmlinuz boot=live quiet vyos-union=/boot/ console=tty0 console=ttyS0,9600 init=/opt/vyatta/sbin/standalone_root_pw_reset
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 vyos-union=/boot/ console=tty0 console=ttyS0,9600 init=/opt/vyatta/sbin/standalone_root_pw_reset
         initrd /boot//initrd.img
 }
 


### PR DESCRIPTION
Let disks settle to workaround issue with MD array not being detected.