### PR TITLE
Fix issue with ovftool signing command (T2239)

### DIFF
--- a/scripts/build-vmware-image
+++ b/scripts/build-vmware-image
@@ -201,10 +201,10 @@ if [ ! -f ${private_key} ]; then
   echo 'Please put your key to "key/privatekey.pem" in repository root, or set PRIVATE_KEY_PATH to environment variables.'
   exit 1
 fi
-ovftool --privateKey=${PRIVATE_KEY_PATH} vyos_vmware_image.ovf vyos_vmware_image-signed.ova
+ovftool --privateKey=${private_key} vyos_vmware_image.ovf vyos_vmware_image-signed.ova
 #ovftool vyos_vmware_image.ovf vyos_vmware_image-signed.ova
 
 # Convert the OVF to signed OVF...
 echo 'Converting the OVF to signed OVF...'
-ovftool --privateKey=${PRIVATE_KEY_PATH} vyos_vmware_image.ovf vyos_vmware_image-signed.ovf
+ovftool --privateKey=${private_key} vyos_vmware_image.ovf vyos_vmware_image-signed.ovf
 #ovftool vyos_vmware_image.ovf vyos_vmware_image-signed.ovf


### PR DESCRIPTION
This PR resolves a bug in the `build-vmware-image` script.

Without this fix, the script checks for the presence of a signing key at
a prescribed location, but then ignores that key when creating the
signed OVA file.

Signing key can be submitted by putting key at a fixed location
(key/privatekey.pem) or by putting the key location in environment
variable PRIVATE_KEY_PATH. The script checks for either of those
possibilities.

ovftool command was incorrectly using the PRIVATE_KEY_PATH variable
even when the key file was dropped in the prescribed location.