### PR TITLE
atop: T3774: Disabled atop services

### DIFF
--- a/data/live-build-config/hooks/live/18-enable-disable_services.chroot
+++ b/data/live-build-config/hooks/live/18-enable-disable_services.chroot
@@ -51,6 +51,7 @@ systemctl disable ndppd.service
 systemctl disable ipsec.service
 systemctl disable strongswan-starter.service
 systemctl disable avahi-daemon.service
+systemctl disable atop-rotate.timer
 
 echo I: Enabling services
 systemctl enable ssh-session-cleanup.service

--- a/data/live-build-config/hooks/live/22-rm_cron_atop.chroot
+++ b/data/live-build-config/hooks/live/22-rm_cron_atop.chroot
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ -f /etc/cron.d/atop ]; then
+  rm -f /etc/cron.d/atop
+fi
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Atop rotation service was disabled, because now it is controlled by logrotate.
Details: https://github.com/vyos/vyos-1x/pull/1068

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T3774

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
atop

## Proposed changes
<!--- Describe your changes in detail -->
To take all the control over atop service and log files original atop-rotate.timer with cron entry was disabled/removed.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
