### PR TITLE
pki: wireguard: T3642: Key pair for migration tests after op-mode command is removed

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -357,8 +357,12 @@ try:
 
     # else, run configtest suite
     else:
-        log.info('Generating a WireGuard default keypair')
-        c.sendline('generate wireguard default-keypair')
+        log.info('Adding a legacy WireGuard default keypair for migrations')
+        c.sendline('sudo mkdir -p /config/auth/wireguard/default')
+        c.expect(op_mode_prompt)
+        c.sendline('echo "aGx+fvW916Ej7QRnBbW3QMoldhNv1u95/WHz45zDmF0=" | sudo tee /config/auth/wireguard/default/private.key')
+        c.expect(op_mode_prompt)
+        c.sendline('echo "x39C77eavJNpvYbNzPSG3n1D68rHYei6q3AEBEyL1z8=" | sudo tee /config/auth/wireguard/default/public.key')
         c.expect(op_mode_prompt)
 
         log.info('Generating some OpenVPN keys')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adds a Wireguard key pair for migration tests after the old op-mode command is removed (incoming in a vyos-1x PR)
*Note: This is a prerequisite for https://github.com/vyos/vyos-1x/pull/929

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Pre-emptive bug fix

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3642

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pki, wireguard

## Proposed changes
<!--- Describe your changes in detail -->
Adds a smoketest static key in the /config/auth/wireguard/default folder for configtest migrations

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
