### PR TITLE
build-iso: T3971: Ability to buid ISO images for xcp-ng

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,19 @@ edgecore: check_build_config clean prepare
 	cd ..
 	@scripts/copy-image
 
+.PHONY: xcp-ng-iso
+.ONESHELL:
+xcp-ng-iso: check_build_config clean prepare
+	@set -e
+	@echo "It's not like I'm building this specially for you or anything!"
+	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' data/package-lists/vyos-x86.list.chroot
+	cd $(build_dir)
+	set -o pipefail
+	lb build 2>&1 | tee build.log; if [ $$? -ne 0 ]; then exit 1; fi
+	cd ..
+	@scripts/copy-image
+	exit 0
+
 .PHONY: test
 .ONESHELL:
 test:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The ability to build ISO images for hypervisor XCP-NG, it required xe-guest-utilities

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3971
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
sudo make xcp-ng-iso
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
