### PR TITLE
T4034: Fix xcp-ng-iso build for crux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ lanner_nca25xx: check_build_config clean prepare
 xcp-ng-iso: check_build_config clean prepare
 	@set -e
 	@echo $(init_msg)
-	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' data/package-lists/vyos-x86.list.chroot
+	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' $(build_dir)/package-lists/vyos-x86.list.chroot
 	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' scripts/build-submodules
 	cd $(build_dir)
 	lb build 2>&1 | tee build.log

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ lanner_nca25xx: check_build_config clean prepare
 xcp-ng-iso: check_build_config clean prepare
 	@set -e
 	@echo $(init_msg)
-	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' $(build_dir)/package-lists/vyos-x86.list.chroot
+	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' $(build_dir)/config/package-lists/vyos-x86.list.chroot
 	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' scripts/build-submodules
 	cd $(build_dir)
 	lb build 2>&1 | tee build.log


### PR DESCRIPTION
The prepare step copies data/package-lists/vyos-x86.list.chroot to $(build_dir)/config/package-lists/vyos-x86.list.chroot.
Therefore, we need to adjust the destination file and not the source file, in order to include xe-guest-utilities instead of vyos-xe-guest-utilities.