### PR TITLE
debian: T5003: Revert hostap removal - AES-256 not supported in Debian.

### DIFF
--- a/packages/hostap/.gitignore
+++ b/packages/hostap/.gitignore
@@ -1,0 +1,2 @@
+hostap/
+wpa/

--- a/packages/hostap/Jenkinsfile
+++ b/packages/hostap/Jenkinsfile
@@ -1,0 +1,34 @@
+// Copyright (C) 2022 VyOS maintainers and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// in order to easy exprort images built to "external" world
+// it under the terms of the GNU General Public License version 2 or later as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+@NonCPS
+
+// Using a version specifier library, use 'current' branch. The underscore (_)
+// is not a typo! You need this underscore if the line immediately after the
+// @Library annotation is not an import statement!
+@Library('vyos-build@current')_
+
+def pkgList = [
+    ['name': 'wpa',
+     'scmCommit': 'debian/2%2.10-7',
+     'scmUrl': 'https://salsa.debian.org/debian/wpa',
+     'buildCmd': '/bin/true'],
+    ['name': 'hostap',
+     'scmCommit': 'b704dc72ef824dfdd96674b90179b274d1d38105',
+     'scmUrl': 'git://w1.fi/srv/git/hostap.git',
+     'buildCmd': 'cd ..; ./build.sh'],
+]
+
+// Start package build using library function from https://github.com/vyos/vyos-build
+buildPackage('hostap', pkgList, null, true, "**/packages/hostap/*")

--- a/packages/hostap/build.sh
+++ b/packages/hostap/build.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+CWD=$(pwd)
+set -e
+
+SRC=hostap
+SRC_DEB=wpa
+
+if [ ! -d ${SRC} ]; then
+    echo "${SRC} directory does not exists, please 'git clone'"
+    exit 1
+fi
+if [ ! -d ${SRC_DEB} ]; then
+    echo "${SRC_DEB} directory does not exists, please 'git clone'"
+    exit 1
+fi
+
+echo "I: Copy Debian build instructions"
+cp -a ${SRC_DEB}/debian ${SRC}
+# Preserve Debian's default of allowing TLSv1.0 for compatibility
+find ${SRC}/debian/patches -mindepth 1 ! -name allow-tlsv1.patch -delete
+echo 'allow-tlsv1.patch' > ${SRC}/debian/patches/series
+
+# Build Debian package
+cd ${SRC}
+echo "I: Create new Debian Package version"
+version="$(git describe --tags | tr _ .)"
+dch -v ${version:7} "New version to support AES-GCM-256 for MACsec" -b
+
+echo "I: Build Debian hostap Package"
+dpkg-buildpackage -us -uc -tc -b -Ppkg.wpa.nogui


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Reverts removal of hostap/wpa_supplicant package. Debian Bookworm does not contain support for AES-256.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5003

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
debian, macsec

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
