### PR TITLE
build: T4013: Add aws-cloudwatch-agent for aws iso images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ GCE-debug: clean prepare
 AWS: clean prepare
 	@set -e
 	@echo "It's not like I'm building this specially for you or anything!"
+	wget -O build/config/packages.chroot/amazon-cloudwatch-agent-amd64.deb https://s3.eu-central-1.amazonaws.com/amazoncloudwatch-agent-eu-central-1/debian/amd64/latest/amazon-cloudwatch-agent.deb
 	mkdir -p build/config/includes.chroot/etc/cloud/cloud.cfg.d
 	cp tools/cloud-init/AWS/90_dpkg.cfg build/config/includes.chroot/etc/cloud/cloud.cfg.d/
 	cp tools/cloud-init/AWS/cloud-init.list.chroot build/config/package-lists/


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add amazon-cloudwatch-agent for AWS.iso images
## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T4013
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
amazon-cloudwatch
## Proposed changes
<!--- Describe your changes in detail -->
Add new package for AWS images.
For some reason when I tried placing .deb packet to directory `packages/`
It didn't copy packets to chroot directory (import-local-packages)
I can suggest that it doesn't work anymore or was broken.
https://github.com/vyos/vyos-build/blob/equuleus/scripts/import-local-packages
So I download it directly to `build/config/packages.chroot/`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

build image for AWS
```
sudo make AWS
```
Check that pkg exist in the image:
```
vyos@vyos:~$ show version all | match cloud
ii  amazon-cloudwatch-agent              1.247349.0b251399-1                 amd64        Amazon CloudWatch Agent
ii  cloud-init                           20.4-404-g0a9f4841-1~bddeb          all          Init scripts for cloud instances
vyos@vyos:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
