### PR TITLE
Fix T4800: wrong chroot_includes_dir var reference

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -412,7 +412,7 @@ if __name__ == "__main__":
     ## Create includes
     if has_nonempty_key(build_config, "includes_chroot"):
         for i in build_config["includes_chroot"]:
-            file_path = os.path.join(includes_chroot_dir, i["path"])
+            file_path = os.path.join(chroot_includes_dir, i["path"])
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, 'w') as f:
                 f.write(i["data"])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary

Wrong var name is used in build script.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

Code bug fix.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->

https://phabricator.vyos.net/T4800

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
