### PR TITLE
strongSwan: T4551: Added soft lifetime calculation

### DIFF
--- a/packages/strongswan/patches/0005-vici-add-soft-lifetime-calculation-if-hard-lifetime-configured.patch
+++ b/packages/strongswan/patches/0005-vici-add-soft-lifetime-calculation-if-hard-lifetime-configured.patch
@@ -1,0 +1,97 @@
+From a2b1e06f07569e8d3f08a37b68a206164b67fbe3 Mon Sep 17 00:00:00 2001
+From: Tobias Brunner <tobias@strongswan.org>
+Date: Tue, 6 Dec 2022 17:33:20 +0100
+Subject: [PATCH] vici: Base default soft lifetime on hard lifetime if
+ configured
+
+Depending on the configured hard lifetime the default soft lifetime
+might not make sense and could even cause rekeying to get disabled.
+To avoid that, derive the soft lifetime from the hard lifetime so it's
+10% higher than the soft lifetime.
+
+References strongswan/strongswan#1414
+---
+ src/libcharon/plugins/vici/vici_config.c | 46 ++++++++++++++++++++----
+ 1 file changed, 40 insertions(+), 6 deletions(-)
+
+diff --git a/src/libcharon/plugins/vici/vici_config.c b/src/libcharon/plugins/vici/vici_config.c
+index 0c061d4b2d7..a59d799caf6 100644
+--- a/src/libcharon/plugins/vici/vici_config.c
++++ b/src/libcharon/plugins/vici/vici_config.c
+@@ -1981,18 +1981,52 @@ CALLBACK(auth_sn, bool,
+  */
+ static void check_lifetimes(lifetime_cfg_t *lft)
+ {
++	/* if no soft lifetime specified, set a default or base it on the hard lifetime */
++	if (lft->time.rekey == LFT_UNDEFINED)
++	{
++		if (lft->time.life != LFT_UNDEFINED)
++		{
++			lft->time.rekey = lft->time.life / 1.1;
++		}
++		else
++		{
++			lft->time.rekey = LFT_DEFAULT_CHILD_REKEY_TIME;
++		}
++	}
++	if (lft->bytes.rekey == LFT_UNDEFINED)
++	{
++		if (lft->bytes.life != LFT_UNDEFINED)
++		{
++			lft->bytes.rekey = lft->bytes.life / 1.1;
++		}
++		else
++		{
++			lft->bytes.rekey = LFT_DEFAULT_CHILD_REKEY_BYTES;
++		}
++	}
++	if (lft->packets.rekey == LFT_UNDEFINED)
++	{
++		if (lft->packets.life != LFT_UNDEFINED)
++		{
++			lft->packets.rekey = lft->packets.life / 1.1;
++		}
++		else
++		{
++			lft->packets.rekey = LFT_DEFAULT_CHILD_REKEY_PACKETS;
++		}
++	}
+ 	/* if no hard lifetime specified, add one at soft lifetime + 10% */
+ 	if (lft->time.life == LFT_UNDEFINED)
+ 	{
+-		lft->time.life = lft->time.rekey * 110 / 100;
++		lft->time.life = lft->time.rekey * 1.1;
+ 	}
+ 	if (lft->bytes.life == LFT_UNDEFINED)
+ 	{
+-		lft->bytes.life = lft->bytes.rekey * 110 / 100;
++		lft->bytes.life = lft->bytes.rekey * 1.1;
+ 	}
+ 	if (lft->packets.life == LFT_UNDEFINED)
+ 	{
+-		lft->packets.life = lft->packets.rekey * 110 / 100;
++		lft->packets.life = lft->packets.rekey * 1.1;
+ 	}
+ 	/* if no rand time defined, use difference of hard and soft */
+ 	if (lft->time.jitter == LFT_UNDEFINED)
+@@ -2026,17 +2060,17 @@ CALLBACK(children_sn, bool,
+ 			.mode = MODE_TUNNEL,
+ 			.lifetime = {
+ 				.time = {
+-					.rekey = LFT_DEFAULT_CHILD_REKEY_TIME,
++					.rekey = LFT_UNDEFINED,
+ 					.life = LFT_UNDEFINED,
+ 					.jitter = LFT_UNDEFINED,
+ 				},
+ 				.bytes = {
+-					.rekey = LFT_DEFAULT_CHILD_REKEY_BYTES,
++					.rekey = LFT_UNDEFINED,
+ 					.life = LFT_UNDEFINED,
+ 					.jitter = LFT_UNDEFINED,
+ 				},
+ 				.packets = {
+-					.rekey = LFT_DEFAULT_CHILD_REKEY_PACKETS,
++					.rekey = LFT_UNDEFINED,
+ 					.life = LFT_UNDEFINED,
+ 					.jitter = LFT_UNDEFINED,
+ 				},


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Depending on the configured hard lifetime the default soft lifetime might not make sense and could even cause rekeying to get disabled. To avoid that, derive the soft lifetime from the hard lifetime so it's 10% higher than the soft lifetime.
https://github.com/strongswan/strongswan/commit/a2b1e06f07569e8d3f08a37b68a206164b67fbe3

## Types of changes
<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply. -->
<!--- NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking the box, please use [x] --> 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
https://phabricator.vyos.net/T4551

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
strongSwan

## Proposed changes
<!--- Describe your changes in detail -->
Depending on the configured hard lifetime the default soft lifetime might not make sense and could even cause rekeying to get disabled. To avoid that, derive the soft lifetime from the hard lifetime so it's 10% higher than the soft lifetime.
https://github.com/strongswan/strongswan/commit/a2b1e06f07569e8d3f08a37b68a206164b67fbe3
This fix was implemented in Strongswan 5.9.9

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
For Example:
If we use lifetime in esp-group eq 28800
We receive rekeying.
This situation is described in https://phabricator.vyos.net/T4551 with configs and show commands
Why it is happening?
1. If only lifetime is configured in strongswan then rekey_time use default value 3600.
2. Then random_time is calculated. random_time = lifetime-rekey_time
3. Then random value is calculated. random_value = rnd(0,random_time)
4. Then real rekey value is calculated. rekey = rekey_time - random_value.

If we use lifetime eq 28800 , random_value can be between 0 and  25200.
So rekey can be a negative value.

After this patch lifetime always will be 10% higher than rekey_time.
So if we use configuration from  https://phabricator.vyos.net/T4551,
we will receive stable CHILD_SA

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
