### PR TITLE
T2278 build-vmware-image script has unmet dependencies

### DIFF
--- a/scripts/build-vmware-image
+++ b/scripts/build-vmware-image
@@ -16,6 +16,8 @@
 # Purpose:
 # Build VyOS image for VMWARE.
 
+apt-get update && apt-get install -y kpartx parted udev
+
 if [ ! $(which vmdk-convert) ]; then
    echo "Your system doesn't have vmdk-convert. Please install it from https://github.com/vmware/open-vmdk."
    exit 1

--- a/scripts/build-vmware-image
+++ b/scripts/build-vmware-image
@@ -16,7 +16,8 @@
 # Purpose:
 # Build VyOS image for VMWARE.
 
-apt-get update && apt-get install -y kpartx parted udev
+apt-get update && apt-get install -y \
+    kpartx parted udev
 
 if [ ! $(which vmdk-convert) ]; then
    echo "Your system doesn't have vmdk-convert. Please install it from https://github.com/vmware/open-vmdk."


### PR DESCRIPTION
This PR updates `scripts/build-vmware-image` to add packages upon which it depends, but which do not appear in a fresh build of the `vyos/vyos-build:latest` container.

It follows the pattern used by `scripts/build-GCE-image`.

[Phabricator task T2278](https://phabricator.vyos.net/T2278)