### PR TITLE
vyos-build: T2854: Add ability to build third-party packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ packer_cache/*
 key/*
 packages/*
 !packages/*/
+packages/thirdparty/*
+!packages/thirdparty/*/
+!packages/thirdparty/README
 testinstall*.img

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/thirdparty/python3-trio"]
+	path = packages/thirdparty/python3-trio
+	url = https://github.com/python-trio/trio

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,9 @@ prepare:
 	mkdir -p build/config
 	cp -r data/live-build-config/* build/config/
 	@scripts/live-build-config
+	@scripts/build-thirdparty-packages
 	@scripts/import-local-packages
-
 	@scripts/make-version-file
-
 	@scripts/build-flavour
 
 .PHONY: iso

--- a/data/live-build-config/archives/buster-backports.pref.chroot
+++ b/data/live-build-config/archives/buster-backports.pref.chroot
@@ -22,6 +22,10 @@ Package: wireguard-tools
 Pin: release n=buster-backports
 Pin-Priority: 600
 
+Package: python3-attr
+Pin: release n=buster-backports
+Pin-Priority: 600
+
 Package: *
 Pin: release n=buster-backports
 Pin-Priority: -10

--- a/packages/thirdparty/README
+++ b/packages/thirdparty/README
@@ -1,0 +1,11 @@
+In this directory, sources for building thirdparty Debian packages that are not
+available in the official repositories can be placed.
+
+Upstream projects can be added as git submodules in this directory and the necessary
+debian control files and a Makefile can be committed to a new branch (vyos) on
+the submodule.
+
+As part of the build process, all submodules in this directory are updated (and
+initialized if necessary). Then, in each directory with a Makefile, "make deb"
+is executed, which should produce an arbitrary number of .deb files in the parent
+directory (= this one).

--- a/scripts/build-thirdparty-packages
+++ b/scripts/build-thirdparty-packages
@@ -1,0 +1,24 @@
+#!/bin/sh -e
+
+ROOT=$(pwd)
+SRC_DIR=$ROOT/packages/thirdparty
+DST_DIR=$ROOT/build/config/packages.chroot
+
+echo "Building thirdparty Debian packages in $SRC_DIR"
+
+echo "Updating submodules"
+git submodule update --init --recursive $SRC_DIR
+
+for dir in $(find $SRC_DIR -maxdepth 1 -type d); do
+    if [ -f "$dir/Makefile" ]; then
+        make -C $dir deb
+    fi
+done
+
+mkdir -p $DST_DIR
+for file in $(find $SRC_DIR -maxdepth 1 -name '*.deb'); do
+    if [ -f "$file" ]; then
+        echo "Adding $(basename $file)"
+        cp $file $DST_DIR
+    fi
+done

--- a/scripts/import-local-packages
+++ b/scripts/import-local-packages
@@ -1,13 +1,14 @@
-#!/bin/sh
+#!/bin/sh -e
 
-LOCAL_PKG_DIR=build/config/packages.chroot
+SRC_DIR=packages
+DST_DIR=build/config/packages.chroot
 
-mkdir -p $LOCAL_PKG_DIR
+echo "Importing local debian packages from $SRC_DIR"
 
-FILES=packages/*.deb
-for f in $FILES
-do
-  if [ -e "$f" ]; then
-    cp $f $LOCAL_PKG_DIR
-  fi
+mkdir -p $DST_DIR
+for file in $(find $SRC_DIR -maxdepth 1 -name '*.deb'); do
+    if [ -f "$file" ]; then
+        echo "Adding $(basename $file)"
+        cp $file $DST_DIR
+    fi
 done


### PR DESCRIPTION
Thirdparty Debian packages can now be added as git submodules under
packages/thirdparty. They'll be built as part of the prepare stage when
building an ISO image. Manual build can be triggered using
scripts/build-thirdparty-packages. More information can be found in
packages/thirdparty/README.
