### PR TITLE
T2085: scripts/build-packages: don't define commit='HEAD' by default

### DIFF
--- a/scripts/build-packages
+++ b/scripts/build-packages
@@ -11,7 +11,7 @@ current_working_directory = os.getcwd()
 repo_root = subprocess.check_output('git rev-parse --show-toplevel', shell=True, universal_newlines=True).rstrip('\n')
 repo_sha  = subprocess.check_output('git rev-parse --short=12 HEAD', shell=True, universal_newlines=True).rstrip('\n')
 
-def add_package(name, url=None, commit='HEAD', branch='current', tag=None, shallow=True, custombuild_cmd=None):
+def add_package(name, url=None, commit=None, branch='current', tag=None, shallow=True, custombuild_cmd=None):
     """
     Build up source package with URL and build commands executed during the later
     called build_package step.


### PR DESCRIPTION
Fixes an issue where the script would always revert to a full clone.