### PR TITLE
initramfs-tools: T5180: Updated initramfs tools to v0.140

### DIFF
--- a/data/live-build-config/archives/bullseye.pref.chroot
+++ b/data/live-build-config/archives/bullseye.pref.chroot
@@ -38,6 +38,14 @@ Package: skopeo
 Pin: release n=bullseye
 Pin-Priority: 600
 
+Package: initramfs-tools-core
+Pin: release n=bullseye
+Pin-Priority: 600
+
+Package: initramfs-tools
+Pin: release n=bullseye
+Pin-Priority: 600
+
 Package: squashfs-tools
 Pin: release n=bullseye
 Pin-Priority: -10


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Updated initramfs tools to v0.140

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5180

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
initramfs-tools

## Proposed changes
<!--- Describe your changes in detail -->
The new initramfs-tools version contains important changes in firmware path selection. This is required for proper driver integrations.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
If you try to install a NIC driver from source or deb package, for example, `ice` from Intel, it will install both kernel module and firmware. Old initramfs-tools will use a kernel module from the installed package, but a firmware from linux-firmware. This happens because it does not honor the `updates` directory for firmware. The problem was fixed in initramfs-tools 0.137. Som with the new version from `bullseye`, everything works fine.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
