### PR TITLE
backport: wide-dhcpv6: T4760: fix support for multiple dhcp6c instances

### DIFF
--- a/packages/wide-dhcpv6/patches/0024-bind-to-single-socket.patch
+++ b/packages/wide-dhcpv6/patches/0024-bind-to-single-socket.patch
@@ -1,0 +1,17 @@
+diff --git a/dhcp6c.c b/dhcp6c.c
+index 1caaaa5..04ce9c5 100644
+--- a/dhcp6c.c
++++ b/dhcp6c.c
+@@ -217,6 +217,12 @@ main(argc, argv)
+ 			    argv[0]);
+ 			exit(1);
+ 		}
++
++        if (setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, argv[0], strlen(argv[0])) != 0) {
++            debug_printf(LOG_ERR, FNAME, "failed to bind %s", argv[0]);
++            exit(1);
++        }
++
+ 		argv++;
+ 	}
+ 


### PR DESCRIPTION
## Change Summary

Backport of #273.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

https://phabricator.vyos.net/T4760

## Component(s) name

packages, wide-dhcpv6

## Proposed changes

See #273.

## How to test

See #273.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
