### PR TITLE
T5512: linux-firmware: expand asterisk in modinfo firmware fields

### DIFF
--- a/packages/linux-kernel/build-linux-firmware.sh
+++ b/packages/linux-kernel/build-linux-firmware.sh
@@ -55,32 +55,32 @@ mkdir -p "${LINUX_FIRMWARE_BUILD_DIR}"
 # Copy firmware file from linux firmware build directory into
 # assembly folder for the vyos-firmware package
 SED_REPLACE="s@${CWD}/${LINUX_FIRMWARE}/@@"
-for FILE in ${FW_FILES}; do
-    # If file is a symlink install the symlink target as well
-    if [ -h "${LINUX_FIRMWARE_BUILD_DIR}/${FILE}" ]; then
-        TARGET="$(realpath --relative-to="${LINUX_FIRMWARE_BUILD_DIR}" "${LINUX_FIRMWARE_BUILD_DIR}/${FILE}")"
+for FILE_PATTERN in ${FW_FILES}; do
+    find "${LINUX_FIRMWARE_BUILD_DIR}" -path "*/${FILE_PATTERN}" -print0 | while IFS= read -r -d $'\0' FILE; do
+        TARGET="$(realpath --relative-to="${LINUX_FIRMWARE_BUILD_DIR}" "${FILE}")"
         TARGET_DIR="${VYOS_FIRMWARE_DIR}/lib/firmware/$(dirname "${TARGET}")"
+        # If file is a symlink install the symlink target as well
+        if [ -h "${FILE}" ]; then
+            if [ ! -f "${TARGET_DIR}/$(basename "${TARGET}")" ]; then
+                if [ -f "${LINUX_FIRMWARE_BUILD_DIR}/${TARGET}" ]; then
+                    mkdir -p "${TARGET_DIR}"
 
-        if [ ! -f "${TARGET_DIR}/$(basename "${TARGET}")" ]; then
-            if [ -f "${LINUX_FIRMWARE_BUILD_DIR}/${TARGET}" ]; then
-                mkdir -p "${TARGET_DIR}"
-
-                echo "I: install firmware: ${TARGET}"
-                cp "${CWD}/${LINUX_FIRMWARE_BUILD_DIR}/${TARGET}" "${TARGET_DIR}"
-            else
-                echo "I: firmware file not found: ${TARGET}"
+                    echo "I: install firmware: ${TARGET}"
+                    cp "${CWD}/${LINUX_FIRMWARE_BUILD_DIR}/${TARGET}" "${TARGET_DIR}"
+                else
+                    echo "I: firmware file not found: ${TARGET}"
+                fi
             fi
         fi
-    fi
 
-    if [ -f ${LINUX_FIRMWARE_BUILD_DIR}/${FILE} ]; then
-        FW_DIR="${VYOS_FIRMWARE_DIR}/lib/firmware/$(dirname ${FILE})"
-        mkdir -p "${FW_DIR}"
-        echo "I: install firmware: ${FILE}"
-        cp -P "${CWD}/${LINUX_FIRMWARE_BUILD_DIR}/${FILE}" "${FW_DIR}"
-    else
-        echo "I: firmware file not found: ${FILE}"
-    fi
+        if [ -f "${FILE}" ]; then
+            mkdir -p "${TARGET_DIR}"
+            echo "I: install firmware: ${TARGET}"
+            cp -P "${CWD}/${LINUX_FIRMWARE_BUILD_DIR}/${TARGET}" "${TARGET_DIR}"
+        else
+            echo "I: firmware file not found: ${TARGET}"
+        fi
+    done
 done
 
 echo "I: Create linux-firmware package"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Use `find` to expand the asterisk in firmware fields.
e.g. brcmfmac firmware "brcm/brcmfmac*-sdio.*.txt"
It will not expand the * sign in the previous version.
So the system will miss some firmwares for the drivers.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5512

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
