### PR TITLE
telegraf: T4831: fix build on arm64 / remove hardcoded amd64 reference

### DIFF
--- a/packages/telegraf/build.sh
+++ b/packages/telegraf/build.sh
@@ -2,6 +2,8 @@
 CWD=$(pwd)
 set -e
 
+BUILD_ARCH=$(dpkg-architecture -qDEB_TARGET_ARCH)
+
 SRC=telegraf
 if [ ! -d ${SRC} ]; then
     echo "Source directory does not exists, please 'git clone'"
@@ -16,7 +18,7 @@ cp ${PLUGIN_DIR}/inputs/all/all.go ${SRC}/plugins/inputs/all/all.go
 echo "I: Selecting Output plugins"
 cp ${PLUGIN_DIR}/outputs/all/all.go ${SRC}/plugins/outputs/all/all.go
 
-echo "I: Build Debian amd64 package"
+echo "I: Build Debian ${BUILD_ARCH} package"
 cd ${SRC}
 export PATH=/opt/go/bin:$PATH
-LDFLAGS=-w make amd64.deb
+LDFLAGS=-w make "${BUILD_ARCH}.deb"


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://phabricator.vyos.net/T4831

## Component(s) name
telegraf

## Proposed changes
Use the output of `dpkg-architecture -qDEB_TARGET_ARCH` to determine the architecture we are building telegraf for
This will return `amd64` or `arm64` as appropriate

## How to test
Only build tested so far

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
