### PR TITLE
T5468: Remove unused manpages to free up space

### DIFF
--- a/data/live-build-config/hooks/live/80-delete-docs.chroot
+++ b/data/live-build-config/hooks/live/80-delete-docs.chroot
@@ -4,3 +4,8 @@
 # Copyright/licenses files are ignored for deletion
 shopt -s extglob
 rm -rf /usr/share/doc/*/!(copyright*|README*) /usr/share/doc-base
+
+# We also do not need any manpages on the system since man-binary is missing.
+# This also frees some space.
+rm -rf /usr/share/man
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We dont need any manpages on the system since man-binary is missing.
This will also free up some space.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Removes functionality who cannot be used anyway since man-binary is missing.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5468

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
manpages

## Proposed changes
<!--- Describe your changes in detail -->
Delete directory /usr/share/man to free up some space since the content cannot be used anyway since man-binary is missing.

Approx 13 megabyte (compressed) can be freed which also shrinks iso-file.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Attempt to run `man` shows that the binary is missing.

Verify that the manpages directory over at /usr/share/man is removed by issuing:

```
ls -la /usr/share/man
```

`du -sm /usr/share/man` can also be used to verify amount of space saved (runned on iso prior to this merge).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
