### PR TITLE
T4966: Delay UDEV execution, avoid rename deadlock

### DIFF
--- a/data/live-build-config/includes.chroot/opt/vyatta/etc/grub/default-union-grub-entry
+++ b/data/live-build-config/includes.chroot/opt/vyatta/etc/grub/default-union-grub-entry
@@ -1,20 +1,20 @@
 menuentry "VyOS  (KVM console)" {
-        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/ console=ttyS0,115200 console=tty0
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 udev.exec_delay=3 vyos-union=/boot/ console=ttyS0,115200 console=tty0
         initrd /boot//initrd.img
 }
 
 menuentry "VyOS  (Serial console)" {
-        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/ console=tty0 console=ttyS0,115200
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 udev.exec_delay=3 vyos-union=/boot/ console=tty0 console=ttyS0,115200
         initrd /boot//initrd.img
 }
 
 menuentry "Lost password change  (KVM console)" {
-        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/ console=ttyS0,115200 console=tty0 init=/opt/vyatta/sbin/standalone_root_pw_reset
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 udev.exec_delay=3 vyos-union=/boot/ console=ttyS0,115200 console=tty0 init=/opt/vyatta/sbin/standalone_root_pw_reset
         initrd /boot//initrd.img
 }
 
 menuentry "Lost password change  (Serial console)" {
-        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/ console=tty0 console=ttyS0,115200 init=/opt/vyatta/sbin/standalone_root_pw_reset
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 udev.exec_delay=3 vyos-union=/boot/ console=tty0 console=ttyS0,115200 init=/opt/vyatta/sbin/standalone_root_pw_reset
         initrd /boot//initrd.img
 }
 


### PR DESCRIPTION
UDEV will rename interfaces from whatever the kernel called them to eX before converting them to ethX during init. In current VyOS, the second renaming operation can run into a lock on the adapter preventing altering its name. As a result, the adapter will remain in the eX configuration, preventing proper execution of subsequent scripts and configuration stanzas.

The initial renaming step has to remain as it is needed to work around other issues, which leaves the somewhat hacky approach of delaying the second renaming step slightly in an effort to let the device lock holders settle, releasing it for rename to ethX. This is accomplished by a kernel commandline paramter (3s), which can be tweaked to reduce impact or wait longer as needed on different devices - udev.exec_delay=3

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/Txxxx

## Component(s) name
UDEV

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
