### PR TITLE
Changed architecture name for 32-bit x86 to 'i386'

### DIFF
--- a/scripts/build-config
+++ b/scripts/build-config
@@ -52,7 +52,7 @@ def get_validator(optdict, name):
 # Options dict format:
 # '$option_name_without_leading_dashes': { ('$help_string', $default_value_generator_thunk, $value_checker_thunk) }
 options = {
-   'architecture': ('Image target architecture (amd64 or i586 or armhf)', lambda: 'amd64', lambda x: x in ['amd64', 'i586', 'armhf']),
+   'architecture': ('Image target architecture (amd64 or i386 or armhf)', lambda: 'amd64', lambda x: x in ['amd64', 'i386', 'armhf']),
    'build-by': ('Builder identifier (e.g. jrandomhacker@example.net)', get_default_build_by, None),
    'debian-mirror': ('Debian repository mirror for ISO build', lambda: defaults.DEBIAN_MIRROR, None),
    'debian-security-mirror': ('Debian security updated mirror', lambda: defaults.DEBIAN_SECURITY_MIRROR, None),

--- a/scripts/build-flavour
+++ b/scripts/build-flavour
@@ -27,7 +27,7 @@ if [ $BUILD_TYPE = "development" ]; then
 fi
 
 # Install grub-pc if it's an x86 build
-if [ $BUILD_ARCH  = 'amd64' -o $BUILD_ARCH = 'i686' ]; then
+if [ $BUILD_ARCH  = 'amd64' -o $BUILD_ARCH = 'i386' ]; then
     cp data/package-lists/vyos-x86.list.chroot build/config/package-lists/
 fi
 


### PR DESCRIPTION
I renamed the architecture from `i586` to `i386`, because that is the official Debian designation and live-build was't working with the string `i586`.

https://www.debian.org/releases/jessie/i386/ch02s01.html.en

(This is also what `dpkg --print-architecture` returns)
