### PR TITLE
Jenkins: docker build variable name reuse issue on amd64 vs arm64

### DIFF
--- a/Jenkinsfile.docker
+++ b/Jenkinsfile.docker
@@ -58,11 +58,11 @@ pipeline {
                     }
                     steps {
                         script {
-                            DOCKER_IMAGE = "vyos/vyos-build:" + getGitBranchName() + "-arm64"
-                            sh "docker build -t ${DOCKER_IMAGE} --build-arg ARCH=arm64v8/ docker"
+                            DOCKER_IMAGE_ARM64 = "vyos/vyos-build:" + getGitBranchName() + "-arm64"
+                            sh "docker build -t ${DOCKER_IMAGE_ARM64} --build-arg ARCH=arm64v8/ docker"
                             if (! isCustomBuild()) {
                                 withDockerRegistry([credentialsId: "DockerHub"]) {
-                                    sh "docker push ${DOCKER_IMAGE}"
+                                    sh "docker push ${DOCKER_IMAGE_ARM64}"
                                 }
                             }
                         }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Rename variable containing the name of the current image to not have rase conditions on amd64 and arm64.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->
see summary

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
