### PR TITLE
keepalived: T3540: Use backport version 2.1.5-0.2

### DIFF
--- a/data/live-build-config/archives/buster-backports.pref.chroot
+++ b/data/live-build-config/archives/buster-backports.pref.chroot
@@ -18,6 +18,10 @@ Package: conserver-client
 Pin: release n=buster-backports
 Pin-Priority: 600
 
+Package: keepalived
+Pin: release n=buster-backports
+Pin-Priority: 600
+
 Package: wireguard-tools
 Pin: release n=buster-backports
 Pin-Priority: 600


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Get keepalived from backport.
The report from the T3540. It was a memory leak in the current buster version.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x ] Other (please describe):

## Related Task(s)
https://phabricator.vyos.net/T3540

## Component(s) name
keepalived

## Proposed changes
Get "keepalived" from buster-backports

## How to test
```
set high-availability vrrp group BND028 advertise-interval '5'
set high-availability vrrp group BND028 interface 'eth1'
set high-availability vrrp group BND028 priority '250'
set high-availability vrrp group BND028 virtual-address '100.64.28.1/29'
set high-availability vrrp group BND028 vrid '28'

```
Check
```
vyos@r6-roll:~$ show version all | match keepalive
ii  keepalived                           1:2.1.5-0.2~bpo10+1                 amd64        Failover and monitoring daemon for LVS clusters
vyos@r6-roll:~$ 
vyos@r6-roll:~$ show vrrp
Name    Interface      VRID  State      Priority  Last Transition
------  -----------  ------  -------  ----------  -----------------
BND028  eth1             28  MASTER          250  12m16s
vyos@r6-roll:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
