### PR TITLE
T3485: Add macos support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ key/*
 packages/*
 !packages/*/
 testinstall*.img
+.vagrant/*

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,18 @@ PACKET: clean prepare
 	cd ..
 	@scripts/copy-image
 
+.PHONY: macos-build
+.ONESHELL:
+macos-build: purge
+	@set -e
+	@echo "It's not like I'm building this specially for you or anything!"
+	@scripts/check-macos-build-env
+	vagrant up
+	mkdir build || true
+	cd $(build_dir); \
+	rsync -Lam --include='*-amd64.iso' --exclude='*' vagrant@10.1.1.254:/opt/vyos-build/build/ .
+	vagrant destroy -f
+
 .PHONY: PACKET-debug
 .ONESHELL:
 PACKET-debug: clean prepare

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,38 @@
+PROVISION = <<-SCRIPT
+sudo apt-get update -y
+sudo apt-get install apt-transport-https \
+  ca-certificates \
+  curl \
+  gnupg2 \
+  git \
+  software-properties-common \
+  rsync -y
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+sudo apt-get update -y
+sudo apt-get install -y docker-ce
+[ -d /home/vagrant/.ssh ] && echo '%{public_key}' >> /home/vagrant/.ssh/authorized_keys; true
+[ -d /home/vagrant/.ssh ] && chmod 600 /home/vagrant/.ssh/authorized_keys; true
+sudo usermod -aG docker vagrant
+git clone -b crux --single-branch https://github.com/vyos/vyos-build /opt/vyos-build
+docker run --rm -t --privileged -v /opt/vyos-build:/vyos -w /vyos vyos/vyos-build:crux \
+  /bin/bash -c './configure --architecture amd64 --build-by "hackerman@vyos.io" && make iso'
+SCRIPT
+
+def define_vm(config, hostname, ip)
+  public_key_path = File.join(Dir.home, ".ssh", "id_rsa.pub")
+  public_key = IO.read(public_key_path)
+
+  config.vm.define hostname do |vm|
+      vm.vm.box = "debian/jessie64"
+      vm.vm.hostname = hostname
+      vm.vm.network 'private_network', ip: ip
+
+      vm.vm.provision :shell, inline: (PROVISION % { public_key: public_key })
+  end
+end
+
+Vagrant.configure("2") do |config|
+  define_vm(config, "vyos", "10.1.1.254")
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+end

--- a/scripts/check-macos-build-env
+++ b/scripts/check-macos-build-env
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2016 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# File: check-macos-build-env
+# Purpose:
+#   Checks if binaries for macOS image building are installed.
+
+
+import os
+import sys
+
+import util
+import platform
+
+platform = platform.system()
+if platform != 'Darwin':
+    print("Your system is not macOS.")
+    sys.exit(1)
+
+deps = {
+    'packages': [],
+    'binaries': [
+       'vagrant',
+       'virtualbox',
+       'rsync'
+    ]
+}
+
+print("Checking if packages required for VyOS image build are installed")
+
+checker = util.DependencyChecker(deps)
+
+missing = checker.get_missing_dependencies()
+print(missing)
+if not missing:
+    print("All dependencies are installed")
+    sys.exit(0)
+else:
+    checker.print_missing_deps()
+    if 'vagrant' in missing['binaries']:
+        print("Your system does not have Vagrant.")
+        print("Please install Vagrant from https://www.vagrantup.com/downloads.")
+        sys.exit(1)
+    elif 'virtualbox' in missing['binaries']:
+        print("Your system does not have Virtualbox.")
+        print("Please install Virtualbox from https://www.virtualbox.org/wiki/Downloads.")
+        sys.exit(1)
+    elif 'rsync' in missing['binaries']:
+        print("Your system does not have Rsync.")
+        print("Please install Rsync from https://formulae.brew.sh/formula/rsync.")
+        sys.exit(1)
+sys.exit(0)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allows building of images in macOS through vagrant/virtualbox/docker

  - add binary dependency checks
  - add os check
  - automate image building
  - use rsync to solely transfer image to local

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3485

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vyos-build

## Proposed changes
<!--- Describe your changes in detail -->
Create an iso in MacOS in an efficient manner using vagrant, virtualbox and docker which tasks are embedded in the make task `macos-build`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
`make macos-build`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
