### PR TITLE
wide-dhcpv6: T4760: fix support for multiple dhcp6c instances

### DIFF
--- a/packages/wide-dhcpv6/patches/0024-bind-to-single-socket.patch
+++ b/packages/wide-dhcpv6/patches/0024-bind-to-single-socket.patch
@@ -1,0 +1,17 @@
+diff --git a/dhcp6c.c b/dhcp6c.c
+index 1caaaa5..04ce9c5 100644
+--- a/dhcp6c.c
++++ b/dhcp6c.c
+@@ -217,6 +217,12 @@ main(argc, argv)
+ 			    argv[0]);
+ 			exit(1);
+ 		}
++
++        if (setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, argv[0], strlen(argv[0])) != 0) {
++            debug_printf(LOG_ERR, FNAME, "failed to bind %s", argv[0]);
++            exit(1);
++        }
++
+ 		argv++;
+ 	}
+ 


### PR DESCRIPTION
## Change Summary

Adds a patch to the WIDE DHCPv6 sources to force the listening socket to bind to a single interface.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

https://phabricator.vyos.net/T4760

## Component(s) name

packages, wide-dhcpv6

## Proposed changes

Currently the issue with having multiple DHCPv6 clients running is that all client daemons bind to all interfaces, causing a single daemon to receive all the packets (and breaking functionality on other daemons). We rectify this by patching the client code to only listen on a single interface (set to the last interface passed on the command line) so that concurrent instances do not step on each other.

**Note:** The WIDE DHCPv6 client is capable of servicing multiple network interfaces at once under a single daemon (that's why it does not bind to any specific interface). Application of this patch breaks that functionality since it restricts packet send/receive to a single interface. This however does not affect the way VyOS uses the client since VyOS is currently architected around launching one daemon per configured interface.

Attempts to rearchitect VyOS to use a single instance of the DHCPv6 client proves to be very difficult since the daemon would need to be relaunched every time a dynamic interface (e.g. PPPoE) appears/disappears. Given that the daemon stores no state data across restarts, any attempt to restart the daemon will cause new DHCPv6 leases to be acquired for all configured interfaces, potentially causing unrelated interfaces (with respect to the dynamic interface that triggered the restart) to be affected.

## How to test

Generate a configuration that requires multiple dhcp6c daemons running at once, such as:
```
interfaces {
    ethernet eth0 {
        address dhcpv6
    }

    ethernet eth1 {
        address dhcpv6
    }
}
```
observe that both interfaces successfully complete their DHCPv6 transactions. Prior to this PR, only one of the two interfaces will succeed.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
