### PR TITLE
T4306: do not perform a dirtiness check for release builds

### DIFF
--- a/scripts/make-version-file
+++ b/scripts/make-version-file
@@ -51,9 +51,12 @@ try:
 
     # Retrieve the Git commit ID of the repository, 14 charaters will be sufficient
     build_git = repo.head.object.hexsha[:14]
-    # If somone played around with the source tree and the build is "dirty", mark it
-    if repo.is_dirty():
-        build_git += "-dirty"
+    # If someone played around with the source tree and the build is "dirty", mark it.
+    # Release builds can be "ditry by design" (e.g. modified default config) though,
+    # so the dirtiness check is only applied to development builds.
+    if build_config["build_type"] == "development":
+        if repo.is_dirty():
+            build_git += "-dirty"
 
     # Retrieve git branch name
     git_branch = repo.active_branch.name


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary

Do not check for dirty repository when building release images.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): build script behavior change

## Related Task(s)

https://phabricator.vyos.net/T4306