### PR TITLE
T4796: Honor additional_repositories

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -381,10 +381,9 @@ if __name__ == "__main__":
         f.write(vyos_repo_entry)
 
     # Add custom APT entries
-    if not args['custom_apt_entry']:
-        args['custom_apt_entry'] = []
     if build_config.get('additional_repositories', False):
-        args['custom_apt_entry'] = args['custom_apt_entry'] + build_config['additional_repositories']
+        build_config['custom_apt_entry'] += build_config['additional_repositories']
+
     if build_config.get('custom_apt_entry', False):
         custom_apt_file = defaults.CUSTOM_REPO_FILE
         entries = "\n".join(build_config['custom_apt_entry'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Currently, additional_repositories in the effective build_config are ignored due to a bug wherein all values end up under `args['custom_apt_entry']` rather than`build_config['custom_apt_entry']`.

This change fixes that, ensuring that the content of `build_config['additional_repositories']` is added to  build_config['custom_apt_entry']` alongside the command-line arguments.
## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T4796
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
- build-vyos-image
## Proposed changes
<!--- Describe your changes in detail -->
Currently, additional_repositories in the effective build_config are ignored due to a bug wherein all values end up under `args['custom_apt_entry']` rather than`build_config['custom_apt_entry']`.

This change fixes that, ensuring that the content of `build_config['additional_repositories']` is added to  build_config['custom_apt_entry']` alongside the command-line arguments.

1) No need to set `args['custom_apt_entry']` to an empty list if not provided, this is now the default value when nothing is provided.

2) If `additional_repositories` is specified in `build_config`, add its values to the current `custom_apt_entry` list.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Create a build container:
```
sudo docker run --rm -it \
-v "$(shell pwd)":/vyos \
      -w /vyos --privileged --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
      -e GOSU_UID=0 -e GOSU_GID=0 \
      vyos/vyos-build:current-arm64 bash
```
### Before

#### Providing `--custom-apt-entry` on the command-line
Set the following content in `data/architectures/arm64.toml`:
```
# Packages included in ARM64 images by default
packages = ["grub-efi-arm"]
```
Run `./build-vyos-image --architecture arm64 --debug --dry-run --custom-apt-entry 'deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable' iso`:
```
D: Adding custom APT entries:
deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable
I: Configuring live-build
D: live-build configuration command
```
#### Specifying additional repositories via `additional_repositories` in mix-in config
Set the following content in `data/architectures/arm64.toml`:
```toml
# Packages included in ARM64 images by default
packages = ["grub-efi-arm"]
additional_repositories =  [
    "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-48 main",
    "deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable",
]
```

Run `./build-vyos-image --architecture arm64 --debug --dry-run iso`:
```
D: Effective build config:

{
    "custom_apt_entry": [],
    "additional_repositories": [
        "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-48 main",
        "deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable"
    ],
}

I: Setting up additional APT entries
D: Adding these entries to config/archives/vyos.list.chroot:
         deb http://dev.packages.vyos.net/repositories/current current main

I: Configuring live-build
D: live-build configuration command
```

This can be worked around by specifying `custom_apt_entry` in the mix-in config. E.g. for `arm64.toml`:
```toml
# Packages included in ARM64 images by default
packages = ["grub-efi-arm"]
custom_apt_entry =  [
    "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-48 main",
    "deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable",
]
```

Run `./build-vyos-image --architecture arm64 --debug --dry-run iso`:
```
D: Effective build config:

{
    "custom_apt_entry": [
        "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-48 main",
        "deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable"
    ],
}

I: Setting up additional APT entries
D: Adding these entries to config/archives/vyos.list.chroot:
         deb http://dev.packages.vyos.net/repositories/current current main

D: Adding custom APT entries:
deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-48 main
deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable
I: Configuring live-build
D: live-build configuration command

```

### After

#### Providing `--custom-apt-entry` on the command-line
Set the following content in `data/architectures/arm64.toml`:
```
# Packages included in ARM64 images by default
packages = ["grub-efi-arm"]
```
Run `./build-vyos-image --architecture arm64 --debug --dry-run --custom-apt-entry 'deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable' iso`:
```
D: Adding custom APT entries:
deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable
I: Configuring live-build
D: live-build configuration command
```
#### Specifying additional repositories via `additional_repositories` in mix-in config
Set the following content in `data/architectures/arm64.toml`:
```toml
# Packages included in ARM64 images by default
packages = ["grub-efi-arm"]
additional_repositories =  [
    "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-45 main",
    "deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable",
]
```

Run `./build-vyos-image --architecture arm64 --debug --dry-run iso`:
```
D: Adding custom APT entries:
deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-45 main
deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable
I: Configuring live-build
D: live-build configuration command
```
#### Specifying via mix-in and command-line
Set the following content in `data/architectures/arm64.toml`:
```toml
# Packages included in ARM64 images by default
packages = ["grub-efi-arm"]
additional_repositories =  [
    "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-45 main",
]
```

Run `./build-vyos-image --architecture arm64 --debug --dry-run --custom-apt-entry 'deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable' iso`:
```
D: Adding custom APT entries:
deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable
deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-45 main
I: Configuring live-build
D: live-build configuration command
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
