### PR TITLE
T4666: hostap: Reintroduce Debian's allow-tlsv1.patch

### DIFF
--- a/packages/hostap/build.sh
+++ b/packages/hostap/build.sh
@@ -16,7 +16,9 @@ fi
 
 echo "I: Copy Debian build instructions"
 cp -a ${SRC_DEB}/debian ${SRC}
-rm -rf ${SRC}/debian/patches
+# Preserve Debian's default of allowing TLSv1.0 for compatibility
+find ${SRC}/debian/patches -mindepth 1 ! -name allow-tlsv1.patch -delete
+echo 'allow-tlsv1.patch' > ${SRC}/debian/patches/series
 
 # Build Debian package
 cd ${SRC}


### PR DESCRIPTION
## Change Summary

After the fixes for T4537/T4584, which added a custom hostap package,
wpa_supplicant no longer allows TLSv1.0 connections, which is required
for EAP-TLS with certain ISPs.

Previously, VyOS allowed TLSv1.0 via Debian's `allow-tlsv1.patch` patch.
This commit reintroduces that patch for the custom hostap package.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Regression from prior VyOS releases

## Related Task(s)

https://phabricator.vyos.net/T4666

## Component(s) name

eapol, hostap, wpa_supplicant

## Proposed changes

(Included above and in commit description)

## How to test

Not sure how to test in isolation as it requires an EAP-TLS setup that only supports TLSv1.0. However, with this commit, I built a new `.deb` package, installed it on top of `1.4-rolling-202209020217`, and was able to connect to my ISP.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
