### PR TITLE
T3351: Add SHA256 checksums

### DIFF
--- a/data/live-build-config/hooks/live/11-busybox.chroot
+++ b/data/live-build-config/hooks/live/11-busybox.chroot
@@ -139,6 +139,7 @@ bb_alternative /usr/bin/renice
 bb_alternative /usr/bin/reset
 bb_alternative /usr/bin/setkeycodes
 bb_alternative /usr/bin/sha1sum
+bb_alternative /usr/bin/sha256sum
 bb_alternative /usr/bin/sort
 bb_alternative /usr/bin/strings
 bb_alternative /usr/bin/tail

--- a/scripts/live-build-config
+++ b/scripts/live-build-config
@@ -41,6 +41,7 @@ lb config noauto \
         --linux-packages linux-image-{{kernel_version}} \
         --bootloader syslinux,grub-efi \
         --binary-images iso-hybrid \
+        --checksums 'sha256 md5' \
         --debian-installer false \
         --distribution {{distribution}} \
         --iso-application "VyOS" \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add SHA256 checksums to the generated images, alongside MD5 checksums.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3351

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
New images will be checked with SHA256, whereas MD5 checksums will remain for compatibility.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
