### PR TITLE
FRR: Fixed BGP as-override behavior

### DIFF
--- a/packages/frr/patches/0003-Fix-as-override-behavior.patch
+++ b/packages/frr/patches/0003-Fix-as-override-behavior.patch
@@ -1,0 +1,77 @@
+From 6320d4941777d317989209f26ca513379f729c30 Mon Sep 17 00:00:00 2001
+From: zsdc <taras@vyos.io>
+Date: Fri, 12 May 2023 13:56:20 +0300
+Subject: [PATCH] Fix as-override behavior
+
+Backported 9bbdb4572d3bb255211fecf1c756452ab27e91c2 from FRR 8.5
+---
+ bgpd/bgp_aspath.c | 22 ----------------------
+ bgpd/bgp_aspath.h |  1 -
+ bgpd/bgp_route.c  |  4 +---
+ 3 files changed, 1 insertion(+), 26 deletions(-)
+
+diff --git a/bgpd/bgp_aspath.c b/bgpd/bgp_aspath.c
+index 5cf3c60fa..9595bae5f 100644
+--- a/bgpd/bgp_aspath.c
++++ b/bgpd/bgp_aspath.c
+@@ -1215,28 +1215,6 @@ bool aspath_private_as_check(struct aspath *aspath)
+ 	return true;
+ }
+ 
+-/* Return True if the entire ASPATH consist of the specified ASN */
+-bool aspath_single_asn_check(struct aspath *aspath, as_t asn)
+-{
+-	struct assegment *seg;
+-
+-	if (!(aspath && aspath->segments))
+-		return false;
+-
+-	seg = aspath->segments;
+-
+-	while (seg) {
+-		int i;
+-
+-		for (i = 0; i < seg->length; i++) {
+-			if (seg->as[i] != asn)
+-				return false;
+-		}
+-		seg = seg->next;
+-	}
+-	return true;
+-}
+-
+ /* Replace all instances of the target ASN with our own ASN */
+ struct aspath *aspath_replace_specific_asn(struct aspath *aspath,
+ 					   as_t target_asn, as_t our_asn)
+diff --git a/bgpd/bgp_aspath.h b/bgpd/bgp_aspath.h
+index 9df352fcd..9bab5bb7b 100644
+--- a/bgpd/bgp_aspath.h
++++ b/bgpd/bgp_aspath.h
+@@ -108,7 +108,6 @@ extern unsigned int aspath_get_first_as(struct aspath *);
+ extern unsigned int aspath_get_last_as(struct aspath *);
+ extern int aspath_loop_check(struct aspath *, as_t);
+ extern bool aspath_private_as_check(struct aspath *);
+-extern bool aspath_single_asn_check(struct aspath *, as_t asn);
+ extern struct aspath *aspath_replace_specific_asn(struct aspath *aspath,
+ 						  as_t target_asn,
+ 						  as_t our_asn);
+diff --git a/bgpd/bgp_route.c b/bgpd/bgp_route.c
+index 48ccb669b..6de3e2a7f 100644
+--- a/bgpd/bgp_route.c
++++ b/bgpd/bgp_route.c
+@@ -1571,11 +1571,9 @@ static void bgp_peer_as_override(struct bgp *bgp, afi_t afi, safi_t safi,
+ 				 struct peer *peer, struct attr *attr)
+ {
+ 	if (peer->sort == BGP_PEER_EBGP
+-	    && peer_af_flag_check(peer, afi, safi, PEER_FLAG_AS_OVERRIDE)) {
+-		if (aspath_single_asn_check(attr->aspath, peer->as))
++	    && peer_af_flag_check(peer, afi, safi, PEER_FLAG_AS_OVERRIDE))
+ 			attr->aspath = aspath_replace_specific_asn(
+ 				attr->aspath, peer->as, bgp->as);
+-	}
+ }
+ 
+ void bgp_attr_add_gshut_community(struct attr *attr)
+-- 
+2.34.1
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed BGP as-override behavior

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5221

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
FRR, bgpd

## Proposed changes
<!--- Describe your changes in detail -->
Override peer's ASN even if original as-path contains other ASNs

This is a backport of 9bbdb4572d3bb255211fecf1c756452ab27e91c2 from the main FRR repository

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
You need to configure three routers:
```
R1 (eth0) <---> (eth0) R2 (eth1) <---> (eth1) R3
```

R1:
```
set interfaces ethernet eth0 address '192.168.1.1/24'
set policy route-map PREP_65003 rule 10 action 'permit'
set policy route-map PREP_65003 rule 10 set as-path-prepend '65003'
set protocols bgp 65001 address-family ipv4-unicast network 192.168.0.0/24
set protocols bgp 65001 neighbor 192.168.1.2 address-family ipv4-unicast route-map export 'PREP_65003'
set protocols bgp 65001 neighbor 192.168.1.2 remote-as '65002'
```

R2:
```
set interfaces ethernet eth0 address '192.168.1.2/24'
set interfaces ethernet eth1 address '192.168.3.1/24'
set protocols bgp 65002 neighbor 192.168.1.1 remote-as '65001'
set protocols bgp 65002 neighbor 192.168.3.2 address-family ipv4-unicast as-override
set protocols bgp 65002 neighbor 192.168.3.2 remote-as '65003'
```

R3:
```
set interfaces ethernet eth1 address '192.168.3.2/24'
set protocols bgp 65003 neighbor 192.168.3.1 remote-as '65002'
```

Without the patch:
```
vyos@vyos:~$ show ip bgp neighbors 192.168.3.2 advertised-routes 
BGP table version is 1, local router ID is 192.168.3.1, vrf id 0
Default local pref 100, local AS 65002
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*> 192.168.0.0/24   0.0.0.0                                0 65001 65003 i

Total number of prefixes 1
```

After the patch:
```
vyos@vyos:~$ show ip bgp neighbors 192.168.3.2 advertised-routes 
BGP table version is 1, local router ID is 192.168.3.1, vrf id 0
Default local pref 100, local AS 65002
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric LocPrf Weight Path
*> 192.168.0.0/24   0.0.0.0                                0 65001 65002 i

Total number of prefixes 1
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
