### PR TITLE
T5511: Cleanup of unused directories (and files) in order to shrink image-size

### DIFF
--- a/data/live-build-config/hooks/live/80-delete-docs.chroot
+++ b/data/live-build-config/hooks/live/80-delete-docs.chroot
@@ -1,11 +1,42 @@
 #!/bin/bash
 
-# We do not need any documentation on the system. This frees some space.
-# Copyright/licenses files are ignored for deletion
+# Delete various unused files and directories in order free some space and shrink imagesize.
+
+# We do not need any documentation on the system.
+# Copyright/licenses files are ignored for deletion.
 shopt -s extglob
 rm -rf /usr/share/doc/*/!(copyright*|README*) /usr/share/doc-base
 
-# We also do not need any manpages on the system since man-binary is missing.
-# This also frees some space.
+# We do not need any manpages on the system since man-binary is missing.
+rm -rf /usr/local/man
+rm -rf /usr/local/share/man
 rm -rf /usr/share/man
+
+# We do not need any games on the system.
+rm -rf /usr/games
+rm -rf /usr/local/games
+
+# We do not need any caches on the system (will be recreated when needed).
+rm -rf /var/cache/*
+
+# We do not need any log-files on the system (will be recreated when needed).
+rm -rf /var/log/alternatives.log
+rm -rf /var/log/bootstrap.log
+rm -rf /var/log/dpkg.log
+rm -rf /var/log/apt/history.log
+rm -rf /var/log/apt/term.log
+rm -rf /var/log/nginx/access.log
+rm -rf /var/log/nginx/error.log
+rm -rf /var/log/squidguard/squidGuard.log
+rm -rf /var/log/stunnel4/stunnel.log
+
+# We do not need any backup-files on the system.
+rm -rf /etc/sudoers.bak
+rm -rf /etc/xml/catalog.old
+rm -rf /etc/xml/polkitd.xml.old
+rm -rf /etc/xml/xml-core.xml.old
+rm -rf /root/.gnupg/pubring.kbx~
+rm -rf /var/lib/dpkg/diversions-old
+rm -rf /var/lib/dpkg/status-old
+rm -rf /var/lib/sgml-base/supercatalog.old
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Delete various unused files and directories in order free some space and shrink imagesize.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5511

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
Spinoff of https://vyos.dev/T5468 to delete more unused files and directories in order to shrink imagesize.

Where T5468 shrunk the imagesize by approx 13MB this task T5511 will shrink it by additional approx 11MB.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
After build verify if the files and directories mentioned in 80-delete-docs.chroot have been deleted.

Note that some files and directories such as in /var/cache/* and /var/log/* will be recreated when needed but they will not be part of the image itself.

Unless there are other merges at the same time that affect imagesize the imagesize should shrink by approx 11MB compared to previous nightly build.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
