### PR TITLE
container: T578: backport podman from 1.4 development branch (equuleus)

### DIFF
--- a/data/live-build-config/archives/bullseye.pref.chroot
+++ b/data/live-build-config/archives/bullseye.pref.chroot
@@ -6,6 +6,38 @@ Package: ddclient
 Pin: release n=bullseye
 Pin-Priority: 600
 
+Package: podman
+Pin: release n=bullseye
+Pin-Priority: 600
+
+Package: libseccomp2
+Pin: release n=bullseye
+Pin-Priority: 600
+
+Package: conmon
+Pin: release n=bullseye
+Pin-Priority: 600
+
+Package: containernetworking-plugins
+Pin: release n=bullseye
+Pin-Priority: 600
+
+Package: runc
+Pin: release n=bullseye
+Pin-Priority: 600
+
+Package: golang-github-containers-common
+Pin: release n=bullseye
+Pin-Priority: 600
+
+Package: golang-github-containers-image
+Pin: release n=bullseye
+Pin-Priority: 600
+
+Package: skopeo
+Pin: release n=bullseye
+Pin-Priority: 600
+
 Package: squashfs-tools
 Pin: release n=bullseye
 Pin-Priority: -10

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -172,7 +172,7 @@ RUN wget https://salsa.debian.org/jestabro-guest/live-build/commit/63425b3e4f7ad
     patch -p1 < /tmp/63425b3e4f7ad3712ced4c9a3584ef9851c0355a.patch && \
     dch -n "Applying fix for missing archive keys" && \
     dpkg-buildpackage -us -uc && \
-    sudo dpkg -i ../live-build*.deb
+    dpkg -i ../live-build*.deb
 
 #
 # live-build: building in docker fails with mounting /proc | /sys
@@ -188,7 +188,7 @@ RUN wget https://salsa.debian.org/klausenbusk-guest/debootstrap/commit/a9a603b17
     patch -p1 < /tmp/a9a603b17cadbf52cb98cde0843dc9f23a08b0da.patch && \
     dch -n "Applying fix for docker image compile" && \
     dpkg-buildpackage -us -uc && \
-    sudo dpkg -i ../debootstrap*.deb
+    dpkg -i ../debootstrap*.deb
 
 #
 # Install Packer
@@ -360,13 +360,10 @@ RUN if dpkg-architecture -ii386 || dpkg-architecture -iamd64; then \
 
 # Go required for validators and vyos-xe-guest-utilities
 RUN GO_VERSION_INSTALL="1.18.3" ; \
-    if [ "$ARCH" = "arm64v8" ] ; then \
-        wget -O /tmp/go${GO_VERSION_INSTALL}.linux-arm64.tar.gz https://go.dev/dl/go${GO_VERSION_INSTALL}.linux-arm64.tar.gz ; \
-    else \
-        wget -O /tmp/go${GO_VERSION_INSTALL}.linux-amd64.tar.gz https://go.dev/dl/go${GO_VERSION_INSTALL}.linux-amd64.tar.gz ; \
-    fi && \
+    wget -O /tmp/go${GO_VERSION_INSTALL}.linux-$(dpkg-architecture -qDEB_HOST_ARCH).tar.gz https://go.dev/dl/go${GO_VERSION_INSTALL}.linux-$(dpkg-architecture -qDEB_HOST_ARCH).tar.gz ; \
     tar -C /opt -xzf /tmp/go*.tar.gz && \
     rm /tmp/go*.tar.gz
+RUN echo "export PATH=/opt/go/bin:$PATH" >> /etc/bash.bashrc
 
 # Packages needed for ipaddrcheck
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

As container support has matured to a certain degree in 1.4-rolling we can start backporting this feature for VyOS 1.3.3

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T578

## Related PRs
- https://github.com/vyos/vyatta-cfg/pull/53
- https://github.com/vyos/vyatta-cfg-system/pull/192
- https://github.com/vyos/vyos-1x/pull/1731

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
container

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Smoketests

```
set container name unifi environment TZ value 'Europe/Berlin'
set container name unifi image 'jacobalberty/unifi:v7.2'
set container name unifi memory '1024'
set container name unifi network test address '172.29.3.20'
set container name unifi volume config destination '/unifi'
set container name unifi volume config source '/config/unifi'
set container network test prefix '172.29.3.0/24'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
