### PR TITLE
T4966: Resolve resource deadlock for udev iface shuffle

### DIFF
--- a/data/live-build-config/hooks/live/82-cleanup-udev-rules.chroot
+++ b/data/live-build-config/hooks/live/82-cleanup-udev-rules.chroot
@@ -5,3 +5,4 @@
 # Need to delete this rule to prevent overhead on interface creation stage
 
 rm /lib/systemd/network/99-default.link
+rm /etc/udev/rules.d/62-temporary-interface-rename.rules


### PR DESCRIPTION
UDEV contains a default rule triggered early-on which renames all NICs by their index to eX, systemd-udevd subsequently renames the eX interface to ethX. Systemd-udevd can fail to rename the iface if it still has resource locks from the prior renaming which then fails to apply all manner of configurations resulting in a booted zombie which cannot handle L3 traffic.

Fix the concern by removing 62-temporary-interface-rename.rules from /etc/udev/rules.d during the cleanup hook executed in data/live-build-config/hooks/live/82-cleanup-udev-rules.chroot.

Testing:
  Boot-tested in OpenStack under identical infrastructure-as-code
states. Verified DHCP-assigned routes, execution of cloud-init, and configuration stanzas injected through cloud-init applied to the FW and system.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4966

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
UDEV
## Proposed changes
<!--- Describe your changes in detail -->
Do not rename interfaces to `eX` at early-init as they can "get stuck" that way, preventing configuration of their `ethX` names - the appropriate way to _retain_ the `ethX` naming scheme is via the `net.ifnames=0 biosdevname=0` kernel parameters which are already upstream in `data/live-build-config/includes.chroot/opt/vyatta/etc/grub/default-union-grub-entry`
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
