### PR TITLE
Docker: T4970: pin OCaml pcre package to avoid JIT support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -126,8 +126,11 @@ RUN curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh \
     sed -i 's/read BINDIR/BINDIR=""/' /tmp/opam_install.sh && sh /tmp/opam_install.sh && \
     opam init --root=/opt/opam --comp=4.12.0 --disable-sandboxing
 
+RUN eval $(opam env --root=/opt/opam --set-root) && \
+    opam pin add pcre https://github.com/mmottl/pcre-ocaml.git#0c4ca03a -y
+
 RUN eval $(opam env --root=/opt/opam --set-root) && opam install -y \
-      pcre re
+      re
 
 RUN eval $(opam env --root=/opt/opam --set-root) && opam install -y \
       num \


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Backport for equuleus:
cherry picked from commit c26f9f9309d3dad0fb344a4691a97a00d39a4b28

Pin pcre-ocaml package to commit before the addition of support of JIT-compilation of patterns, which adds a rwx mmap'd region.

Note that after merging, one will need to rebuild vyos-utils.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe):
        security concern

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T4970

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

On equuleus:
`strace /usr/libexec/vyos/validators/numeric`
will reveal:

`mmap(NULL, 65536, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)`

Pinning the package avoids it.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
