### PR TITLE
T4796: Allow configuration of 'bootloader' param

### DIFF
--- a/data/architectures/arm64.toml
+++ b/data/architectures/arm64.toml
@@ -1,2 +1,3 @@
 # Packages included in ARM64 images by default
 packages = ["grub-efi-arm"]
+bootloaders = "grub-efi"

--- a/data/defaults.toml
+++ b/data/defaults.toml
@@ -13,6 +13,7 @@ vyos_branch = "current"
 release_train = "current"
 
 kernel_version = "5.15.78"
+bootloaders = "syslinux,grub-efi"
 
 website_url = "https://vyos.io"
 support_url = "https://support.vyos.io"

--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -426,7 +426,7 @@ if __name__ == "__main__":
             --bootappend-live-failsafe "live components memtest noapic noapm nodma nomce nolapic nomodeset nosmp nosplash vga=normal console=ttyS0,115200 console=tty0 net.ifnames=0 biosdevname=0" \
             --linux-flavours {{kernel_flavor}} \
             --linux-packages linux-image-{{kernel_version}} \
-            --bootloader syslinux,grub-efi \
+            --bootloader {{ bootloaders }} \
             --binary-images iso-hybrid \
             --checksums 'sha256 md5' \
             --debian-installer none \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
Allow the `bootloader` live-build parameter to be set by mix-in configuration.

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
T4796
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build-vyos-image
## Proposed changes
<!--- Describe your changes in detail -->

- Remove hard-coded values for "bootloader" when creating the live-build, replaced with the value of `bootloaders`.
- Set the current value to the default value if not specified, via `defaults.toml`.
- Add the default for arm64 as `grub-efi`.

This restores the behaviour of the previous build script, before the flavor-based `build-vyos-image` was introduced:
https://github.com/vyos/vyos-build/blob/7149a2aa2e51abe6ffb2d81db4ff58da825f0da8/data/defaults.json
https://github.com/vyos/vyos-build/blob/7149a2aa2e51abe6ffb2d81db4ff58da825f0da8/data/generic-arm64.json
https://github.com/vyos/vyos-build/blob/7149a2aa2e51abe6ffb2d81db4ff58da825f0da8/scripts/live-build-config

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Start a build container:
```
sudo docker run --rm -it \
-v "$(shell pwd)":/vyos \
      -w /vyos --privileged --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
      -e GOSU_UID=0 -e GOSU_GID=0 \
      vyos/vyos-build:current-arm64 bash
```

Set the contents of `data/architectures/arm64.toml`:
```toml
# Packages included in ARM64 images by default
packages = ["grub-efi-arm64"]
kernel_flavor= "v8-arm64-vyos"
bootloaders = "grub-efi"
additional_repositories =  [
    "deb [arch=arm64] http://repo.powerdns.com/debian bullseye-rec-48 main",
    "deb [arch=arm64] https://repos.influxdata.com/debian bullseye stable",
]
custom_apt_key = [
    "/vyos/influxdb.key",
]
```

### Before
Run `./build-vyos-image --architecture arm64 --debug iso`:
```
D: Effective build config:
{
<snip>
    "bootloaders": "grub-efi",
<snip>
}
D: live-build configuration command

    lb config noauto             --architectures arm64 <snip>  --bootloader syslinux,grub-efi
```

Eventually the build fails with:
```
xorriso : FAILURE : Cannot find in ISO image: -boot_image ... bin_path='/isolinux/isolinux.bin'
```

### After
#### Building an arm64 image with `bootloader` set via architecture mix-in 
Run `./build-vyos-image --architecture arm64 --debug iso`:
```
ISO image produced: 186229 sectors
Written to medium : 186229 sectors at LBA 0
Writing to 'stdio:live-image-arm64.hybrid.iso' completed successfully.
```

#### Building an amd64 image with `bootloader` inherited from defaults
Run `./build-vyos-image --debug iso`:
```
ISO image produced: 232448 sectors
Written to medium : 232448 sectors at LBA 0
Writing to 'stdio:live-image-amd64.hybrid.iso' completed successfully.
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
