### PR TITLE
T4034: Fix package path for xcp-ng build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ edgecore: check_build_config clean prepare
 xcp-ng-iso: check_build_config clean prepare
 	@set -e
 	@echo "It's not like I'm building this specially for you or anything!"
-	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' $(build_dir)/package-lists/vyos-x86.list.chroot
+	sed -i 's/vyos-xe-guest-utilities/xe-guest-utilities/g' $(build_dir)/config/package-lists/vyos-x86.list.chroot
 	cd $(build_dir)
 	set -o pipefail
 	lb build 2>&1 | tee build.log; if [ $$? -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
The prepare step copies data/package-lists/vyos-x86.list.chroot to $(build_dir)/config/package-lists/vyos-x86.list.chroot.
Therefore, we need to adjust the destination file and not the source file, in order to include xe-guest-utilities instead of vyos-xe-guest-utilities.

This PR fixes my bad fix before :-(