### PR TITLE
frr: T4737: Fixed connected to BGP routes redistribution

### DIFF
--- a/packages/frr/patches/0002-zebra-Allow-one-connected-route-per-network-mask-on-.patch
+++ b/packages/frr/patches/0002-zebra-Allow-one-connected-route-per-network-mask-on-.patch
@@ -1,0 +1,94 @@
+From 30eee3c450937a9bc2fd02527cff266f85a818ed Mon Sep 17 00:00:00 2001
+From: Taras Pudiak <taras@vyos.io>
+Date: Tue, 31 Jan 2023 18:18:44 +0200
+Subject: [PATCH] zebra: Allow one connected route per network mask on a
+ interface
+
+Backport of 92980561382fc04380414a6e2f6ca6746c2fe5e9 from FRR repository
+---
+ zebra/connected.c | 48 +++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/zebra/connected.c b/zebra/connected.c
+index 8c4ba163b..bc5941657 100644
+--- a/zebra/connected.c
++++ b/zebra/connected.c
+@@ -207,6 +207,9 @@ void connected_up(struct interface *ifp, struct connected *ifc)
+ 	};
+ 	struct zebra_vrf *zvrf;
+ 	uint32_t metric;
++	uint32_t count = 0;
++	struct listnode *cnode;
++	struct connected *c;
+ 
+ 	zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+ 	if (!zvrf) {
+@@ -251,6 +254,28 @@ void connected_up(struct interface *ifp, struct connected *ifc)
+ 
+ 	metric = (ifc->metric < (uint32_t)METRIC_MAX) ?
+ 				ifc->metric : ifp->metric;
++
++	/*
++	 * It's possible to add the same network and mask
++	 * to an interface over and over.  This would
++	 * result in an equivalent number of connected
++	 * routes.  Just add one connected route in
++	 * for all the addresses on an interface that
++	 * resolve to the same network and mask
++	 */
++	for (ALL_LIST_ELEMENTS_RO(ifp->connected, cnode, c)) {
++		struct prefix cp;
++
++		PREFIX_COPY(&cp, CONNECTED_PREFIX(c));
++		apply_mask(&cp);
++
++		if (prefix_same(&cp, &p))
++			count++;
++
++		if (count >= 2)
++			return;
++	}
++
+ 	rib_add(afi, SAFI_UNICAST, zvrf->vrf->vrf_id, ZEBRA_ROUTE_CONNECT,
+ 		0, 0, &p, NULL, &nh, 0, zvrf->table_id, metric, 0, 0, 0);
+ 
+@@ -350,6 +375,9 @@ void connected_down(struct interface *ifp, struct connected *ifc)
+ 		.vrf_id = ifp->vrf_id,
+ 	};
+ 	struct zebra_vrf *zvrf;
++	uint32_t count = 0;
++	struct listnode *cnode;
++	struct connected *c;
+ 
+ 	zvrf = zebra_vrf_lookup_by_id(ifp->vrf_id);
+ 	if (!zvrf) {
+@@ -388,6 +416,26 @@ void connected_down(struct interface *ifp, struct connected *ifc)
+ 		break;
+ 	}
+ 
++	/*
++	 * It's possible to have X number of addresses
++	 * on a interface that all resolve to the same
++	 * network and mask.  Find them and just
++	 * allow the deletion when are removing the last
++	 * one.
++	 */
++	for (ALL_LIST_ELEMENTS_RO(ifp->connected, cnode, c)) {
++		struct prefix cp;
++
++		PREFIX_COPY(&cp, CONNECTED_PREFIX(c));
++		apply_mask(&cp);
++
++		if (prefix_same(&p, &cp))
++			count++;
++
++		if (count >= 2)
++			return;
++	}
++
+ 	/*
+ 	 * Same logic as for connected_up(): push the changes into the
+ 	 * head.
+-- 
+2.37.2
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed connected to BGP routes redistribution

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4737

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
FRR

## Proposed changes
<!--- Describe your changes in detail -->
This is backported commit for FRR 7.5.1 https://github.com/FRRouting/frr/commit/92980561382fc04380414a6e2f6ca6746c2fe5e9

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
1. Configure VyOS via CLI:
    ```
    set protocols bgp 65000 address-family ipv4-unicast redistribute connected
    ```
2. Add addresses to an interface:
    ```
    sudo ip a add 192.168.123.1/24 dev eth0 & sudo ip a add 192.168.123.2/24 dev eth0
    ```
3. Check BGP routing table:
    Without the patch:
    ```
    vyos@vyos:~$ show ip bgp 
    No BGP prefixes displayed, 0 exist
    ```
    With the patch:
    ```
    vyos@vyos:~$ show ip bgp 
    BGP table version is 1, local router ID is 192.168.123.2, vrf id 0
    Default local pref 100, local AS 65000
    Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
                   i internal, r RIB-failure, S Stale, R Removed
    Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
    Origin codes:  i - IGP, e - EGP, ? - incomplete

       Network          Next Hop            Metric LocPrf Weight Path
    *> 192.168.123.0/24 0.0.0.0                  0         32768 ?

    Displayed  1 routes and 1 total paths
    ```    

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
