### PR TITLE
T5122: Move archive-areas to defaults.toml to support non-free-firmwa…

### DIFF
--- a/data/defaults.toml
+++ b/data/defaults.toml
@@ -7,6 +7,8 @@ debian_distribution = "bookworm"
 debian_mirror = "http://deb.debian.org/debian"
 debian_security_mirror = "http://deb.debian.org/debian-security"
 
+debian_archive_areas = "main contrib non-free"
+
 vyos_mirror = "http://dev.packages.vyos.net/repositories/current"
 
 vyos_branch = "current"

--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -439,7 +439,7 @@ if __name__ == "__main__":
             --mirror-chroot-security {{debian_security_mirror}} \
             --mirror-binary {{debian_mirror}} \
             --mirror-binary-security {{debian_security_mirror}} \
-            --archive-areas "main contrib non-free" \
+            --archive-areas {{debian_archive_areas}} \
             --firmware-chroot false \
             --firmware-binary false \
             --updates true \


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5122

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build script

## Proposed changes
<!--- Describe your changes in detail -->
Move "archive-areas" to defaults.toml to support "non-free-firmware" repository



## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
