### PR TITLE
backport: vyos-utils: T4683: add kitty-terminfo package to build

### DIFF
--- a/data/live-build-config/package-lists/vyos-utils.list.chroot
+++ b/data/live-build-config/package-lists/vyos-utils.list.chroot
@@ -1,3 +1,4 @@
 systemd-sysv
 systemd-bootchart
 ncurses-term
+kitty-terminfo


### PR DESCRIPTION
## Change Summary

Backport of #264

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4683

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
See #264.

## How to test
See #264.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
