### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ To build a single package use the same script as above but specify packages with
 Executed from the root of `vyos-build`
 
 ```bash
-$ docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/PACKAGENAME \
+$ docker run --rm -it -v $(pwd):/vyos -w /vyos \
              --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
              vyos-builder scripts/build-packages -b <package>
 ```
@@ -238,7 +238,7 @@ $ mkdir packages
 $ cd packages
 $ git clone git@github.com:myname/vyos-1x.git
 $ cd ..
-$ docker run --rm -it -v $(pwd):/vyos -w /vyos/packages/PACKAGENAME \
+$ docker run --rm -it -v $(pwd):/vyos -w /vyos \
              --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
              vyos-builder scripts/build-packages -b vyos-1x
 ```


### PR DESCRIPTION
fix incorrect work directory in individual package build instructions:
  * -w /vyos/packages/PACKAGENAME tells docker to use /vyos/packages/vyos-1x (from example) as work directory, then creates a packages directory in there, THEN clones the vyos-1x repository again, instead of using . as working directory, discovering there's already a vyos-1x package in there, and building that one.