### PR TITLE
Docker: T2666: fix wrong filename

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -460,7 +460,7 @@ RUN if dpkg-architecture -ii386 || dpkg-architecture -iamd64; then \
 RUN echo "deb http://deb.debian.org/debian/ buster-backports main" \
       > /etc/apt/sources.list.d/buster-backports.list && \
     apt-get update && apt-get install -y -t buster-backports libbpf-dev && \
-    rm -f /etc/apt/sources.list.d/jessie-backports.list
+    rm -f /etc/apt/sources.list.d/buster-backports.list
 
 # Install open-vmdk
 RUN wget -O /tmp/open-vmdk-master.zip https://github.com/vmware/open-vmdk/archive/master.zip && \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
The temporary file in sources.list.d should be removed with the same name under which it is added

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T2666

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Docker

## Proposed changes
<!--- Describe your changes in detail -->
The temporary file in sources.list.d should be removed with the same name under which it is added

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
