### PR TITLE
keepalived: T4128: remove buster-backports APT pinning

### DIFF
--- a/data/live-build-config/archives/buster-backports.pref.chroot
+++ b/data/live-build-config/archives/buster-backports.pref.chroot
@@ -18,10 +18,6 @@ Package: conserver-client
 Pin: release n=buster-backports
 Pin-Priority: 600
 
-Package: keepalived
-Pin: release n=buster-backports
-Pin-Priority: 600
-
 Package: wireguard-tools
 Pin: release n=buster-backports
 Pin-Priority: 600


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 5226a4a ("keepalived: T4128: build package from upstream source") added the required files to build the keepalived package from source. The resulting binary DEB is thus located inside the VyOS repositories - this makes APT pinning from Debian Buster Backport repository superfluous.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Cleanup

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

https://phabricator.vyos.net/T4128

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

keepalived

## Proposed changes
<!--- Describe your changes in detail -->

Remove APT pinning

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Smoketests
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
