### PR TITLE
T2678: Fixing massive memory usage with ssh and large number of routes

### DIFF
--- a/data/live-build-config/includes.chroot/etc/nsswitch.conf
+++ b/data/live-build-config/includes.chroot/etc/nsswitch.conf
@@ -1,0 +1,21 @@
+# /etc/nsswitch.conf
+#
+# Example configuration of GNU Name Service Switch functionality.
+# If you have the `glibc-doc-reference' and `info' packages installed, try:
+# `info libc "Name Service Switch"' for information about this file.
+
+passwd:         files
+group:          files
+shadow:         files
+gshadow:        files
+
+# Per T2678, commenting out myhostname
+hosts:          files dns #myhostname
+networks:       files
+
+protocols:      db files
+services:       db files
+ethers:         db files
+rpc:            db files
+
+netgroup:       nis


### PR DESCRIPTION
Due to some buggy systemd behavior, when you have many routes and ssh in from a host without a PTR record, ssh sessions take up massive amounts of memory.  I had one server taking up to a gigabyte of memory per SSH session.

This patch gets around this broken behavior, and shouldn't impact anything as it's a condition that shouldn't be hit anyway.