### PR TITLE
T5510: Shrink imagesize and improve read performance by changing mksquashfs syntax

### DIFF
--- a/data/defaults.toml
+++ b/data/defaults.toml
@@ -17,7 +17,7 @@ release_train = "current"
 kernel_version = "6.1.50"
 bootloaders = "syslinux,grub-efi"
 
-chroot-squashfs-compression-type = "xz -Xbcj x86 -b 256k -no-recovery -always-use-fragments -no-duplicates"
+squashfs_compression_type = "xz -Xbcj x86 -b 256k -no-recovery -always-use-fragments -no-duplicates"
 
 website_url = "https://vyos.io"
 support_url = "https://support.vyos.io"

--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -428,7 +428,7 @@ if __name__ == "__main__":
             --bootloader {{bootloaders}} \
             --binary-images iso-hybrid \
             --checksums 'sha256 md5' \
-            --chroot-squashfs-compression-type {{chroot-squashfs-compression-type}} \
+            --chroot-squashfs-compression-type {{squashfs_compression_type}} \
             --debian-installer none \
             --distribution {{debian_distribution}} \
             --iso-application "VyOS" \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Set variable `--chroot-squashfs-compression-type` to be used by live-build when running mksquashfs which creates the filesystem.squashfs which is included in the iso.

The result except for smaller iso should also be slightly better read performance compared to default settings.

The penalty is slightly longer buildtime.

2nd attempt:

Adjusting added variable name from "-" into "_" due to error during build (smoketest):

https://github.com/vyos/vyos-rolling-nightly-builds/actions/runs/6055144564/job/16433670804

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5510

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
* data/defaults.toml:

Added variable `squashfs_compression_type`.

* scripts/build-vyos-image:

Added `--chroot-squashfs-compression-type {{squashfs_compression_type}} \` to variable `lb_config_tmpl`.

The expected result is about 5% smaller iso file with the penalty that the squashfs creation will take approx 5-10% longer time (measured on an Intel i5 cpu give or take about 1 minute longer buildtime).

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
The obvious test is if VyOS boots at all since the created `filesystem.squashfs` is the readonly root filesystem which VyOS applies an OverlayFS to for persistence storage.

The more detailed test is to extract the `filesystem.squashfs` file from an iso made prior to this PR being merged and compare it to one efter this PR being merged.

Information about how a `filesystem.squashfs` was created before vs. after merge can be seen by running:

```
unsquashfs -s ./filesystem.squashfs
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
