### PR TITLE
T5121: Fix, make architecture and build-type loaded from build flavor and cli arguments

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -145,8 +145,7 @@ if __name__ == "__main__":
        'vyos-mirror': ('VyOS package mirror', None, None),
        'build-type': ('Build type, release or development', None, lambda x: x in ['release', 'development']),
        'version': ('Version number (release builds only)', None, None),
-       'build-comment': ('Optional build comment', lambda: '', None),
-       'debian-mirror-server': ('Replace (deb|security).debian.org to debian-mirror-server in all debian mirror settings (e.g. mirrors.bit.edu.cn)', None, None)
+       'build-comment': ('Optional build comment', lambda: '', None)
     }
 
     # Create the option parser
@@ -211,22 +210,6 @@ if __name__ == "__main__":
 
     if pre_build_config['pbuilder_debian_mirror'] is None:
         args['pbuilder_debian_mirror'] = pre_build_config['pbuilder_debian_mirror'] = pre_build_config['debian_mirror']
-
-    # Replace (deb|security).debian.org to debian_mirror_server if it's set
-    if args['debian_mirror_server'] is not None:
-        args['debian_mirror'] = re.sub('(deb|security).debian.org', args['debian_mirror_server'], pre_build_config['debian_mirror'])
-        args['debian_security_mirror'] = re.sub('(deb|security).debian.org', args['debian_mirror_server'], pre_build_config['debian_security_mirror'])
-        args['pbuilder_debian_mirror'] = re.sub('(deb|security).debian.org', args['debian_mirror_server'], pre_build_config['pbuilder_debian_mirror'])
-
-        # overwrite data/live-build-config/archives/buster.list.chroot
-        with open('data/live-build-config/archives/buster.list.chroot', 'w+') as fp:
-            print(fp.read())
-            buster_repo = """
-deb http://deb.debian.org/debian/ buster main non-free
-deb http://deb.debian.org/debian/ buster-updates main non-free
-deb http://security.debian.org/debian-security buster/updates main non-free
-"""
-            fp.write(re.sub('(deb|security).debian.org', args['debian_mirror_server'], buster_repo))
 
     # Version can only be set for release builds,
     # for dev builds it hardly makes any sense

--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -57,7 +57,7 @@ def get_validator(optdict, name):
     except KeyError:
         return None
 
