### PR TITLE
T3664: Add support for local packages, generate apt release pinning

### DIFF
--- a/data/live-build-config/archives/current.pref.chroot
+++ b/data/live-build-config/archives/current.pref.chroot
@@ -1,3 +1,0 @@
-Package: *
-Pin: release n=current
-Pin-Priority: 600

--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -447,13 +447,21 @@ if __name__ == "__main__":
             --security true \
             --backports true \
             --apt-recommends false \
-            --apt-options "--yes -oAPT::Default-Release="{{release_train}}" -oAPT::Get::allow-downgrades=true" \
+            --apt-options "--yes -oAPT::Get::allow-downgrades=true" \
             --apt-indices false
             "${@}"
     """)
 
-
     lb_config_command = lb_config_tmpl.render(build_config)
+
+    ## Pin release for VyOS packages
+    apt_pin = f"""Package: *
+Pin: release n={build_config['release_train']}
+Pin-Priority: 600
+"""
+
+    with open(f'../data/live-build-config/archives/vyos.pref.chroot', 'w') as f:
+        f.write(apt_pin)
 
     print("I: Configuring live-build")
 
@@ -471,6 +479,11 @@ if __name__ == "__main__":
         print("I: dry-run, not starting image build")
         sys.exit(0)
 
+    ## Add local packages
+    local_packages = glob.glob('../packages/*.deb')
+    if local_packages:
+        for f in local_packages:
+            shutil.copy(f, 'config/packages.chroot/' + os.path.basename(f))
 
     ## Build the image
     print("I: Starting image build")


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for local packages with new build system
Generate apt release pinning file instead of using APT::Default-Release (caused issue with local packages)

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3664

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
