### PR TITLE
T1202: Add `hvinfo` to the packages directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -237,3 +237,7 @@
 	path = packages/igmpproxy
 	url = https://github.com/vyos/igmpproxy.git
 	branch = current
+[submodule "packages/hvinfo"]
+	path = packages/hvinfo
+	url = https://github.com/dmbaturin/hvinfo.git
+	branch = master

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -234,6 +234,11 @@ RUN eval $(opam env --root=/opt/opam --set-root) && \
     dpkg-buildpackage -uc -us -tc -b && \
     dpkg -i ../libvyosconfig0_*_amd64.deb
 
+# Packages needed for hvinfo
+RUN apt-get update && apt-get install -y \
+      gnat \
+      gprbuild
+
 # Packages needed for vyos-1x
 RUN apt-get update && apt-get install -y \
       whois

--- a/scripts/build-submodules
+++ b/scripts/build-submodules
@@ -198,6 +198,7 @@ for PKG in mdns-repeater \
            eventwatchd \
            ddclient \
            rtrlib \
+           hvinfo \
            igmpproxy \
            libvyosconfig \
            vyatta-bash \


### PR DESCRIPTION
Add `hvinfo` to the packages directory

hvinfo is by @dmbaturin and is depended on by `vyos-1x`:
https://github.com/vyos/vyos-1x/blob/current/debian/control

`hvinfo` is not available in Debian or Ubuntu.
