### PR TITLE
VyOS in Docker: T2640: Fixed builds for sagitta

### DIFF
--- a/docker-vyos/vyos_install_common.sh
+++ b/docker-vyos/vyos_install_common.sh
@@ -36,7 +36,7 @@ function prepare_apt() {
         echo -e "deb ${APT_VYOS_MIRROR}/vyos ${APT_VYOS_BRANCH} main\ndeb ${APT_VYOS_MIRROR}/debian ${APT_VYOS_BRANCH} main\n${APT_ADDITIONAL_REPOS}" > /etc/apt/sources.list.d/vyos.list
     fi
 
-    if [[ "${RELEASE_TRAIN}" == "equuleus" ]]; then
+    if [[ "${RELEASE_TRAIN}" == "equuleus" || "${RELEASE_TRAIN}" == "sagitta" ]]; then
         echo -e "deb ${APT_VYOS_MIRROR} ${APT_VYOS_BRANCH} main\n${APT_ADDITIONAL_REPOS}" > /etc/apt/sources.list.d/vyos.list
         # Add backports repository
         echo -e "deb http://deb.debian.org/debian buster-backports main\ndeb http://deb.debian.org/debian buster-backports non-free" >> /etc/apt/sources.list.d/vyos.list
@@ -47,7 +47,10 @@ function prepare_apt() {
         cat /tmp/*list.chroot >> /etc/apt/sources.list.d/vyos.list
     fi
     if grep -sq Package /tmp/*.pref.chroot; then
-        cat /tmp/*pref.chroot >> /etc/apt/preferences.d/10vyos
+        for pref_file in /tmp/*.pref.chroot; do
+            cat $pref_file >> /etc/apt/preferences.d/10vyos
+            echo -e "\n" >> /etc/apt/preferences.d/10vyos
+        done
     fi
 
     # Add GPG keys


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed the problem when APT repositories were not configured properly in VyOS 1.4 / sagitta during a Docker image build.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T2640

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
VyOS Docker image

## Proposed changes
<!--- Describe your changes in detail -->
After creating the new release train `sagitta` the script that configures the APT repository for a Docker image was not able to do this properly, due to missing this train in the `if` condition.
Also, fixed the bug when multiple APT preferences files lead to the wrong syntax in a preference file inside a Docker container.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Run this before and after the commit will produce broken and normal VyOS images accordingly.
```
git clone -b current https://github.com/vyos/vyos-build.git
cd vyos-build/docker-vyos/
docker build --no-cache --pull --compress -f Dockerfile -t vyos:1.4-`date -u +%Y%m%d%H%M%S` --build-arg BUILD_DATE="`date -u --rfc-3339=seconds`" --build-arg VYOS_VERSION=1.4 --build-arg DEBIAN_VERSION=buster --progress plain ..
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
