### PR TITLE
ddclient: T5573: Patch ddclient to fix caching issues with new providers

### DIFF
--- a/packages/ddclient/patches/z5_caching-1.patch
+++ b/packages/ddclient/patches/z5_caching-1.patch
@@ -1,0 +1,211 @@
+From 00ae6ec809cd5db7a3b4418ad393c145252f1b75 Mon Sep 17 00:00:00 2001
+From: Lenard Hess <lenard@rrhess.de>
+Date: Mon, 10 Jul 2023 18:57:02 +0200
+Subject: [PATCH 1/3] Fixed caching behaviour for new providers with legacy
+ 'use' logic
+
+Ref: https://github.com/rrthomas/ddclient/pull/10
+---
+ ddclient.in | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/ddclient.in b/ddclient.in
+index 9221a1c9..c871b5b6 100755
+--- a/ddclient.in
++++ b/ddclient.in
+@@ -1337,6 +1337,18 @@ sub update_nics {
+         if (@hosts) {
+             $0 = sprintf("%s - updating %s", $program, join(',', @hosts));
+             &$update(@hosts);
++
++            # Backwards compatibility:
++            # If we only have 'use', we set 'wantipv4' or 'wantipv6' depending on the IP type of
++            # 'wantip'. Newer provider implementations such as cloudflare only check 'wantipv*'
++            # and set 'status-ipv*' accordingly, ignoring 'wantip' and 'status'.
++            # For these we then load back the 'status' from 'status-ipv*' to ensure correct
++            # caching and updating behaviour.
++            foreach my $h (@hosts) {
++                $config{$h}{'status'} //= $config{$h}{'status-ipv4'};
++                $config{$h}{'status'} //= $config{$h}{'status-ipv6'};
++            }
++
+             runpostscript(join ' ', keys %ipsv4, keys %ipsv6);
+         }
+     }
+
+From 240176c5de6360ed9202975fb5e72e9f4148540f Mon Sep 17 00:00:00 2001
+From: Lenard Hess <lenard@rrhess.de>
+Date: Mon, 10 Jul 2023 21:48:27 +0200
+Subject: [PATCH 2/3] Added preliminary explanation for provider functions
+
+---
+ ddclient.in | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/ddclient.in b/ddclient.in
+index c871b5b6..3a4a0780 100755
+--- a/ddclient.in
++++ b/ddclient.in
+@@ -3696,6 +3696,25 @@ sub header_ok {
+     }
+     return $ok;
+ }
++
++######################################################################
++## DDNS providers
++#  A DDNS provider consists of an example function, the update
++#  function, and an optional updateable function.
++#
++#  The example function simply returns a string for the help message,
++#  explaining how to configure the provider
++#
++#  The update function performs the actual record update.
++#  It receives an array of hosts as its argument.
++#
++#  The updateable function allows a provider implementation to force
++#  an update even if ddclient has itself determined no update is
++#  necessary. The function shall return 1 if an update should be
++#  performed, else 0.
++######################################################################
++
++
+ ######################################################################
+ ## nic_dyndns1_examples
+ ######################################################################
+
+From 6c91b3ca2c868989ad5bf6535fa186dbae74ba14 Mon Sep 17 00:00:00 2001
+From: Lenard Hess <lenard@rrhess.de>
+Date: Thu, 13 Jul 2023 14:10:44 +0200
+Subject: [PATCH 3/3] easydns, porkbun: Set status-ipv4 and status-ipv6 instead
+ of status
+
+This fixes caching issues when using the 'usev4' or 'usev6' parameters.
+Without this, the "min-interval" and "warned-min-interval" limits will
+not work.
+
+For the legacy 'use' parameter, the wrapping code takes care of
+translating 'status-ipv*' to 'status'.
+---
+ ddclient.in | 31 ++++++++++++++++---------------
+ 1 file changed, 16 insertions(+), 15 deletions(-)
+
+diff --git a/ddclient.in b/ddclient.in
+index 3a4a0780..65076d26 100755
+--- a/ddclient.in
++++ b/ddclient.in
+@@ -4747,7 +4747,8 @@ sub nic_easydns_update {
+                 my ($status) = $line =~ /^(\S*)\b.*/;
+                 my $h = shift @hosts;
+
+-                $config{$h}{'status'} = $status;
++                $config{$h}{'status-ipv4'} = $status if $ipv4;
++                $config{$h}{'status-ipv6'} = $status if $ipv6;
+                 if ($status eq 'NOERROR') {
+                     $config{$h}{'ipv4'}  = $ipv4;
+                     $config{$h}{'ipv6'}  = $ipv6;
+@@ -7081,12 +7082,12 @@ sub nic_porkbun_update {
+             );
+             # No response, declare as failed
+             if (!defined($reply) || !$reply) {
+-                $config{$host}{'status'} = "bad";
++                $config{$host}{'status-ipv4'} = "bad";
+                 failed("updating %s: Could not connect to porkbun.com.", $host);
+                 next;
+             }
+             if (!header_ok($host, $reply)) {
+-                $config{$host}{'status'} = "bad";
++                $config{$host}{'status-ipv4'} = "bad";
+                 failed("updating %s: failed (%s)", $host, $reply);
+                 next;
+             }
+@@ -7095,12 +7096,12 @@ sub nic_porkbun_update {
+             $reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
+             my $response = eval { decode_json(${^MATCH}) };
+             if (!defined($response)) {
+-                $config{$host}{'status'} = "bad";
++                $config{$host}{'status-ipv4'} = "bad";
+                 failed("%s -- Unexpected service response.", $host);
+                 next;
+             }
+             if ($response->{status} ne 'SUCCESS') {
+-                $config{$host}{'status'} = "bad";
++                $config{$host}{'status-ipv4'} = "bad";
+                 failed("%s -- Unexpected status. (status = %s)", $host, $response->{status});
+                 next;
+             }
+@@ -7112,7 +7113,7 @@ sub nic_porkbun_update {
+                 }
+                 my $current_content = $records->[0]->{'content'};
+                 if ($current_content eq $ipv4) {
+-                    $config{$host}{'status'} = "good";
++                    $config{$host}{'status-ipv4'} = "good";
+                     success("updating %s: skipped: IPv4 address was already set to %s.", $host, $ipv4);
+                     next;
+                 }
+@@ -7144,11 +7145,11 @@ sub nic_porkbun_update {
+                     failed("updating %s: failed (%s)", $host, $reply);
+                     next;
+                 }
+-                $config{$host}{'status'} = "good";
++                $config{$host}{'status-ipv4'} = "good";
+                 success("updating %s: good: IPv4 address set to %s", $host, $ipv4);
+                 next;
+             } else {
+-                $config{$host}{'status'} = "bad";
++                $config{$host}{'status-ipv4'} = "bad";
+                 failed("updating %s: No applicable existing records.", $host);
+                 next;
+             }
+@@ -7174,12 +7175,12 @@ sub nic_porkbun_update {
+             );
+             # No response, declare as failed
+             if (!defined($reply) || !$reply) {
+-                $config{$host}{'status'} = "bad";
++                $config{$host}{'status-ipv6'} = "bad";
+                 failed("updating %s: Could not connect to porkbun.com.", $host);
+                 next;
+             }
+             if (!header_ok($host, $reply)) {
+-                $config{$host}{'status'} = "bad";
++                $config{$host}{'status-ipv6'} = "bad";
+                 failed("updating %s: failed (%s)", $host, $reply);
+                 next;
+             }
+@@ -7188,12 +7189,12 @@ sub nic_porkbun_update {
+             $reply =~ qr/{(?:[^{}]*|(?R))*}/mp;
+             my $response = eval { decode_json(${^MATCH}) };
+             if (!defined($response)) {
+-                $config{$host}{'status'} = "bad";
++                $config{$host}{'status-ipv6'} = "bad";
+                 failed("%s -- Unexpected service response.", $host);
+                 next;
+             }
+             if ($response->{status} ne 'SUCCESS') {
+-                $config{$host}{'status'} = "bad";
++                $config{$host}{'status-ipv6'} = "bad";
+                 failed("%s -- Unexpected status. (status = %s)", $host, $response->{status});
+                 next;
+             }
+@@ -7205,7 +7206,7 @@ sub nic_porkbun_update {
+                 }
+                 my $current_content = $records->[0]->{'content'};
+                 if ($current_content eq $ipv6) {
+-                    $config{$host}{'status'} = "good";
++                    $config{$host}{'status-ipv6'} = "good";
+                     success("updating %s: skipped: IPv6 address was already set to %s.", $host, $ipv6);
+                     next;
+                 }
+@@ -7237,11 +7238,11 @@ sub nic_porkbun_update {
+                     failed("updating %s: failed (%s)", $host, $reply);
+                     next;
+                 }
+-                $config{$host}{'status'} = "good";
++                $config{$host}{'status-ipv6'} = "good";
+                 success("updating %s: good: IPv6 address set to %s", $host, $ipv4);
+                 next;
+             } else {
+-                $config{$host}{'status'} = "bad";
++                $config{$host}{'status-ipv6'} = "bad";
+                 failed("updating %s: No applicable existing records.", $host);
+                 next;
+             }


### PR DESCRIPTION
Patch ddclient to fix caching issues with new providers.

For details see:
    - https://github.com/ddclient/ddclient/issues/544
    - https://github.com/rrthomas/ddclient/pull/10

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This patches ddclient build to fix the way cache entry is generated.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5573

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
dns dynamic

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
`monitor log dns dynamic` should not show messages like
`WARNING:  updating foo.example.com: nochg: No update required; unnecessary attempts to change to the current address are considered abusive`


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
