### PR TITLE
initramfs: T1971: Added initramfs-hook script for including modules

### DIFF
--- a/data/live-build-config/includes.chroot/etc/initramfs-tools/hooks/10-vyos-add-modules
+++ b/data/live-build-config/includes.chroot/etc/initramfs-tools/hooks/10-vyos-add-modules
@@ -1,0 +1,23 @@
+#!/bin/sh
+PREREQ=""
+prereqs()
+{
+    echo "$PREREQ"
+}
+case $1 in
+prereqs)
+    prereqs
+    exit 0
+    ;;
+esac
+. /usr/share/initramfs-tools/hook-functions
+# Begin real processing below this line
+
+# include listed modules to initramfs but not load them without the necessity
+manual_add_modules igb ixgbe ixgbevf i40e i40evf
+
+# include modules from file (one per line) to initramfs but not load them without the necessity
+# add_modules_from_file /tmp/modlist
+
+# include listed modules to initramfs and load them during the boot
+# force_load xxx

--- a/data/live-build-config/includes.chroot/etc/initramfs-tools/hooks/10-vyos-addons
+++ b/data/live-build-config/includes.chroot/etc/initramfs-tools/hooks/10-vyos-addons
@@ -21,3 +21,9 @@ manual_add_modules igb ixgbe ixgbevf i40e i40evf
 
 # include listed modules to initramfs and load them during the boot
 # force_load xxx
+
+# executable to copy to initramfs, with library dependencies
+copy_exec /usr/lib/x86_64-linux-gnu/libnss_dns.so.2
+
+# copy other files ("other" here is a file type, so do not delete this keyword)
+copy_file other /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
The script allows include to initramfs or include and force to load any modules, listed inside.
Initially, the script replaces the trick used for intel drivers.