### PR TITLE
T1214: Add `ipaddrcheck` to the packages directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -245,3 +245,7 @@
 	path = packages/libyang
     url = https://github.com/opensourcerouting/libyang.git
     branch = debian
+[submodule "packages/ipaddrcheck"]
+	path = packages/ipaddrcheck
+	url = https://github.com/vyos/ipaddrcheck.git
+	branch = master

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -234,6 +234,12 @@ RUN eval $(opam env --root=/opt/opam --set-root) && \
     dpkg-buildpackage -uc -us -tc -b && \
     dpkg -i ../libvyosconfig0_*_amd64.deb
 
+# Packages needed for ipaddrcheck
+RUN apt-get update && apt-get install -y \
+      libpcre3-dev \
+      libcidr-dev \
+      check
+
 # Packages needed for hvinfo
 RUN apt-get update && apt-get install -y \
       gnat \

--- a/scripts/build-submodules
+++ b/scripts/build-submodules
@@ -260,6 +260,7 @@ for PKG in mdns-repeater \
            rtrlib \
            hvinfo \
            igmpproxy \
+           ipaddrcheck \
            libvyosconfig \
            vyatta-bash \
            vyatta-biosdevname \


### PR DESCRIPTION
While building the `current` branch of vyos-build, I found that the `vyos-1x` and `vyatta-cfg-quagga` packages depends upon `ipaddrcheck` but isn't listed in the packages directory.