### PR TITLE
Compile frr, set user with gosu in docker and fixup of logging and errors in build-subpackages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,18 @@ RUN apt-get update && apt-get install -y \
       cmake \
       liblua5.1-dev
 
+# Packages needed for vyos-frr
+RUN sudo apt-get update && sudo apt-get install -y \
+      texinfo \
+      imagemagick \
+      groff \
+      hardening-wrapper \
+      gawk \
+      chrpath \
+      libjson0 \
+      libjson0-dev \
+      python-ipaddr
+
 # Update live-build
 RUN echo 'deb http://ftp.debian.org/debian stretch main' | tee -a /etc/apt/sources.list.d/stretch.list &&\
     apt-get update &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' | tee -a /etc/
       python3-coverage
 
 # Packages needed for building vyos-strongswan
-RUN apt-get install -y -t jessie-backports \
+RUN apt-get update && apt-get install -y -t jessie-backports \
       debhelper &&\
     apt-get install -y \
       dh-apparmor \
@@ -68,30 +68,30 @@ RUN apt-get install -y -t jessie-backports \
       pkg-config
 
 # Package needed for mdns-repeater
-RUN apt-get install -y -t jessie-backports \
+RUN apt-get update && apt-get install -y -t jessie-backports \
       dh-systemd
 
 # Packages needed for vyatta-bash
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
       libncurses5-dev \
       locales
 
 # Packages needed for vyatta-cfg
-RUN apt-get install -y \
+RUN apt-get update &&apt-get install -y \
       libboost-filesystem-dev
 
 # Packages needed for vyatta-iproute
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
       libatm1-dev \
       libdb-dev
 
 # Packages needed for vyatta-webgui
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
       libexpat1-dev \
       subversion
 
 # Packages needed for pmacct
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
       libpcap-dev \
       libpq-dev \
       libmysqlclient-dev \
@@ -102,18 +102,18 @@ RUN apt-get install -y \
       libnetfilter-log-dev
 
 # Packages needed for vyos-keepalived
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
       libnl-3-dev \
       libnl-genl-3-dev \
       libpopt-dev \
       libsnmp-dev
 
 # Pavkages needed for wireguard
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
       libmnl-dev
 
 # Packages needed for kernel
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
       libelf-dev
 
 # Packages needed for vyos-accel-ppp

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM debian:jessie
 
 RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' | tee -a /etc/apt/sources.list &&\
     apt-get update && apt-get install -y \
+      gosu \
       vim \
       git \
       make \
@@ -143,10 +144,12 @@ RUN export LATEST="$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packe
     curl -K- | gzip -d > /usr/bin/packer && \
     chmod +x /usr/bin/packer
 
+COPY scripts/docker-entrypoint.sh /usr/local/bin/
 # Create vyos_bld user account and enable sudo
