### PR TITLE
T4796: Prefer mix-in config over default config

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -216,15 +216,15 @@ if __name__ == "__main__":
     ## Load the flavor file and mix-ins
     with open(make_toml_path(defaults.BUILD_TYPES_DIR, build_config["build_type"]), 'r') as f:
         build_type_config = toml.load(f)
-        build_config = merge_dicts(build_config, build_type_config)
+        build_config = merge_dicts(build_type_config, build_config)
 
     with open(make_toml_path(defaults.BUILD_ARCHES_DIR, build_config["architecture"]), 'r') as f:
         build_arch_config = toml.load(f)
-        build_config = merge_dicts(build_config, build_arch_config)
+        build_config = merge_dicts(build_arch_config, build_config)
 
     with open(make_toml_path(defaults.BUILD_FLAVORS_DIR, build_config["build_flavor"]), 'r') as f:
         flavor_config = toml.load(f)
-        build_config = merge_dicts(build_config, flavor_config)
+        build_config = merge_dicts(flavor_config, build_config)
 
     ## Rename and merge some fields for simplicity
     ## E.g. --custom-packages is for the user, but internally


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Preference custom values over default values when constructing the effective `build_config`.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T4796
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
- build-vyos-image
## Proposed changes
<!--- Describe your changes in detail -->
In the current state of the `build-vyos-image` script, values specified in build-types, architecture, or build-flavors toml files will never be preferenced above existing configuration. If there's already a default value set and you're trying to override that default using an architecture toml file, the default will be preferred.

This seems unlikely to be the intended behaviour, so this change reverses the preferences when merging those mix-in configs into the current config.

This will also cause each type of mix-in config to be preferenced above the previously parsed one (most recently parsed value wins). I'm not sure exactly how these configurations should be ordered preferentially? `build_type` -> `build_flavor` -> `architecture` would make sense to me, but I'm not an expert!

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
I created a build container:
```
sudo docker run --rm -it \
-v "$(shell pwd)":/vyos \
      -w /vyos --privileged --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
      -e GOSU_UID=0 -e GOSU_GID=0 \
      vyos/vyos-build:current-arm64 bash
```
Set the following content in `data/architectures/arm64.toml`:
```
# Packages included in ARM64 images by default
packages = ["grub-efi-arm64"]
kernel_version = "5.15.75"
```

Added a debugging snippet to the build script:
```
    build_config = merge_dicts(args, build_defaults)
    if debug:
        import json
        print("D: Initial build config:\n")
        print(json.dumps(build_config, indent=4))
```

Ran `./build-vyos-image --architecture arm64 --debug --dry-run iso`
```
D: Initial build config:

{
<snip>
    "kernel_version": "5.15.77",
<snip>
}
D: Effective build config:

{
<snip>
    "kernel_version": "5.15.77",
<snip>
}
```
Then again, after making the change:
```
D: Initial build config:

{
<snip>
    "kernel_version": "5.15.77",
<snip>
}
D: Effective build config:

{
<snip>
    "kernel_version": "5.15.75",
<snip>
}
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
