### PR TITLE
GitHub: sync to author assign workflow changed from current

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,19 +1,3 @@
 ---
-docker-vyos/**:
-  - sever-sever
-  - DmitriyEshenko
-
-vars/**:
-  - c-po
-  - UnicronNL
-
-.github/**:
-  - c-po
-  - dmbaturin
-  - UnicronNL
-
-'**':
-  - c-po
-  - dmbaturin
-  - jestabro
-  - UnicronNL
+"**/*":
+  - team: reviewers

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request review based on files changes and/or groups the author belongs to
-        uses: shufo/auto-assign-reviewer-by-files@v1.1.1
+        uses: shufo/auto-assign-reviewer-by-files@v1.1.4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PR_ACTION_ASSIGN_REVIEWERS }}
           config: .github/reviewers.yml

--- a/data/defaults.json
+++ b/data/defaults.json
@@ -5,7 +5,7 @@
   "debian_distribution": "buster",
   "vyos_mirror": "http://dev.packages.vyos.net/repositories/equuleus",
   "vyos_branch": "equuleus",
-  "kernel_version": "5.4.224",
+  "kernel_version": "5.4.227",
   "kernel_flavor": "amd64-vyos",
   "release_train": "equuleus",
   "additional_repositories": [


### PR DESCRIPTION
* GitHub: sync to author assign workflow changed from current
  Use the vyos/reviewers team instead of individuals.

* Update Kernel