### PR TITLE
T4034: Fix package list for xcp-ng-iso build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ edgecore: check_build_config clean prepare
 xcp-ng-iso: check_build_config clean prepare
 	@set -e
 	@echo "It's not like I'm building this specially for you or anything!"
-	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' data/package-lists/vyos-x86.list.chroot
+	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' $(build_dir)/package-lists/vyos-x86.list.chroot
 	cd $(build_dir)
 	set -o pipefail
 	lb build 2>&1 | tee build.log; if [ $$? -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
prepare target is running before xcp-ng-iso which copies ./data/package-lists/vyos-x86.list.chroot to $(build_dir)/config/package-lists/vyos-x86.list.chroot.
During the build step, this is too late and therefore we need to patch the package list inside the build directory.