### PR TITLE
firewall: T4299: Include initial GeoIP database

### DIFF
--- a/data/live-build-config/hooks/live/40-init-geoip-database.chroot
+++ b/data/live-build-config/hooks/live/40-init-geoip-database.chroot
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Geolocation data provided by DB-IP.com
+# License: https://creativecommons.org/licenses/by/4.0/ (CC BY 4.0)
+
+DATE_SUFFIX=$(date +%Y-%m)
+URL="https://download.db-ip.com/free/dbip-country-lite-${DATE_SUFFIX}.csv.gz"
+OUT_PATH="/usr/share/vyos-geoip/dbip-country-lite.csv.gz"
+
+mkdir -p $(dirname $OUT_PATH)
+wget -O - $URL > $OUT_PATH
+
+if [ $? -ne 0 ]; then
+    echo "Failed to download GeoIP database"
+    rm $OUT_PATH
+fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4299

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->
Provides a GeoIP database with base image (only ~3MB)

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
