### PR TITLE
T5151: hostap: Remove ConditionFileNotEmpty from Debian's hostapd systemd units

### DIFF
--- a/packages/hostap/build.sh
+++ b/packages/hostap/build.sh
@@ -23,6 +23,11 @@ allow-tlsv1.patch
 allow-legacy-renegotiation.patch
 EOF
 
+# Don't block hostapd service from starting if the config path doesn't match
+# Debian's default. This reverse the following change from Debian:
+# https://salsa.debian.org/debian/wpa/-/commit/d204ceb5a2dc33db888eb55b5fee542a1005e69c
+sed -i '/ConditionFileNotEmpty/d' ${SRC}/debian/hostapd{,@}.service
+
 # Build Debian package
 cd ${SRC}
 


### PR DESCRIPTION
## Change Summary

In commit c260174c5bfcdf7cc3bd6db0f2bd51cf7b1f8648 ("T5151: hostap: Reintroduce Debian's allow-legacy-renegotiation.patch"), debian's packaging was updated from `debian/2%2.10-10` to `debian/2%2.10-12`, which introduced a `ConditionFileNotEmpty=/etc/hostapd/<...>` directive in the hostapd systemd units. This would cause hostapd to never start because vyos uses `/run/hostapd/<...>` paths. This commit undoes Debian's change in VyOS' custom hostap package.

https://salsa.debian.org/debian/wpa/-/commit/d204ceb5a2dc33db888eb55b5fee542a1005e69c

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

https://vyos.dev/T5151

## Component(s) name

hostap

## Proposed changes

(Included above)

## How to test

Tested with `test_interfaces_wireless.py`, which now passes.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
