### PR TITLE
T4796: Check more cautiously for presence of keys

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -383,9 +383,9 @@ if __name__ == "__main__":
     # Add custom APT entries
     if not args['custom_apt_entry']:
         args['custom_apt_entry'] = []
-    if build_config['additional_repositories']:
+    if build_config.get('additional_repositories', False):
         args['custom_apt_entry'] = args['custom_apt_entry'] + build_config['additional_repositories']
-    if build_config['custom_apt_entry']:
+    if build_config.get('custom_apt_entry', False):
         custom_apt_file = defaults.CUSTOM_REPO_FILE
         entries = "\n".join(build_config['custom_apt_entry'])
         if debug:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Check more cautiously for presence of keys in `build_config`, default to `False` if no value is found.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T4796
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
- build-vyos-image
## Proposed changes
<!--- Describe your changes in detail -->

If a situation exists where `build_config` may not have a key set, then rather than looking for a truthy value with `if build_config['keyname']` we'd be safer using `get` with a default value of `False`.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Launched a build container:
```
sudo docker run --rm -it \
-v "$(shell pwd)":/vyos \
      -w /vyos --privileged --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
      -e GOSU_UID=0 -e GOSU_GID=0 \
      vyos/vyos-build:current-arm64 bash
```


Ran ``./build-vyos-image --architecture arm64 --debug --dry-run iso`:
```
Traceback (most recent call last):
  File "/vyos/./build-vyos-image", line 386, in <module>
    if build_config['additional_repositories']:
KeyError: 'additional_repositories'
```

Made the change in this PR and re-ran without issue.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
