### PR TITLE
T5517: Fix equuleus build for missing package linux-image-5.4.254-amd64-vyos

### DIFF
--- a/data/defaults.json
+++ b/data/defaults.json
@@ -5,7 +5,7 @@
   "debian_distribution": "buster",
   "vyos_mirror": "http://dev.packages.vyos.net/repositories/equuleus",
   "vyos_branch": "equuleus",
-  "kernel_version": "5.4.254",
+  "kernel_version": "5.4.243",
   "kernel_flavor": "amd64-vyos",
   "release_train": "equuleus",
   "additional_repositories": [


### PR DESCRIPTION
## Change Summary
Downgrade kernel to `5.4.243` from `5.4.254` to fix the build.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T5517

## Component(s) name
Kernel version

## Proposed changes
In PR https://github.com/vyos/vyos-build/pull/380 the kernel image has been updated from `5.4.243` to `5.4.254`, however this package does not exist in the [VyOS deb packages repo](http://dev.packages.vyos.net/?dir=repositories/equuleus/pool/main/l). This causes the build for equuleus to fail at the moment, see also ticket [T5517](https://vyos.dev/T5517). To get the build running again, this PR downgrades the kernel back to version `5.4.243`. As soon as package `linux-image-5.4.254-amd64-vyos` is released and added to the repo, the kernel can be upgraded again.

## How to test
```
$ ./configure --architecture amd64 --build-by "j.randomhacker@vyos.io"
$ sudo make iso
```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
