### PR TITLE
T4796: Fix some bugs in the build-vyos-image script

### DIFF
--- a/data/architectures/amd64.toml
+++ b/data/architectures/amd64.toml
@@ -1,3 +1,10 @@
+additional_repositories = [
+  "deb [arch=amd64] https://repo.saltproject.io/py3/debian/11/amd64/3004 bullseye main",
+  "deb [arch=amd64] http://repo.powerdns.com/debian bullseye-rec-48 main"
+]
+
+kernel_flavor = "amd64-vyos"
+
 # Packages added to images for x86 by default
 packages = [
   "grub2",
@@ -6,5 +13,3 @@ packages = [
   "vyos-intel-qat",
   "telegraf"
 ]
-
-kernel_flavor = "amd64-vyos"

--- a/data/defaults.toml
+++ b/data/defaults.toml
@@ -14,11 +14,6 @@ release_train = "current"
 
 kernel_version = "5.15.77"
 
-additional_repositories = [
-  "deb [arch=amd64] https://repo.saltproject.io/py3/debian/11/amd64/3004 bullseye main",
-  "deb [arch=amd64] http://repo.powerdns.com/debian bullseye-rec-48 main"
-]
-
 website_url = "https://vyos.io"
 support_url = "https://support.vyos.io"
 bugtracker_url = "https://phabricator.vyos.net"

--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -397,7 +397,7 @@ if __name__ == "__main__":
 
     # Add custom APT keys
     if has_nonempty_key(build_config, 'custom_apt_key'):
-        key_dir = ARCHIVES_DIR
+        key_dir = defaults.ARCHIVES_DIR
         for k in build_config['custom_apt_key']:
             dst_name = '{0}.key.chroot'.format(os.path.basename(k))
             shutil.copy(k, os.path.join(key_dir, dst_name))

--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -206,10 +206,6 @@ if __name__ == "__main__":
             print("Use --build-type=release option if you want to set version number")
             sys.exit(1)
 
-    if not args['custom_apt_entry']:
-        args['custom_apt_entry'] = []
-    args['custom_apt_entry'] = args['custom_apt_entry'] + build_defaults['additional_repositories']
-
     ## Inject some useful hardcoded options
     args['build_dir'] = defaults.BUILD_DIR
     args['pbuilder_config'] = os.path.join(defaults.BUILD_DIR, defaults.PBUILDER_CONFIG)
@@ -385,6 +381,10 @@ if __name__ == "__main__":
         f.write(vyos_repo_entry)
 
     # Add custom APT entries
+    if not args['custom_apt_entry']:
+        args['custom_apt_entry'] = []
+    if build_config['additional_repositories']:
+        args['custom_apt_entry'] = args['custom_apt_entry'] + build_config['additional_repositories']
     if build_config['custom_apt_entry']:
         custom_apt_file = defaults.CUSTOM_REPO_FILE
         entries = "\n".join(build_config['custom_apt_entry'])

--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -71,7 +71,7 @@ def merge_dicts(source, destination):
         if key not in tmp:
             tmp[key] = value
         elif isinstance(source[key], dict):
-            tmp[key] = dict_merge(source[key], tmp[key])
+            tmp[key] = merge_dicts(source[key], tmp[key])
         elif isinstance(source[key], list):
             tmp[key] = source[key] + tmp[key]
         else:


### PR DESCRIPTION
## Change Summary
Fix some bugs with the build-vyos-image script:
-  `additional_repositories` defined in an architecture or build-flavor file were being ignored
-  `custom_apt_key` could not be used
-  `merge_dicts` could not correctly handle a key which was a dict
- Move definition of `additional_repositories` to architecture files rather than defaults, so we don't try to include amd64 repos on other platforms

Minor code style change:
- Sorted the keys in amd64.toml


## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code style update (formatting, renaming)


## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T4796

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vyos-build

## Proposed changes

Move `additional_repositories` out of `defaults.toml` and into `architecture/amd64.toml`, as the repositories within are pinned to amd64 architecture which is undesirable on other platforms.

When parsing custom_apt_entry and additional_reposiories:
- Parse *after* build_config has been merged.
- Rather than only looking at the default config, look at the merged build_config.
- Check whether additional_repositories is actually defined before trying to reference it.

`ARCHIVES_DIR` should be `defaults.ARCHIVE_DIR`.

The `merge_dicts` function contains a line I believe is intended to be self-referential - when a parsed key is of the `dict` type, we're trying to pass it to a function called `dict_merge`. Update that reference to be `merge_dicts`.

## How to test
Testing involved creating an arm64 build container:
```
sudo docker run --rm -it \
-v "$(shell pwd)":/vyos \
      -w /vyos --privileged --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
      -e GOSU_UID=0 -e GOSU_GID=0 \
      vyos/vyos-build:current-arm64 bash
```
Then repeatedly making changes to the build script and TOML definitions, running `./build-vyos-image --architecture arm64 --debug --dry-run iso`, and observing the `Effective build config` output. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
