### PR TITLE
Equuleus: Fixes for booting live-build image on Buster. 

### DIFF
--- a/data/live-build-config/hooks/live/10-unmountfs.chroot
+++ b/data/live-build-config/hooks/live/10-unmountfs.chroot
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+exit 0
 # hack umountfs script to cleanly unmount live systems
 
 sed \

--- a/data/live-build-config/hooks/live/24-efi_packages.chroot
+++ b/data/live-build-config/hooks/live/24-efi_packages.chroot
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+exit 0
 echo I: Download grub-efi packages.
 
 mkdir -p /usr/share/vyos/packages

--- a/data/package-lists/vyos-x86.list.chroot
+++ b/data/package-lists/vyos-x86.list.chroot
@@ -2,5 +2,3 @@ grub2
 grub-pc
 qemu-guest-agent
 hyperv-daemons
-vyos-xe-guest-utilities
-vyos-netplug

--- a/scripts/live-build-config
+++ b/scripts/live-build-config
@@ -35,7 +35,7 @@ util.check_build_config()
 lb_config_tmpl = """
 lb config noauto \
         --architectures {{architecture}} \
-        --bootappend-live "boot=live components hostname=vyos username=live nopersistence noautologin nonetworking union=overlay" \
+        --bootappend-live "boot=live components hostname=vyos username=live nopersistence noautologin nonetworking union=overlay console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0" \
         --linux-flavours {{kernel_flavor}} \
         --linux-packages linux-image-{{kernel_version}} \
         --bootloader syslinux,grub-efi \


### PR DESCRIPTION
This PR fixes or hotfixes a few issues with booting vyos on buster, with these fixes and a fix to `vyatta-cfg-system` it is possible to build an iso from buster as a start.