### PR TITLE
T5511: Cleanup of unused directories (and files) in order to shrink image-size

### DIFF
--- a/data/live-build-config/rootfs/excludes
+++ b/data/live-build-config/rootfs/excludes
@@ -1,0 +1,1 @@
+/var/cache/apt/*


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Another method of shrinking filesystem.squashfs (which will shrink the iso-file) is to use an excludefilelist.

The excludefilelist will define which files and directories (line by line) incl wildcards to be excluded when the filesystem.squashfs is created by mksquashfs (live-build).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5511

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
By adding `data/live-build-config/rootfs/excludes` and fill that with files and directories (line by line) incl wildcards those will be excluded by mksquashfs (live-build through binary_rootfs script) when the filesystem.squashfs is created.

The result will be smaller filesystem.squashfs file (and because of that also smaller iso-file).

It turned out that using `data/live-build-config/hooks/live/` wasnt enough because during "lb build" for example the `/var/cache/apt/*` will be filled with files which then are included in the filesystem.squashfs that gets created.

Newer live-build fixes this through script `binary_chroot`.

As a first attempt the `data/live-build-config/rootfs/excludes` file is only populated with:

```
/var/cache/apt/*
```

If succeeded it means we will have two methods of deleting/excluding files from the resulting filesystem.squashfs:

1) Through hooks in: `data/live-build-config/hooks/live/`.
2) Through an excludefilelist in: `data/live-build-config/rootfs/excludes`.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
After the iso have been built and either booted or installed in a system verify that the `/var/cache/apt` directory is empty. If succeeded this would shrink the iso-file by approx 4MB.

Before the change (VyOS 1.5-rolling-202309130022):

```
vyos@vyos:~$ ls -la /var/cache/apt
total 3701
drwxr-xr-x 3 root root      74 Sep 13 03:45 .
drwxr-xr-x 1 root root    4096 Sep 13 11:09 ..
drwxr-xr-x 3 root root      42 Sep 13 03:45 archives
-rw-r--r-- 1 root root 2189971 Sep 13 03:45 pkgcache.bin
-rw-r--r-- 1 root root 1594438 Sep 13 03:45 srcpkgcache.bin
vyos@vyos:~$ du -sm /var/cache/apt
4	/var/cache/apt
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
