### PR TITLE
Added menhir as a build dependency for libvyosconfig

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -186,7 +186,8 @@ RUN apt-get update && apt-get install -y \
 
 # Packages needed for libvyosconfig && VyConf
 RUN apt-get update && apt-get install -y \
-      libffi-dev
+      libffi-dev \
+      menhir
 
 # Packages needed for libvyosconfig
 RUN curl https://raw.githubusercontent.com/ocaml/opam/2.0.2/shell/install.sh --output /tmp/opam_install.sh && \


### PR DESCRIPTION
I had trouble building the libvyosconfig package / sub-module because I didn't have [menhir](https://packages.debian.org/jessie/menhir) installed

As called in the Makefile:
https://github.com/vyos/libvyosconfig/blob/master/Makefile#L84
