### PR TITLE
ntp: T5170: Relocate NTP config path from 'system' to 'service'

### DIFF
--- a/data/live-build-config/includes.chroot/opt/vyatta/etc/config.boot.default
+++ b/data/live-build-config/includes.chroot/opt/vyatta/etc/config.boot.default
@@ -18,11 +18,6 @@ system {
             }
         }
     }
-    ntp {
-        server "time1.vyos.net"
-        server "time2.vyos.net"
-        server "time3.vyos.net"
-    }
     console {
         device ttyS0 {
             speed 115200
@@ -35,5 +30,16 @@ system {
 
 interfaces {
     loopback lo {
+    }
+}
+
+service {
+    ntp {
+        server time1.vyos.net {
+        }
+        server time2.vyos.net {
+        }
+        server time3.vyos.net {
+        }
     }
 }


### PR DESCRIPTION
The ntp config path has moved from 'system ntp' to 'service ntp' and server nodes are tag nodes instead of leaf nodes.

This is followup of T3008.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5170
* https://vyos.dev/T3008

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ntp

## Proposed changes
<!--- Describe your changes in detail -->
This is a minor change to update `ntp` configuration path in bundled `config.boot.default`.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
