### PR TITLE
Update debian saltstack http path with new one

### DIFF
--- a/data/defaults.json
+++ b/data/defaults.json
@@ -9,7 +9,7 @@
   "kernel_flavor": "amd64-vyos",
   "release_train": "crux",
   "additional_repositories": [
-    "deb http://repo.saltstack.com/apt/debian/8/amd64/2017.7 jessie main",
+    "deb http://archive.repo.saltstack.com/apt/debian/8/amd64/2017.7 jessie main",
     "deb http://archive.debian.org/debian/ jessie-backports main"
   ],
   "custom_packages": []


### PR DESCRIPTION
Today, I spent a lot of time to build this branch because of missing repository the I noticed that this path should be updated as
deb http://archive.repo.saltstack.com/apt/debian/8/amd64/2017.7 jessie main"