### PR TITLE
T5151: hostap: Reintroduce Debian's allow-legacy-renegotiation.patch

### DIFF
--- a/packages/hostap/Jenkinsfile
+++ b/packages/hostap/Jenkinsfile
@@ -21,7 +21,7 @@
 
 def pkgList = [
     ['name': 'wpa',
-     'scmCommit': 'debian/2%2.10-10',
+     'scmCommit': 'debian/2%2.10-12',
      'scmUrl': 'https://salsa.debian.org/debian/wpa',
      'buildCmd': '/bin/true'],
     ['name': 'hostap',

--- a/packages/hostap/build.sh
+++ b/packages/hostap/build.sh
@@ -16,9 +16,12 @@ fi
 
 echo "I: Copy Debian build instructions"
 cp -a ${SRC_DEB}/debian ${SRC}
-# Preserve Debian's default of allowing TLSv1.0 for compatibility
-find ${SRC}/debian/patches -mindepth 1 ! -name allow-tlsv1.patch -delete
-echo 'allow-tlsv1.patch' > ${SRC}/debian/patches/series
+# Preserve Debian's default of allowing TLSv1.0 and legacy renegotiation for
+# compatibility with networks that use legacy crypto
+cat > ${SRC}/debian/patches/series << EOF
+allow-tlsv1.patch
+allow-legacy-renegotiation.patch
+EOF
 
 # Build Debian package
 cd ${SRC}


### PR DESCRIPTION
## Change Summary

The Debian 12 upgrade in T5003 caused a regression for connecting to legacy networks that only support TLSv1.0/1.1 for EAP-TLS. This commit fixes one part of the issue by adding Debian's patch for allowing legacy renegotiation (`SSL_OP_LEGACY_SERVER_CONNECT` flag). The flag used to be allowed by default, but that changed with the openssl 3.0 upgrade in Debian 12.

(This commit also updates `build.sh` to just overwrite `debian/patches/series` and not delete patch files since dpkg-buildpackage/quilt never applies unlisted patches.)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T5151

## Component(s) name

wpa_supplicant

## Proposed changes

(Mentioned above)

## How to test

I've tested this personally with my ISP, but I don't know how to set up a legacy auth server to test this in other environments.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
