### PR TITLE
T2638: FRR: FRR-reload needs patching to work on 7.3.0

### DIFF
--- a/packages/frr/Jenkinsfile
+++ b/packages/frr/Jenkinsfile
@@ -21,11 +21,10 @@
 @Library('vyos-build@current')_
 
 def pkgList = [
-    // pkg-libnftnl
     ['name': 'frr',
      'scmCommit': 'frr-7.3.1',
      'scmUrl': 'https://github.com/FRRouting/frr.git',
-     'buildCmd': '''./tools/tarsource.sh -V; dpkg-buildpackage -us -uc -Ppkg.frr.rtrlib'''],
+     'buildCmd': '''cd ..; ./build-frr.sh'''],
 ]
 
 // Start package build using library function from https://github.com/c-po/vyos-build

--- a/packages/frr/build-frr.sh
+++ b/packages/frr/build-frr.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+CWD=$(pwd)
+set -e
+
+FRR_SRC=frr
+
+if [ ! -d ${FRR_SRC} ]; then
+    echo "FRR source directory does not exists, please 'git clone'"
+    exit 1
+fi
+
+# VyOS requires some small FRR Patches - apply them here
+# It's easier to habe them here and make use of the upstream
+# repository instead of maintaining a full Fork.
+# Saving time/resources is essential :-)
+cd ${FRR_SRC}
+
+PATCH_DIR=${CWD}/patches
+
+for patch in $(ls ${PATCH_DIR})
+do
+    echo "I: Apply FRR patch: ${PATCH_DIR}/${patch}"
+    patch -p1 < ${PATCH_DIR}/${patch}
+    git add $(lsdiff ${PATCH_DIR}/${patch} | sed -e 's#^[ab]/##')
+    if [ -z "$(git config --list | grep -e user.name -e user.email)" ]; then
+        # if git user.name and user.email is not set, -c sets temorary user.name and 
+        # user.email variables as these is not set in the build container by default. 
+        git -c user.name="VyOS CI" -c user.email="ci@vyos.io" commit -m "Applied patch: ${patch}" --author "VyOS CI <ci@vyos.io>"
+    else
+        git commit -m "Applied patch: ${patch}" --author "VyOS CI <ci@vyos.io>"
+    fi
+
+done
+
+# Prepare FRR source for building
+echo "I: Prepare FRR source for building"
+./tools/tarsource.sh -V
+
+# Build Debian FRR package
+echo "I: Build Debian FRR Package"
+dpkg-buildpackage -us -uc -Ppkg.frr.rtrlib

--- a/packages/frr/patches/0001-Fix-6062-frr-reload-always-seems-to-reapply-configs.patch
+++ b/packages/frr/patches/0001-Fix-6062-frr-reload-always-seems-to-reapply-configs.patch
@@ -1,0 +1,31 @@
+From d3851bdceff09301e110f839af7878e1fb4607c8 Mon Sep 17 00:00:00 2001
+From: Runar Borge <runar@borge.nu>
+Date: Thu, 25 Jun 2020 20:14:47 +0200
+Subject: [PATCH] Fix #6062 frr-reload always seems to reapply configs
+
+https://github.com/FRRouting/frr/issues/6062
+dteach-rv commented on 30 Apr
+It looks like there was a concerted effort to handle the vtysh -> stderr output
+change in frr-reload.py. But the subprocess call in def load-from_show_running
+was missed, which is why frr-reload.py is trying to re-add every command.
+It's comparing the file config to an empty running config.
+---
+ tools/frr-reload.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/frr-reload.py b/tools/frr-reload.py
+index 3e97635df..f4eb8400e 100755
+--- a/tools/frr-reload.py
++++ b/tools/frr-reload.py
+@@ -155,7 +155,7 @@ class Config(object):
+         try:
+             config_text = subprocess.check_output(
+                 bindir + "/vtysh --config_dir " + confdir + " -c 'show run " + daemon + "' | /usr/bin/tail -n +4 | " + bindir + "/vtysh --config_dir " + confdir + " -m -f -",
+-                shell=True)
++                shell=True, stderr=subprocess.STDOUT)
+         except subprocess.CalledProcessError as e:
+             ve = VtyshMarkException(e)
+             ve.output = e.output
+-- 
+2.25.1
+


### PR DESCRIPTION
Because of FRR bug 6062 (https://github.com/FRRouting/frr/issues/6062) frr-reload in frr 7.3.0 and 7.3.1
needs to be patched to finction properly. without this patch frr-reload will allways compare against
a blank/empty running configuration.