### PR TITLE
VMware: T2343: Memory allocation change

### DIFF
--- a/scripts/template.ovf
+++ b/scripts/template.ovf
@@ -146,6 +146,7 @@
         <rasd:InstanceID xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">2</rasd:InstanceID>
         <rasd:ResourceType>4</rasd:ResourceType>
         <rasd:VirtualQuantity>512</rasd:VirtualQuantity>
+        <rasd:Reservation>512</rasd:Reservation>
       </Item>
       <Item configuration="4CPU-16GB">
         <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
@@ -154,6 +155,7 @@
         <rasd:InstanceID xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">2</rasd:InstanceID>
         <rasd:ResourceType>4</rasd:ResourceType>
         <rasd:VirtualQuantity>16384</rasd:VirtualQuantity>
+        <rasd:Reservation>16384</rasd:Reservation>
       </Item>
       <Item configuration="8CPU-32GB">
         <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
@@ -162,6 +164,7 @@
         <rasd:InstanceID xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">2</rasd:InstanceID>
         <rasd:ResourceType>4</rasd:ResourceType>
         <rasd:VirtualQuantity>32768</rasd:VirtualQuantity>
+        <rasd:Reservation>32768</rasd:Reservation>
       </Item>
       <Item>
         <rasd:Address xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">0</rasd:Address>
@@ -214,6 +217,7 @@
       </ovf:Item>
       <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="true"/>
       <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="true"/>
+      <vmw:ExtraConfig ovf:required="false" vmw:key="sched.mem.pin" vmw:value="TRUE"/>
     </VirtualHardwareSection>
   </VirtualSystem>
 </ovf:Envelope>


### PR DESCRIPTION
Changed the OVF template to be sure that a router always has access to all the configured memory.