### PR TITLE
T5562: Fix smp-syntax for qemu-system-x86_64

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -143,7 +143,7 @@ def get_qemu_cmd(name, enable_kvm, enable_uefi, disk_img, raid=None, iso_img=Non
     macbase = '52:54:00:00:00'
     cmd = f'qemu-system-x86_64 \
         -name "{name}" \
-        -smp {cpucount} sockets=1,cores={cpucount},threads=1 \
+        -smp {cpucount},sockets=1,cores={cpucount},threads=1 \
         -cpu host \
         {uefi} \
         -m 3G \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixing missing comma in smp-syntax for qemu-system-x86_64.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5562

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
In `/scripts/check-qemu-install` change from:

```
-smp {cpucount} sockets=1,cores={cpucount},threads=1 \
```

to:

```
-smp {cpucount},sockets=1,cores={cpucount},threads=1 \
```

That is fix missing comma.

Ref: https://manpages.debian.org/bookworm-backports/qemu-system-x86/qemu-system-amd64.1.en.html

```
-smp [[cpus=]n][,maxcpus=maxcpus][,sockets=sockets][,dies=dies][,clusters=clusters][,cores=cores][,threads=threads]
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
See if VyOS builds and can run smoketests.

Watch out for something similar to these lines in the smoketest log:

```
2023-09-08T18:08:40.9152507Z DEBUG - qemu-system-x86_64: warning: This family of AMD CPU doesn't support hyperthreading(3)
2023-09-08T18:08:40.9153908Z DEBUG - Please configure -smp options properly or try enabling topoext feature.
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
