### PR TITLE
T4415: keep copyright* and README* files from /usr/share/doc in the image

### DIFF
--- a/data/live-build-config/hooks/live/80-delete-docs.chroot
+++ b/data/live-build-config/hooks/live/80-delete-docs.chroot
@@ -3,4 +3,4 @@
 # We do not need any documentation on the system. This frees some space.
 # Copyright/licenses files are ignored for deletion
 shopt -s extglob
-rm -rf /usr/share/doc/*/!(copyright) /usr/share/doc-base
+rm -rf /usr/share/doc/*/!(copyright*|README*) /usr/share/doc-base


### PR DESCRIPTION
Right now we keep all `copyright*` files in the image when we remove the rest of /use/share/doc to save space, but some packages use different names. For example, OpenNHRP keeps its copyright info in README, so we should probably keep all `README*` just in case.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

T4415

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