-def merge_dicts(source, destination):
+def merge_dicts(source, destination, skip_none=False):
     """ Merge two dictionaries and return a new dict which has the merged key/value pairs.
     Merging logic is as follows:
       Sub-dicts are merged.
@@ -74,7 +74,7 @@ def merge_dicts(source, destination):
             tmp[key] = merge_dicts(source[key], tmp[key])
         elif isinstance(source[key], list):
             tmp[key] = source[key] + tmp[key]
-        else:
+        elif not skip_none or source[key] is not None:
             tmp[key] = source[key]
 
     return tmp
@@ -137,16 +137,16 @@ if __name__ == "__main__":
     # Options dict format:
     # '$option_name_without_leading_dashes': { ('$help_string', $default_value_generator_thunk, $value_checker_thunk) }
     options = {
-       'architecture': ('Image target architecture (amd64 or arm64)',
-          lambda: build_defaults['architecture'], lambda x: x in ['amd64', 'arm64']),
+       'architecture': ('Image target architecture (amd64 or arm64)', None, lambda x: x in ['amd64', 'arm64', None]),
        'build-by': ('Builder identifier (e.g. jrandomhacker@example.net)', get_default_build_by, None),
-       'debian-mirror': ('Debian repository mirror', lambda: build_defaults['debian_mirror'], None),
-       'debian-security-mirror': ('Debian security updates mirror', lambda: build_defaults['debian_security_mirror'], None),
-       'pbuilder-debian-mirror': ('Debian repository mirror for pbuilder env bootstrap', lambda: build_defaults['debian_mirror'], None),
-       'vyos-mirror': ('VyOS package mirror', lambda: build_defaults["vyos_mirror"], None),
-       'build-type': ('Build type, release or development', lambda: 'development', lambda x: x in ['release', 'development']),
+       'debian-mirror': ('Debian repository mirror', None, None),
+       'debian-security-mirror': ('Debian security updates mirror', None, None),
+       'pbuilder-debian-mirror': ('Debian repository mirror for pbuilder env bootstrap', None, None),
+       'vyos-mirror': ('VyOS package mirror', None, None),
+       'build-type': ('Build type, release or development', None, lambda x: x in ['release', 'development']),
        'version': ('Version number (release builds only)', None, None),
-       'build-comment': ('Optional build comment', lambda: '', None)
+       'build-comment': ('Optional build comment', lambda: '', None),
+       'debian-mirror-server': ('Replace (deb|security).debian.org to debian-mirror-server in all debian mirror settings (e.g. mirrors.bit.edu.cn)', None, None)
     }
 
     # Create the option parser
@@ -191,16 +191,46 @@ if __name__ == "__main__":
         print("\n".join(build_flavors))
         sys.exit(1)
 
+    ## Try to get correct architecture and build type from build flavor and CLI arguments
+    pre_build_config = merge_dicts({}, build_defaults)
+
+    flavor_config = {}
+    with open(make_toml_path(defaults.BUILD_FLAVORS_DIR, args["build_flavor"]), 'r') as f:
+        flavor_config = toml.load(f)
+        pre_build_config = merge_dicts(flavor_config, pre_build_config)
+
+    ## Combine configs args > flavor > defaults
+    pre_build_config = merge_dicts(args, pre_build_config, skip_none=True)
+
     # Some fixup for mirror settings.
     # The idea is: if --debian-mirror is specified but --pbuilder-debian-mirror is not,
     # use the --debian-mirror value for both lb and pbuilder bootstrap
-    if (args['debian_mirror'] != build_defaults["debian_mirror"]) and \
-       (args['pbuilder_debian_mirror'] == build_defaults["debian_mirror"]):
-        args['pbuilder_debian_mirror'] = args['debian_mirror']
+    if pre_build_config['debian_mirror'] is None or pre_build_config['debian_security_mirror'] is None:
+        print("debian_mirror and debian_security_mirror cannot be empty")
+        sys.exit(1)
+
+    if pre_build_config['pbuilder_debian_mirror'] is None:
+        args['pbuilder_debian_mirror'] = pre_build_config['pbuilder_debian_mirror'] = pre_build_config['debian_mirror']
+
+    # Replace (deb|security).debian.org to debian_mirror_server if it's set
+    if args['debian_mirror_server'] is not None:
+        args['debian_mirror'] = re.sub('(deb|security).debian.org', args['debian_mirror_server'], pre_build_config['debian_mirror'])
+        args['debian_security_mirror'] = re.sub('(deb|security).debian.org', args['debian_mirror_server'], pre_build_config['debian_security_mirror'])
+        args['pbuilder_debian_mirror'] = re.sub('(deb|security).debian.org', args['debian_mirror_server'], pre_build_config['pbuilder_debian_mirror'])
+
+        # overwrite data/live-build-config/archives/buster.list.chroot
+        with open('data/live-build-config/archives/buster.list.chroot', 'w+') as fp:
+            print(fp.read())
+            buster_repo = """
+deb http://deb.debian.org/debian/ buster main non-free
+deb http://deb.debian.org/debian/ buster-updates main non-free
+deb http://security.debian.org/debian-security buster/updates main non-free
+"""
+            fp.write(re.sub('(deb|security).debian.org', args['debian_mirror_server'], buster_repo))
 
     # Version can only be set for release builds,
     # for dev builds it hardly makes any sense
-    if args['build_type'] == 'development':
+    if pre_build_config['build_type'] == 'development':
         if args['version'] is not None:
             print("Version can only be set for release builds")
             print("Use --build-type=release option if you want to set version number")
@@ -211,20 +241,20 @@ if __name__ == "__main__":
     args['pbuilder_config'] = os.path.join(defaults.BUILD_DIR, defaults.PBUILDER_CONFIG)
 
     ## Combine the arguments with non-configurable defaults
-    build_config = merge_dicts(args, build_defaults)
+    build_config = merge_dicts({}, build_defaults)
 
-    ## Load the flavor file and mix-ins
-    with open(make_toml_path(defaults.BUILD_TYPES_DIR, build_config["build_type"]), 'r') as f:
+    ## Load correct mix-ins
+    with open(make_toml_path(defaults.BUILD_TYPES_DIR, pre_build_config["build_type"]), 'r') as f:
         build_type_config = toml.load(f)
         build_config = merge_dicts(build_type_config, build_config)
 
-    with open(make_toml_path(defaults.BUILD_ARCHES_DIR, build_config["architecture"]), 'r') as f:
+    with open(make_toml_path(defaults.BUILD_ARCHES_DIR, pre_build_config["architecture"]), 'r') as f:
         build_arch_config = toml.load(f)
         build_config = merge_dicts(build_arch_config, build_config)
 
-    with open(make_toml_path(defaults.BUILD_FLAVORS_DIR, build_config["build_flavor"]), 'r') as f:
-        flavor_config = toml.load(f)
-        build_config = merge_dicts(flavor_config, build_config)
+    ## Override with flavor and then CLI arguments
+    build_config = merge_dicts(flavor_config, build_config)
+    build_config = merge_dicts(args, build_config, skip_none=True)
 
     ## Rename and merge some fields for simplicity
     ## E.g. --custom-packages is for the user, but internally
@@ -495,3 +525,4 @@ Pin-Priority: 600
     # Copy the image
     shutil.copy("live-image-{0}.hybrid.iso".format(build_config["architecture"]),
       "vyos-{0}-{1}.iso".format(version_data["version"], build_config["architecture"]))
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Load correct architecture & build-type toml file based on arguments from build defaults, build flavor, and CLI arguments.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5121

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build script

## Proposed changes
<!--- Describe your changes in detail -->

Load correct architecture & build-type toml file based on arguments from build defaults, build flavor, and CLI arguments.

Changes:
1. Add skip_none=False to merge_dicts, if it's True, None value in source will be ignored
2. Remove all default values from options object
3. Add pre_build_config = build_defaults + flavor_config + args (skip_none=True for args)
4. Fix variables check
5. New build_config = build_defaults + build_type_config + build_arch_config + flavor_config + args (skip_none=True for args)

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
