### PR TITLE
charon-syslog: T2620: Add ike-name to IPSec logs

### DIFF
--- a/data/live-build-config/hooks/live/30-strongswan-configs.chroot
+++ b/data/live-build-config/hooks/live/30-strongswan-configs.chroot
@@ -36,3 +36,22 @@ with open('/etc/strongswan.d/charon/farp.conf', 'r') as f:
 
 with open('/etc/strongswan.d/charon/farp.conf', 'w') as f:
     f.write(farp_conf)
+
+
+# Add ike-name to logging
+charon_logging = """
+charon {
+    syslog {
+        # prefix for each log message
+        identifier = charon
+        # use default settings to log to the LOG_DAEMON facility
+        daemon {
+            default = 1
+            ike_name = yes
+        }
+    }
+}
+"""
+
+with open('/etc/strongswan.d/charon-logging.conf', 'w') as f:
+    f.write(charon_logging)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add ike-name to IPSec logs. It allows checking/parse vpn logs in more clear format.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T2620

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipsec, charon-logging
## Proposed changes
<!--- Describe your changes in detail -->
Get ike-name (peer name) in the logs

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Add IPSec config and show logs, we should see "**<peer-192.0.2.2-tunnel-0|1>**" (ike-name) in the logs.
```
Jun  8 00:59:20 r1-roll ipsec_starter[2373]: charon (2374) started after 400 ms
Jun  8 00:59:20 r1-roll charon: 05[CFG] received stroke: add connection 'peer-192.0.2.2-tunnel-0'
Jun  8 00:59:20 r1-roll charon: 05[CFG] added configuration 'peer-192.0.2.2-tunnel-0'
Jun  8 00:59:20 r1-roll charon: 07[CFG] received stroke: initiate 'peer-192.0.2.2-tunnel-0'
Jun  8 00:59:20 r1-roll charon: 07[IKE] <peer-192.0.2.2-tunnel-0|1> initiating Main Mode IKE_SA peer-192.0.2.2-tunnel-0[1] to 192.0.2.2
Jun  8 00:59:20 r1-roll charon: 07[ENC] <peer-192.0.2.2-tunnel-0|1> generating ID_PROT request 0 [ SA V V V V V ]
Jun  8 00:59:20 r1-roll charon: 07[NET] <peer-192.0.2.2-tunnel-0|1> sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (180 bytes)
Jun  8 00:59:20 r1-roll charon: 09[NET] <peer-192.0.2.2-tunnel-0|1> received packet: from 192.0.2.2[500] to 192.0.2.1[500] (160 bytes)
Jun  8 00:59:20 r1-roll charon: 09[ENC] <peer-192.0.2.2-tunnel-0|1> parsed ID_PROT response 0 [ SA V V V V ]
Jun  8 00:59:20 r1-roll charon: 09[IKE] <peer-192.0.2.2-tunnel-0|1> received XAuth vendor ID
Jun  8 00:59:20 r1-roll charon: 09[IKE] <peer-192.0.2.2-tunnel-0|1> received DPD vendor ID
Jun  8 00:59:20 r1-roll charon: 09[IKE] <peer-192.0.2.2-tunnel-0|1> received FRAGMENTATION vendor ID
Jun  8 00:59:20 r1-roll charon: 09[IKE] <peer-192.0.2.2-tunnel-0|1> received NAT-T (RFC 3947) vendor ID
Jun  8 00:59:20 r1-roll charon: 09[CFG] <peer-192.0.2.2-tunnel-0|1> selected proposal: IKE:AES_CBC_256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
Jun  8 00:59:20 r1-roll charon: 09[ENC] <peer-192.0.2.2-tunnel-0|1> generating ID_PROT request 0 [ KE No NAT-D NAT-D ]
Jun  8 00:59:20 r1-roll charon: 09[NET] <peer-192.0.2.2-tunnel-0|1> sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (244 bytes)
Jun  8 00:59:20 r1-roll charon: 10[NET] <peer-192.0.2.2-tunnel-0|1> received packet: from 192.0.2.2[500] to 192.0.2.1[500] (244 bytes)
Jun  8 00:59:20 r1-roll charon: 10[ENC] <peer-192.0.2.2-tunnel-0|1> parsed ID_PROT response 0 [ KE No NAT-D NAT-D ]
Jun  8 00:59:20 r1-roll charon: 10[ENC] <peer-192.0.2.2-tunnel-0|1> generating ID_PROT request 0 [ ID HASH N(INITIAL_CONTACT) ]
Jun  8 00:59:20 r1-roll charon: 10[NET] <peer-192.0.2.2-tunnel-0|1> sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (108 bytes)
Jun  8 00:59:20 r1-roll charon: 11[NET] <peer-192.0.2.2-tunnel-0|1> received packet: from 192.0.2.2[500] to 192.0.2.1[500] (76 bytes)
Jun  8 00:59:20 r1-roll charon: 11[ENC] <peer-192.0.2.2-tunnel-0|1> parsed ID_PROT response 0 [ ID HASH ]
Jun  8 00:59:20 r1-roll charon: 11[IKE] <peer-192.0.2.2-tunnel-0|1> IKE_SA peer-192.0.2.2-tunnel-0[1] established between 192.0.2.1[192.0.2.1]...192.0.2.2[192.0.2.2]
Jun  8 00:59:20 r1-roll charon: 11[IKE] <peer-192.0.2.2-tunnel-0|1> scheduling rekeying in 2720s
Jun  8 00:59:20 r1-roll charon: 11[IKE] <peer-192.0.2.2-tunnel-0|1> maximum IKE_SA lifetime 3260s
Jun  8 00:59:20 r1-roll charon: 11[ENC] <peer-192.0.2.2-tunnel-0|1> generating QUICK_MODE request 3783917425 [ HASH SA No KE ID ID ]
Jun  8 00:59:20 r1-roll charon: 11[NET] <peer-192.0.2.2-tunnel-0|1> sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (316 bytes)
Jun  8 00:59:20 r1-roll charon: 12[NET] <peer-192.0.2.2-tunnel-0|1> received packet: from 192.0.2.2[500] to 192.0.2.1[500] (316 bytes)
Jun  8 00:59:20 r1-roll charon: 12[ENC] <peer-192.0.2.2-tunnel-0|1> parsed QUICK_MODE response 3783917425 [ HASH SA No KE ID ID ]
Jun  8 00:59:20 r1-roll charon: 12[CFG] <peer-192.0.2.2-tunnel-0|1> selected proposal: ESP:AES_CBC_256/HMAC_SHA1_96/MODP_1024/NO_EXT_SEQ
Jun  8 00:59:20 r1-roll charon: 12[IKE] <peer-192.0.2.2-tunnel-0|1> CHILD_SA peer-192.0.2.2-tunnel-0{1} established with SPIs c4d940b7_i c9a69e83_o and TS 10.1.0.0/24 === 10.2.3.0/24
Jun  8 00:59:20 r1-roll charon: 12[ENC] <peer-192.0.2.2-tunnel-0|1> generating QUICK_MODE request 3783917425 [ HASH ]
Jun  8 00:59:20 r1-roll charon: 12[NET] <peer-192.0.2.2-tunnel-0|1> sending packet: from 192.0.2.1[500] to 192.0.2.2[500] (60 bytes)

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
