### PR TITLE
smoketest: Move PKI file generate to script in vyos-1x

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -520,49 +520,13 @@ try:
         c.sendline('echo "x39C77eavJNpvYbNzPSG3n1D68rHYei6q3AEBEyL1z8=" | sudo tee /config/auth/wireguard/default/public.key')
         c.expect(op_mode_prompt)
 
-        log.info('Generating some OpenVPN keys')
-        subject = '/C=DE/ST=BY/O=VyOS/localityName=Cloud/commonName=vyos/' \
-                  'organizationalUnitName=VyOS/emailAddress=maintainers@vyos.io/'
-        ca_subject = '/C=DE/ST=BY/O=VyOS/localityName=Cloud/commonName=vyos\ CA/' \
-                  'organizationalUnitName=VyOS/emailAddress=maintainers@vyos.io/'
-        subca_subject = '/C=DE/ST=BY/O=VyOS/localityName=Cloud/commonName=vyos\ SubCA/' \
-                  'organizationalUnitName=VyOS/emailAddress=maintainers@vyos.io/'
-        ca_cert = '/config/auth/ovpn_test_ca.pem'
-        ca_cert_chain = '/config/auth/ovpn_test_chain.pem'
-        subca_cert = '/config/auth/ovpn_test_subca.pem'
-        subca_csr = '/tmp/subca.csr'
-        subca_key = '/config/auth/ovpn_test_subca.key'
-        ssl_cert = '/config/auth/ovpn_test_server.pem'
-        ssl_key  = '/config/auth/ovpn_test_server.key'
-        dh_pem   = '/config/auth/ovpn_test_dh.pem'
-        s2s_key  = '/config/auth/ovpn_test_site2site.key'
-        auth_key = '/config/auth/ovpn_test_tls_auth.key'
-
-        c.sendline(f'openssl req -newkey rsa:4096 -new -nodes -x509 -days 3650 '\
-                   f'-keyout {ssl_key} -out {ssl_cert} -subj {subject}')
-        c.expect(op_mode_prompt, timeout=600)
-        c.sendline(f'openssl req -new -x509 -extensions v3_ca -key {ssl_key} -out {ca_cert} -subj {ca_subject}')
-        c.expect(op_mode_prompt, timeout=600)
-        c.sendline(f'openssl req -newkey rsa:2048 -new -nodes -keyout {subca_key} -out {subca_csr} -subj {subca_subject}')
-        c.expect(op_mode_prompt, timeout=600)
-        c.sendline(f'openssl x509 -req -CA {ca_cert} -CAkey {ssl_key} -set_serial 01 -extfile /etc/ssl/openssl.cnf -extensions v3_ca -days 3650 -out {subca_cert} -in {subca_csr}')
-        c.expect(op_mode_prompt, timeout=600)
-        c.sendline(f'cat {subca_cert} {ca_cert} > {ca_cert_chain}')
-        c.expect(op_mode_prompt, timeout=600)
-        c.sendline(f'openssl dhparam -out {dh_pem} 2048')
-        c.expect(op_mode_prompt, timeout=600)
-        c.sendline(f'openvpn --genkey secret {s2s_key}')
-        c.expect(op_mode_prompt)
-        c.sendline(f'openvpn --genkey secret {auth_key}')
-        c.expect(op_mode_prompt)
+        log.info('Generating PKI objects')
+        c.sendline(f'/usr/bin/vyos-configtest-pki')
+        c.expect(op_mode_prompt, timeout=900)
 
         script_file = '/config/scripts/vyos-foo-update.script'
         c.sendline(f'echo "#!/bin/sh" > {script_file}; chmod 775 {script_file}')
         c.expect(op_mode_prompt)
-
-        for file in [ca_cert, ca_cert_chain, ssl_cert, ssl_key, dh_pem, s2s_key, auth_key]:
-            c.sendline(f'sudo chown openvpn:openvpn {file}')
-            c.expect(op_mode_prompt)
 
         log.info('Executing load config tests')
         c.sendline('/usr/bin/vyos-configtest')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

See https://github.com/vyos/vyos-1x/pull/1385

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://github.com/vyos/vyos-1x/pull/1385

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
