### PR TITLE
containers: T2216: Implement containers

### DIFF
--- a/data/live-build-config/hooks/live/18-enable-disable_services.chroot
+++ b/data/live-build-config/hooks/live/18-enable-disable_services.chroot
@@ -48,6 +48,7 @@ systemctl disable dropbear.service
 systemctl disable fastnetmon.service
 systemctl disable ocserv.service
 systemctl disable tuned.service
+systemctl disable docker.service
 
 echo I: Enabling services
 systemctl enable ssh-session-cleanup.service

--- a/data/live-build-config/hooks/live/30-docker-containers-chroot
+++ b/data/live-build-config/hooks/live/30-docker-containers-chroot
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Before starting docker we define default docker config in format JSON.
+
+echo I: Creating container directory.
+
+mkdir -p /config/containers
+mkdir -p /etc/docker
+
+cat <<< '{
+    "bridge": "none",
+    "iptables": false,
+    "ip-forward": false,
+    "ip-masq": false,
+    "data-root": "/config/containers",
+    "storage-driver": "vfs"
+} ' > /etc/docker/daemon.json


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add default configuration before start containers
## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T2216
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
containers
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
