### PR TITLE
Update Dockerfile to fix syslinux install failure

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y \
       autoconf \
       automake \
       dpkg-dev \
-      syslinux \
+      syslinux-common \
       genisoimage \
       lsb-release \
       fakechroot \


### PR DESCRIPTION
Building the container yields the error that syslinux has been replaced by syslinux-common. Updated Dockerfile to reflect that. 

Step 8/53 : RUN apt-get update && apt-get install -y       vim       git       curl       make       sudo       mc       pbuilder       devscripts       squashfs-tools       autoconf       automake       dpkg-dev       syslinux       genisoimage       lsb-release       fakechroot       libtool       libapt-pkg-dev       parted       kpartx       qemu-system-x86       qemu-utils       quilt       python3-lxml       python3-setuptools       python3-nose       python3-coverage       python3-sphinx       python3-pystache       pkg-config       debhelper       jq
 ---> Running in c292327dc0c8
Hit http://security.debian.org jessie/updates InRelease
Ign http://deb.debian.org jessie InRelease
Hit http://deb.debian.org jessie-updates InRelease
Hit http://deb.debian.org jessie Release.gpg
Hit http://deb.debian.org jessie Release
Get:1 http://security.debian.org jessie/updates/main armhf Packages [872 kB]
Get:2 http://deb.debian.org jessie-updates/main armhf Packages [20 B]
Get:3 http://deb.debian.org jessie/main armhf Packages [8,898 kB]
Fetched 9,771 kB in 1min 16s (127 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package syslinux is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  syslinux-common

E: Package 'syslinux' has no installation candidate