### PR TITLE
frr-syslog: T2061: Moving FRR logs to messages: Crux

### DIFF
--- a/data/live-build-config/hooks/live/30-frr-configs.chroot
+++ b/data/live-build-config/hooks/live/30-frr-configs.chroot
@@ -51,8 +51,22 @@ watchfrr_enable=no
 valgrind_enable=no
 """
 
+frr_conf = """
+log syslog
+log facility local7
+"""
+
+frr_log = ''
+
 with open("/etc/frr/daemons", "w") as f:
     f.write(daemons)
+
+with open("/etc/frr/frr.conf", "w") as f:
+    f.write(frr_conf)
+
+# Prevent writing logs to /var/log/frr/frr.log. T2061
+with open("/etc/rsyslog.d/45-frr.conf", "w") as f:
+    f.write(frr_log)
 
 # Create empty daemon configs so that they start properly
 for name in ["zebra.conf", "bgpd.conf", "ospfd.conf", "ospf6d.conf", "ripd.conf", "ripngd.conf"]:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

With that pr, logs will be placed in the file /var/log/messages
It allow to send them to a remote Syslog server.
Also, it fixes debug mode for protocols. So before we see only "informational" level.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T2061 crux
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
frr, rsyslog
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```
monitor protocol bgp enable allow-martians
monitor protocol bgp enable neighbor-events
monitor protocol bgp enable updates
```
And show monitor
```
vyos@r12-1.2.6:~$ monitor protocol bgp 
tail: unrecognized file system type 0x794c7630 for ‘/var/log/messages’. please report this to bug-coreutils@gnu.org. reverting to polling


  BGP: 192.168.122.1 [FSM] Timer (connect timer expire) 
  BGP: 192.168.122.1 [FSM] ConnectRetry_timer_expired (Active->Connect), fd -1 
  BGP: 192.168.122.1 [Event] Connect start to 192.168.122.1 fd 27 
  BGP: 192.168.122.1 [FSM] Non blocking connect waiting result, fd 27 
  BGP: bgp_fsm_change_status : vrf default(0), Status: Connect established_peers 0 
  BGP: 192.168.122.1 went from Active to Connect 
  BGP: 192.168.122.1 [Event] Connect failed 111(Connection refused) 
  BGP: 192.168.122.1 [FSM] TCP_connection_open_failed (Connect->Active), fd 27 
  BGP: bgp_fsm_change_status : vrf default(0), Status: Active established_peers 0 
  BGP: 192.168.122.1 went from Connect to Active 
  BGP: 192.168.122.1 [FSM] Timer (connect timer expire) 
  BGP: 192.168.122.1 [FSM] ConnectRetry_timer_expired (Active->Connect), fd -1 
  BGP: 192.168.122.1 [Event] Connect start to 192.168.122.1 fd 27 
  BGP: 192.168.122.1 [FSM] Non blocking connect waiting result, fd 27 
  BGP: bgp_fsm_change_status : vrf default(0), Status: Connect established_peers 0


vyos@r12-1.2.6:~$ cat /var/log/messages | grep bgp | tail -n 5
Dec 22 14:52:22 r12-1 bgpd[1036]: 192.168.122.1 went from Active to Connect
Dec 22 14:52:22 r12-1 bgpd[1036]: 192.168.122.1 [Event] Connect failed 111(Connection refused)
Dec 22 14:52:22 r12-1 bgpd[1036]: 192.168.122.1 [FSM] TCP_connection_open_failed (Connect->Active), fd 27
Dec 22 14:52:22 r12-1 bgpd[1036]: bgp_fsm_change_status : vrf default(0), Status: Active established_peers 0
Dec 22 14:52:22 r12-1 bgpd[1036]: 192.168.122.1 went from Connect to Active

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
