### PR TITLE
T5123: Use 'patch' instead of 'git am' to make it more robust

### DIFF
--- a/packages/frr/build-frr.sh
+++ b/packages/frr/build-frr.sh
@@ -25,7 +25,8 @@ if [ -d $PATCH_DIR ]; then
             # user.email variables as these is not set in the build container by default.
             OPTS="-c user.name=VyOS-CI -c user.email=maintainers@vyos.io"
         fi
-        git $OPTS am --committer-date-is-author-date ${PATCH_DIR}/${patch}
+        #git $OPTS am --committer-date-is-author-date ${PATCH_DIR}/${patch}
+        patch -Np1 -i ${PATCH_DIR}/${patch}
     done
 fi
 


### PR DESCRIPTION
Refer to pull request #342 and #328, `git am` seems still not working.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5123

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ospfd

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Use command `show ip ospf route detail` to show detailed information.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
