### PR TITLE
T5120: Override all debian mirror server name in url

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -146,7 +146,8 @@ if __name__ == "__main__":
        'vyos-mirror': ('VyOS package mirror', lambda: build_defaults["vyos_mirror"], None),
        'build-type': ('Build type, release or development', lambda: 'development', lambda x: x in ['release', 'development']),
        'version': ('Version number (release builds only)', None, None),
-       'build-comment': ('Optional build comment', lambda: '', None)
+       'build-comment': ('Optional build comment', lambda: '', None),
+       'debian-mirror-server': ('Replace (deb|security).debian.org to debian-mirror-server in all debian mirror settings (e.g. mirrors.bit.edu.cn)', None, None)
     }
 
     # Create the option parser
@@ -238,6 +239,22 @@ if __name__ == "__main__":
         arch = build_config["architecture"]
         if arch in build_config["architectures"]:
             build_config["packages"] += build_config["architectures"][arch]["packages"]
+
+    # Replace (deb|security).debian.org to debian_mirror_server if it's set
+    if build_config['debian_mirror_server'] is not None:
+        build_config['debian_mirror'] = re.sub('(deb|security).debian.org', build_config['debian_mirror_server'], build_config['debian_mirror'])
+        build_config['debian_security_mirror'] = re.sub('(deb|security).debian.org', build_config['debian_mirror_server'], build_config['debian_security_mirror'])
+        build_config['pbuilder_debian_mirror'] = re.sub('(deb|security).debian.org', build_config['debian_mirror_server'], build_config['pbuilder_debian_mirror'])
+
+        # overwrite data/live-build-config/archives/buster.list.chroot
+        with open('data/live-build-config/archives/buster.list.chroot', 'w+') as fp:
+            buster_repo = """
+deb http://deb.debian.org/debian/ buster main non-free
+deb http://deb.debian.org/debian/ buster-updates main non-free
+deb http://security.debian.org/debian-security buster/updates main non-free
+"""
+            fp.write(re.sub('(deb|security).debian.org', build_config['debian_mirror_server'], buster_repo))
+
 
     ## Dump the complete config if the user enabled debug mode
     if debug:

--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -255,6 +255,18 @@ deb http://security.debian.org/debian-security buster/updates main non-free
 """
             fp.write(re.sub('(deb|security).debian.org', build_config['debian_mirror_server'], buster_repo))
 
+        debian_code_names = ["trixie"]
+
+        for code_name in debian_code_names:
+            # overwrite data/live-build-config/archives/{{CODE_NAME}}.list.chroot
+            if os.path.exists(f'data/live-build-config/archives/{code_name}.list.chroot'):
+                with open(f'data/live-build-config/archives/{code_name}.list.chroot', 'w+') as fp:
+                    debian_repo = f"""
+deb http://deb.debian.org/debian/ {code_name} main non-free
+deb http://deb.debian.org/debian/ {code_name}-updates main non-free
+deb http://security.debian.org/debian-security {code_name}-security main non-free
+"""
+                    fp.write(re.sub('(deb|security).debian.org', build_config['debian_mirror_server'], debian_repo))
 
     ## Dump the complete config if the user enabled debug mode
     if debug:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Override all debian mirror server name in url, to make all debian mirrors use the overrided server.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5120

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build script

## Proposed changes
<!--- Describe your changes in detail -->

In VyOS 1.4 build system, debian mirrors can be set from:

`--debian-mirror`, `--debian-security-mirror`, `--pbuilder-debian-mirror`
`defaults.toml` and build flavors
But there is still a buster.list.chroot with hard coded deb.debian.org and security.debian.org.

My solution is :

* Accept `--debian-mirror-server`
* Replace debian mirror urls `(deb|security).debian.org` to `--debian-mirror-server` if set
* Overwrite buster.list.chroot if `--debian-mirror-server` is set

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
