### PR TITLE
T5142: systemd-journald-audit must not show logs from auditd

### DIFF
--- a/data/live-build-config/hooks/live/18-enable-disable_services.chroot
+++ b/data/live-build-config/hooks/live/18-enable-disable_services.chroot
@@ -71,3 +71,6 @@ systemctl enable ssh-session-cleanup.service
 systemctl enable vyos-hostsd.service
 systemctl enable acpid.service
 systemctl enable vyos-configd.service
+
+echo I: Masking services
+systemctl mask systemd-journald-audit.socket


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
auditd logs must no be displayed for journalctl
mask it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Mask `systemd-journald-audit.socket`

## Related PR
* https://github.com/vyos/vyos-1x/pull/1938

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5142
* https://vyos.dev/T4712

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
log
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r14:~$ show log audit | tail -n 2
type=USER_END msg=audit(1680605966.407:955): pid=4150 uid=1003 auid=1003 ses=1 msg='op=PAM:session_close grantors=pam_limits,pam_permit,pam_mkhomedir,pam_unix acct="root" exe="/usr/bin/sudo" hostname=? addr=? terminal=/dev/pts/0 res=success'UID="vyos" AUID="vyos"
type=CRED_DISP msg=audit(1680605966.407:956): pid=4150 uid=1003 auid=1003 ses=1 msg='op=PAM:setcred grantors=pam_permit acct="root" exe="/usr/bin/sudo" hostname=? addr=? terminal=/dev/pts/0 res=success'UID="vyos" AUID="vyos"
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ sudo journalctl --no-hostname --boot _TRANSPORT=audit --no-pager
-- No entries --
vyos@r14:~$ 
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
