### PR TITLE
T3303: Modify os_release file for changing Welcome message on boot

### DIFF
--- a/scripts/make-version-file
+++ b/scripts/make-version-file
@@ -100,6 +100,18 @@ version_data = {
     'build_comment': build_config['build_comment']
 }
 
+os_release = f"""
+PRETTY_NAME="VyOS {version} ({build_config['release_train']})"
+NAME="VyOS"
+VERSION_ID="{version}"
+VERSION="{version} ({build_config['release_train']})"
+VERSION_CODENAME=buster
+ID=vyos
+HOME_URL="https://vyos.io"
+SUPPORT_URL="https://support.vyos.io"
+BUG_REPORT_URL="https://phabricator.vyos.net"
+"""
+
 os.makedirs(os.path.join(defaults.CHROOT_INCLUDES_DIR, 'usr/share/vyos'), exist_ok=True)
 with open(os.path.join(defaults.CHROOT_INCLUDES_DIR, 'usr/share/vyos/version.json'), 'w') as f:
     json.dump(version_data, f)
@@ -116,3 +128,8 @@ with open(os.path.join(defaults.CHROOT_INCLUDES_DIR, 'opt/vyatta/etc/version'), 
 # neither we want to use lengthy paths in makefiles
 with open(os.path.join(defaults.BUILD_DIR, 'version'), 'w') as f:
     print(version, file=f)
+
+# Define variables that influence to welcome message on boot
+os.makedirs(os.path.join(defaults.CHROOT_INCLUDES_DIR, 'usr/lib/'), exist_ok=True)
+with open(os.path.join(defaults.CHROOT_INCLUDES_DIR, 'usr/lib//os-release'), 'w') as f:
+    print(os_release, file=f)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Change welcome message on boot

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