-RUN useradd -ms /bin/bash -u 1006 --gid users vyos_bld && \
-    usermod -aG sudo vyos_bld && \
-    echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+#RUN useradd -ms /bin/bash -u 1006 --gid users vyos_bld && \
+#    usermod -aG sudo vyos_bld && \
+#    echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-USER vyos_bld
-WORKDIR /home/vyos_bld
+#USER vyos_bld
+#WORKDIR /home/vyos_bld
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/scripts/build-submodules
+++ b/scripts/build-submodules
@@ -66,21 +66,6 @@ error_msg() {
 ROOTDIR="$(pwd)"
 PKGDIR="$(pwd)/packages"
 
-initiate_package() {
-  PKG=$1
-  status_start "Initializing subpackage: $PKG"
-  ( set -e
-    git submodule update --init packages/$PKG  >>$PKGDIR/$PKG.buildlog 2>&1
-    cd $PKGDIR/$PKG
-    git checkout current
-  )
-  if [ $? -ne 0 ]; then
-    status_fail "Failed to initiate package $PKG, look in $PKG.buildlog to examine the fault\n"
-    return 1
-  fi
-  status_ok
-  return 0
-}
 
 build_package() {
   PKG=$1
@@ -89,10 +74,10 @@ build_package() {
     status_skip "No source for: $PKG"
     return 1
   fi
-  ( set -e
-    cd $PKGDIR/$PKG > /dev/null
-    dpkg-buildpackage -uc -us -tc -b >>$PKGDIR/$PKG.buildlog 2>&1
-  )
+  ( set -e; set -x
+    cd $PKGDIR/$PKG
+    dpkg-buildpackage -uc -us -tc -b
+  ) >>$PKGDIR/$PKG.buildlog 2>&1
   if [ $? -ne 0 ]; then
     status_fail
     error_msg "Failed to build package $PKG, look in $PKG.buildlog to examine the fault\n"
@@ -108,6 +93,28 @@ rm -rf $PKGDIR/*.buildlog
 echo "-----------------------------------------------------"
 echo "Starting build process for all packages"
 echo ""
+
+initialize_packages() {
+  status_start "Initializing packages"
+  (
+    set -x
+    git submodule update --init --recursive
+    git submodule update --remote
+  ) >>$PKGDIR/init-packages.buildlog 2>&1
+  if [ $? -ne 0 ]; then
+      status_fail
+      if [ $VERBOSE ]; then
+          cat $PKGDIR/init-packages.buildlog
+      fi
+      error_msg "Failed to update all package, look in init-packages.buildlog to examine the fault\n"
+      return 1
+  fi
+  status_ok
+}
+if [ $INIT_PACKAGES ]; then
+  initialize_packages
+fi
+
 for PKG in mdns-repeater \
            pmacct \
            udp-broadcast-relay \
@@ -152,9 +159,6 @@ for PKG in mdns-repeater \
            vyos-strongswan \
            vyos-world \
            ; do
-  if [ $INIT_PACKAGES ]; then
-    initiate_package "$PKG"
-  fi
   build_package "$PKG"
 done
 
@@ -167,10 +171,10 @@ build_kernel() {
     return 0
   fi
 
-  ( set -e
+  ( set -e; set -x
     cd packages/vyos-kernel > /dev/null
-    bash -c '../../scripts/build-kernel' >$PKGDIR/vyos-kernel.buildlog 2>&1
-  )
+    bash -c '../../scripts/build-kernel'
+  ) >>$PKGDIR/vyos-kernel.buildlog 2>&1
   if [ $? -ne 0 ]; then
     status_fail
     if [ $VERBOSE ]; then
@@ -216,11 +220,11 @@ build_wireguard() {
   SUBLEVEL=$(grep "^SUBLEVEL" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
   ARCH=$(dpkg --print-architecture)
   # Collect kernel information
-  ( set -e
-    pushd packages/vyos-wireguard > /dev/null
-    echo "src/wireguard.ko /lib/modules/$VERSION.$PATCHLEVEL.$SUBLEVEL-$ARCH-vyos/extra" > debian/wireguard-modules.install
-    bash -c 'KERNELDIR=/vyos/packages/vyos-kernel dpkg-buildpackage -uc -us -tc -b' >$PKGDIR/vyos-wireguard.buildlog 2>&1
-  )
+  ( set -e; set -x
+    cd packages/vyos-wireguard
+    echo "src/wireguard.ko /lib/modules/$VERSION.$PATCHLEVEL.$SUBLEVEL-$ARCH-vyos/extra" | tee debian/wireguard-modules.install
+    bash -c 'KERNELDIR=/vyos/packages/vyos-kernel dpkg-buildpackage -uc -us -tc -b'
+  ) >>$PKGDIR/vyos-wireguard.buildlog 2>&1
   if [ $? -ne 0 ]; then
     status_fail
     if [ $VERBOSE ]; then
@@ -231,7 +235,7 @@ build_wireguard() {
   fi
   status_ok
 }
-(build_wireguard)
+build_wireguard
 
 
 # ACCEL-PPP
@@ -242,8 +246,9 @@ build_accel-ppp() {
     return 0
   fi
 
-  if [ -f "packages/vyos-kernel/Makefile" ]; then
-    error_msg "Something wrong with the kernel module?"
+  if [ ! -f "packages/vyos-kernel/Makefile" ]; then
+    status_fail
+    error_msg "No Makefile found in kernel package"
     return 1
   fi
 
@@ -257,12 +262,12 @@ build_accel-ppp() {
   SUBLEVEL=$(grep "^SUBLEVEL" packages/vyos-kernel/Makefile | grep -Eo '[0-9]{1,4}')
   ARCH=$(dpkg --print-architecture)
 
-  ( set -e
+  ( set -e; set -x
     pushd packages/vyos-accel-ppp > /dev/null
-    echo "lib/modules/$VERSION.$PATCHLEVEL.$SUBLEVEL-$ARCH-vyos/extra/*.ko" > debian/vyos-accel-ppp-ipoe-kmod.install
+    echo "lib/modules/$VERSION.$PATCHLEVEL.$SUBLEVEL-$ARCH-vyos/extra/*.ko" | tee debian/vyos-accel-ppp-ipoe-kmod.install
     sed -i "s#[0-9].[0-9][0-9].[0-9]-amd64-vyos#$VERSION.$PATCHLEVEL.$SUBLEVEL-$ARCH-vyos#g" debian/rules
-    KERNELDIR=$PKGDIR/vyos-kernel dpkg-buildpackage -uc -us -tc -b >$PKGDIR/vyos-accel-ppp.buildlog 2>&1
-  )
+    KERNELDIR=$PKGDIR/vyos-kernel dpkg-buildpackage -uc -us -tc -b
+  ) >>$PKGDIR/vyos-accel-ppp.buildlog 2>&1
   if [ $? -ne 0 ]; then
     status_fail
     if [ $VERBOSE ]; then

--- a/scripts/build-submodules
+++ b/scripts/build-submodules
@@ -247,7 +247,8 @@ build_accel-ppp() {
   fi
 
   if [ ! -f "packages/vyos-kernel/Makefile" ]; then
-    error_msg "Something wrong with the kernel module?"
+    status_fail
+    error_msg "No Makefile found in kernel package"
     return 1
   fi
 

--- a/scripts/build-submodules
+++ b/scripts/build-submodules
@@ -145,6 +145,7 @@ for PKG in mdns-repeater \
            vyatta-wireless \
            vyatta-wirelessmodem \
            vyatta-zone \
+           vyos-frr \
            vyos-keepalived \
            vyos-nhrp \
            vyos-pppoe-server \

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Use GOSU_USER if its specified, else wirking dir user
+if [ -n "$GOSU_USER" ]; then 
+  ID=$GOSU_USER
+else
+  ID=$(stat -c "%u:%g" .)
+fi
+
+# Don't use GOSU if we are root
+if [ ! "$ID" = "0:0" ]; then
+  exec gosu $ID "$@"
+else
+  exec "$@"
+fi


### PR DESCRIPTION
Quite a few changes in this PR.

1:   The docker image now finds the userid to execute under from the owner of the current directory, this is done with the gosu utillity.
2:  Deps added to Dockerfile for successful compilation of FRR

3: build-subpackages now saves all commands and execution output to the buildlog files.

4: the Dockerfile not executes apt-get update inside any RUN that uses apt-get install. this is to not run into issues when rebuilding image from cache where the apt-cache is outdated