### PR TITLE
T3962: Check if open-vm-tools is present before attempting to write its config [crux]

### DIFF
--- a/data/live-build-config/hooks/live/30-openvmtools-configs.chroot
+++ b/data/live-build-config/hooks/live/30-openvmtools-configs.chroot
@@ -2,6 +2,7 @@
 
 # open-vm-tools settings
 
+import os
 import re
 
 vmtools_config = """
@@ -10,5 +11,8 @@ vmtools_config = """
 
 """
 
-with open('/etc/vmware-tools/tools.conf', 'w') as f:
-    f.write(vmtools_config)
+if os.path.isdir('/etc/vmware-tools'):
+    with open('/etc/vmware-tools/tools.conf', 'w') as f:
+        f.write(vmtools_config)
+else:
+    print('Open VM Tools not found. Skipping its configuration.')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Image build fails without `open-vm-tools` even for targets that don't need it.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3962

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
Check for the config dir before attempting to write there.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
