### PR TITLE
T5538: Change order within variable lb_config_tmpl to fit order of manpage and fix some typos

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -420,35 +420,35 @@ if __name__ == "__main__":
     ## Configure live-build
     lb_config_tmpl = jinja2.Template("""
     lb config noauto \
-            --architectures {{architecture}} \
+            --apt-indices false \
+            --apt-options "--yes -oAPT::Get::allow-downgrades=true" \
+            --apt-recommends false \
+            --architecture {{architecture}} \
+            --archive-areas {{debian_archive_areas}} \
+            --backports true \
+            --binary-image iso-hybrid \
             --bootappend-live "boot=live components hostname=vyos username=live nopersistence noautologin nonetworking union=overlay console=ttyS0,115200 console=tty0 net.ifnames=0 biosdevname=0" \
             --bootappend-live-failsafe "live components memtest noapic noapm nodma nomce nolapic nomodeset nosmp nosplash vga=normal console=ttyS0,115200 console=tty0 net.ifnames=0 biosdevname=0" \
-            --linux-flavours {{kernel_flavor}} \
-            --linux-packages linux-image-{{kernel_version}} \
-            --bootloader {{bootloaders}} \
-            --binary-images iso-hybrid \
+            --bootloaders {{bootloaders}} \
             --checksums 'sha256 md5' \
             --chroot-squashfs-compression-type {{squashfs_compression_type}} \
             --debian-installer none \
+            --debootstrap-options "--variant=minbase --exclude=isc-dhcp-client,isc-dhcp-common,ifupdown --include=apt-utils,ca-certificates,gnupg2" \
             --distribution {{debian_distribution}} \
+            --firmware-binary false \
+            --firmware-chroot false \
             --iso-application "VyOS" \
             --iso-publisher "{{build_by}}" \
             --iso-volume "VyOS" \
-            --debootstrap-options "--variant=minbase --exclude=isc-dhcp-client,isc-dhcp-common,ifupdown --include=apt-utils,ca-certificates,gnupg2" \
+            --linux-flavours {{kernel_flavor}} \
+            --linux-packages linux-image-{{kernel_version}} \
+            --mirror-binary {{debian_mirror}} \
+            --mirror-binary-security {{debian_security_mirror}} \
             --mirror-bootstrap {{debian_mirror}} \
             --mirror-chroot {{debian_mirror}} \
             --mirror-chroot-security {{debian_security_mirror}} \
-            --mirror-binary {{debian_mirror}} \
-            --mirror-binary-security {{debian_security_mirror}} \
-            --archive-areas {{debian_archive_areas}} \
-            --firmware-chroot false \
-            --firmware-binary false \
-            --updates true \
             --security true \
-            --backports true \
-            --apt-recommends false \
-            --apt-options "--yes -oAPT::Get::allow-downgrades=true" \
-            --apt-indices false
+            --updates true
             "${@}"
     """)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Change order within variable lb_config_tmpl (scripts/build-vyos-image) to fit order of manpage and fix some typos aswell.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5538

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
* scripts/build-vyos-image

Refactor variable lb_config_tmpl so the variables follow the same order as in the manpage for live-build (debian:bookworm).

* scripts/build-vyos-image

`--architectures` is according to the manpage for debian:bookworm spelled as `--architecture`.

https://manpages.debian.org/bookworm/live-build/lb_config.1.en.html#a

* scripts/build-vyos-image

`--binary-images` is according to the manpage for debian:bookworm spelled as `--binary-image`.

https://manpages.debian.org/bookworm/live-build/lb_config.1.en.html#b

* scripts/build-vyos-image

`--bootloader` is according to the manpage for debian:bookworm spelled as `--bootloaders`.

https://manpages.debian.org/bookworm/live-build/lb_config.1.en.html#bootloaders

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
The variable lb_config_tmpl is used to setup how live-build will compile and create the squashfs and bake this into the iso file.

So if everything went well we should have a iso file created without errors.

Can also be compared to previous nightly build.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
