### PR TITLE
ndppd: T4172: Backport upstream fix for ndppd

### DIFF
--- a/packages/ndppd/Jenkinsfile
+++ b/packages/ndppd/Jenkinsfile
@@ -1,0 +1,32 @@
+// Copyright (C) 2020-2021 VyOS maintainers and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// in order to easy exprort images built to "external" world
+// it under the terms of the GNU General Public License version 2 or later as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+@NonCPS
+
+// Using a version specifier library, use 'current' branch. The underscore (_)
+// is not a typo! You need this underscore if the line immediately after the
+// @Library annotation is not an import statement!
+@Library('vyos-build@current')_
+
+// NOTE: we can build with -d as the libbpf dependency is installed manually
+// and not via a DEB package
+def pkgList = [
+    ['name': 'ndppd',
+     'scmCommit': 'debian/0.2.5.6',
+     'scmUrl': 'https://salsa.debian.org/debian/ndppd',
+     'buildCmd': 'cd ..; ./build.sh'],
+]
+
+// Start package build using library function from https://github.com/vyos/vyos-build
+buildPackage('ndppd', pkgList, null, true, "**/packages/ndppd/*")

--- a/packages/ndppd/build.sh
+++ b/packages/ndppd/build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+CWD=$(pwd)
+set -e
+
+SRC=ndppd
+if [ ! -d ${SRC} ]; then
+    echo "Source directory does not exists, please 'git clone'"
+    exit 1
+fi
+
+cd ${SRC}
+PATCH_DIR=${CWD}/patches
+for patch in $(ls ${PATCH_DIR})
+do
+    echo "I: Apply patch: ${PATCH_DIR}/${patch}"
+    patch -p1 < ${PATCH_DIR}/${patch}
+done
+
+echo "I: Build Debian Package"
+dpkg-buildpackage -uc -us -tc -b -d

--- a/packages/ndppd/patches/0001-skip-route-table-if-there-is-no-auto-rule.patch
+++ b/packages/ndppd/patches/0001-skip-route-table-if-there-is-no-auto-rule.patch
@@ -1,0 +1,83 @@
+From b148ba055245cec5007ee91dd3ffbfeb58d49c5a Mon Sep 17 00:00:00 2001
+From: Henning Surmeier <me@hensur.de>
+Date: Sun, 9 Jan 2022 20:35:15 +0100
+Subject: [PATCH 1/2] skip route table if there is no auto rule
+
+---
+ src/ndppd.cc | 3 ++-
+ src/rule.cc  | 8 ++++++++
+ src/rule.h   | 4 ++++
+ 3 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/src/ndppd.cc b/src/ndppd.cc
+index bec9656..b303721 100644
+--- a/src/ndppd.cc
++++ b/src/ndppd.cc
+@@ -304,7 +304,8 @@ int main(int argc, char* argv[], char* env[])
+         t1.tv_sec  = t2.tv_sec;
+         t1.tv_usec = t2.tv_usec;
+ 
+-        route::update(elapsed_time);
++        if (rule::any_auto())
++            route::update(elapsed_time);
+         session::update_all(elapsed_time);
+     }
+ 
+diff --git a/src/rule.cc b/src/rule.cc
+index 9e72480..a1e8376 100644
+--- a/src/rule.cc
++++ b/src/rule.cc
+@@ -24,6 +24,8 @@
+ 
+ NDPPD_NS_BEGIN
+ 
++bool rule::_any_aut = false;
++
+ rule::rule()
+ {
+ }
+@@ -49,6 +51,7 @@ ptr<rule> rule::create(const ptr<proxy>& pr, const address& addr, bool aut)
+     ru->_pr    = pr;
+     ru->_addr  = addr;
+     ru->_aut   = aut;
++    _any_aut = _any_aut || aut;
+ 
+     logger::debug()
+         << "rule::create() if=" << pr->ifa()->name().c_str() << ", addr=" << addr
+@@ -57,6 +60,11 @@ ptr<rule> rule::create(const ptr<proxy>& pr, const address& addr, bool aut)
+     return ru;
+ }
+ 
++bool rule::any_auto()
++{
++    return _any_aut;
++}
++
+ const address& rule::addr() const
+ {
+     return _addr;
+diff --git a/src/rule.h b/src/rule.h
+index 6663066..ca2aa36 100644
+--- a/src/rule.h
++++ b/src/rule.h
+@@ -42,6 +42,8 @@ public:
+ 
+     bool check(const address& addr) const;
+ 
++    static bool any_auto();
++
+ private:
+     weak_ptr<rule> _ptr;
+ 
+@@ -53,6 +55,8 @@ private:
+ 
+     bool _aut;
+ 
++    static bool _any_aut;
++
+     rule();
+ };
+ 
+-- 
+2.34.1
+

--- a/packages/ndppd/patches/0002-set-vyos-version.patch
+++ b/packages/ndppd/patches/0002-set-vyos-version.patch
@@ -1,0 +1,25 @@
+From b0789cf679b0179d37e22f5a936af273d982abeb Mon Sep 17 00:00:00 2001
+From: Henning Surmeier <me@hensur.de>
+Date: Tue, 11 Jan 2022 13:05:47 +0100
+Subject: [PATCH 2/2] set -vyos version
+
+---
+ src/ndppd.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ndppd.h b/src/ndppd.h
+index 008726c..61ed950 100644
+--- a/src/ndppd.h
++++ b/src/ndppd.h
+@@ -21,7 +21,7 @@
+ #define NDPPD_NS_BEGIN   namespace ndppd {
+ #define NDPPD_NS_END     }
+ 
+-#define NDPPD_VERSION   "0.2.4"
++#define NDPPD_VERSION   "0.2.5-vyos"
+ 
+ #include <assert.h>
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Backports a fix to not read the full ipv6 route table if there is no
need to do so.
Which is the case when no auto prefixes are configured.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T4172

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ndppd

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
