### PR TITLE
T1445: Revert "Update to apply arguments"

### DIFF
--- a/configure
+++ b/configure
@@ -1,1 +1,1 @@
-scripts/build-config "$@"
+scripts/build-config


### PR DESCRIPTION
Reverts vyos/vyos-build#49
#49 breaks the build the configure symlink is replaced with this: `lrwxrwxrwx 1 vyos vyos    26 juni  18 10:40 configure -> 'scripts/build-config "$@"'$'\n'`

this is the only thing changed in PR #49 , so  i can't really se what this is supposed to fix..

also the statements in the PR is also invalid, because all options are allowed to be configured from the configure-script today
