### PR TITLE
T3318: T5003: Docker and Kernel updates for equuleus

### DIFF
--- a/data/defaults.json
+++ b/data/defaults.json
@@ -5,7 +5,7 @@
   "debian_distribution": "buster",
   "vyos_mirror": "http://dev.packages.vyos.net/repositories/equuleus",
   "vyos_branch": "equuleus",
-  "kernel_version": "5.4.229",
+  "kernel_version": "5.4.233",
   "kernel_flavor": "amd64-vyos",
   "release_train": "equuleus",
   "additional_repositories": [

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -609,8 +609,8 @@ RUN gem install public_suffix -v 4.0.7
 RUN gem install --no-document fpm
 
 # Allow password-less 'sudo' for all users in group 'sudo'
-RUN sed "s/^%sudo.*/%sudo\tALL=(ALL) NOPASSWD:ALL/g" -i /etc/sudoers && \
-    chmod a+s /usr/sbin/useradd /usr/sbin/groupadd /usr/sbin/gosu /usr/sbin/usermod
+RUN echo -e "vyos_bld\tALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/vyos_bld && \
+    chmod a+s /usr/sbin/useradd /usr/sbin/groupadd
 
 # Ensure sure all users have access to our OCAM and Go installation
 RUN echo "$(opam env --root=/opt/opam --set-root)" >> /etc/skel/.bashrc && \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,9 +24,12 @@ if ! grep -q $NEW_GID /etc/group; then
 fi
 
 useradd --shell /bin/bash --uid $NEW_UID --gid $NEW_GID --non-unique --create-home $USER_NAME
-usermod --append --groups sudo $USER_NAME
 sudo chown $NEW_UID:$NEW_GID /home/$USER_NAME
 export HOME=/home/$USER_NAME
 
+if [ "$(id -u)" == "0" ]; then
+    exec gosu $USER_NAME "$@"
+fi
+
 # Execute process
-exec /usr/sbin/gosu $USER_NAME "$@"
+exec "$@"


### PR DESCRIPTION
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

The newer Docker versions seem to be a bit more picky when using tools like goso. The container will no longer start if the  gosu binary has the setuid root bit set.

This change adjusts the container to continue working on recent Docker versions.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5003 (re-used same task-id as the change in current was required with the Debian update)
* https://vyos.dev/T3318

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* Kernel
* Docker build environemnt

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
