### PR TITLE
Cloud-init: T2117: Updated requirements list for Cloud-init package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -355,6 +355,7 @@ RUN apt-get update && apt-get install -y \
       python3-yaml \
       python3-jsonschema \
       python3-contextlib2 \
+      python3-pytest-cov \
       cloud-utils
 
 # Packages needed for libnss-mapuser & libpam-radius


### PR DESCRIPTION
To build newer Cloud-init packages we need also the `python3-pytest-cov` package in the vyos-build image