### PR TITLE
 T4796: Default args to list where list is expected

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -164,9 +164,9 @@ if __name__ == "__main__":
     parser.add_argument('--dry-run', help='Check build configuration and exit', action='store_true')
 
     # Custom APT entry and APT key options can be used multiple times
-    parser.add_argument('--custom-apt-entry', help="Custom APT entry", action='append')
-    parser.add_argument('--custom-apt-key', help="Custom APT key file", action='append')
-    parser.add_argument('--custom-package', help="Custom package to install from repositories", action='append')
+    parser.add_argument('--custom-apt-entry', help="Custom APT entry", action='append', default=[])
+    parser.add_argument('--custom-apt-key', help="Custom APT key file", action='append', default=[])
+    parser.add_argument('--custom-package', help="Custom package to install from repositories", action='append', default=[])
 
     # Build flavor is a positional argument
     parser.add_argument('build_flavor', help='Build flavor', nargs='?', action='store')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
`custom_apt_entry`, `custom_apt_key`, and `custom_package` are expected to be lists, but when a value is not provided they default to None. This prevents lists provided in mix-in or flavor configurations from being merged as expected.

https://docs.python.org/3/library/argparse.html#default

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T4796
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

- build-vyos-image

## Proposed changes
<!--- Describe your changes in detail -->

`custom_apt_entry`, `custom_apt_key`, and `custom_package` are expected to be lists, but when a value is not provided they default to None. This prevents lists provided in mix-in or flavor configurations from being merged as expected.

This change defaults those values to an empty list, which 

https://docs.python.org/3/library/argparse.html#default
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Testing involved creating an arm64 build container:
```
sudo docker run --rm -it \
-v "$(shell pwd)":/vyos \
      -w /vyos --privileged --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
      -e GOSU_UID=0 -e GOSU_GID=0 \
      vyos/vyos-build:current-arm64 bash
```
Then repeatedly making changes to the build script and TOML definitions, running `./build-vyos-image --architecture arm64 --debug --dry-run iso`, and observing the `Effective build` config output.

With the following content in `data/arm64.toml`:
```
# Packages included in ARM64 images by default
packages = ["grub-efi-arm64"]
kernel_flavor= "v8-arm64-vyos"
bootloaders = "grub-efi"
additional_repositories =  [
    "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-45 main",
    "deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable",
]
custom_apt_key = [
    "/vyos/vyos-build/influxdb.key",
]
```
Output before change:
```
D: Effective build config:

{
    "image_format": "iso",
    "packages": [
        "gdb",
        "strace",
        "apt-rdepends",
        "tshark",
        "vim",
        "vyos-1x-smoketest",
        "grub-efi-arm64",
        "qemu-guest-agent",
        "vyos-xe-guest-utilities"
    ],
    "architectures": {
        "amd64": {
            "packages": [
                "hyperv-daemons",
                "vyos-1x-vmware"
            ]
        }
    },
    "kernel_flavor": "v8-arm64-vyos",
    "bootloaders": "grub-efi",
    "additional_repositories": [
        "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-45 main",
        "deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable"
    ],
    "custom_apt_key": null,
    "build_type": "development",
    "architecture": "arm64",
    "debian_distribution": "bullseye",
    "debian_mirror": "http://deb.debian.org/debian",
    "debian_security_mirror": "http://deb.debian.org/debian-security",
    "vyos_mirror": "http://dev.packages.vyos.net/repositories/current",
    "vyos_branch": "current",
    "release_train": "current",
    "kernel_version": "5.15.77",
    "website_url": "https://vyos.io",
    "support_url": "https://support.vyos.io",
    "bugtracker_url": "https://phabricator.vyos.net",
    "build_by": "root@e1cc68d7f3c0",
    "pbuilder_debian_mirror": "http://deb.debian.org/debian",
    "version": null,
    "build_comment": "",
    "debug": true,
    "dry_run": true,
    "custom_apt_entry": null,
    "custom_package": null,
    "build_flavor": "iso",
    "build_dir": "build",
    "pbuilder_config": "build/pbuilderrc"
}
```

Output after change:
```
D: Effective build config:

{
    "image_format": "iso",
    "packages": [
        "gdb",
        "strace",
        "apt-rdepends",
        "tshark",
        "vim",
        "vyos-1x-smoketest",
        "grub-efi-arm64",
        "qemu-guest-agent",
        "vyos-xe-guest-utilities"
    ],
    "architectures": {
        "amd64": {
            "packages": [
                "hyperv-daemons",
                "vyos-1x-vmware"
            ]
        }
    },
    "kernel_flavor": "v8-arm64-vyos",
    "bootloaders": "grub-efi",
    "additional_repositories": [
        "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-45 main",
        "deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable"
    ],
    "custom_apt_key": [
        "/vyos/influxdb.key"
    ],
    "build_type": "development",
    "architecture": "arm64",
    "debian_distribution": "bullseye",
    "debian_mirror": "http://deb.debian.org/debian",
    "debian_security_mirror": "http://deb.debian.org/debian-security",
    "vyos_mirror": "http://dev.packages.vyos.net/repositories/current",
    "vyos_branch": "current",
    "release_train": "current",
    "kernel_version": "5.15.77",
    "website_url": "https://vyos.io",
    "support_url": "https://support.vyos.io",
    "bugtracker_url": "https://phabricator.vyos.net",
    "build_by": "root@e1cc68d7f3c0",
    "pbuilder_debian_mirror": "http://deb.debian.org/debian",
    "version": null,
    "build_comment": "",
    "debug": true,
    "dry_run": true,
    "custom_apt_entry": [],
    "custom_package": [],
    "build_flavor": "iso",
    "build_dir": "build",
    "pbuilder_config": "build/pbuilderrc"
}
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
