### PR TITLE
cloud images: T3039: Added cloud-guest-utils package dependency

### DIFF
--- a/tools/cloud-init/cloud-init.list.chroot
+++ b/tools/cloud-init/cloud-init.list.chroot
@@ -1,1 +1,2 @@
 cloud-init
+cloud-guest-utils


### PR DESCRIPTION
Cloud-init requires the `growpart` script which is a part of the cloud-guest-utils package to grow a VyOS partition to all available space during deployment. Therefore it is necessary to add this package to images for virtual environments.