### PR TITLE
T5511: Cleanup of unused directories (and files) in order to shrink image-size

### DIFF
--- a/data/live-build-config/rootfs/excludes
+++ b/data/live-build-config/rootfs/excludes
@@ -1,1 +1,14 @@
-/var/cache/apt/*
+# Exclude various unused files and directories in order to free some space and shrink imagesize.
+#
+# For information on how to use wildcards properly (Anchored and Non-anchored excludes):
+#
+# https://github.com/plougher/squashfs-tools/blob/master/RELEASE-READMEs/README-3.3
+#
+# Note:
+#
+# - root starts without leading '/'.
+#
+
+# We do not need any caches on the system (will be recreated when needed).
+var/cache/*
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixes previous PR: https://github.com/vyos/vyos-build/pull/406

Another method of shrinking filesystem.squashfs (which will shrink the iso-file) is to use an excludefilelist.

The excludefilelist will define which files and directories (line by line) incl wildcards to be excluded when the filesystem.squashfs is created by mksquashfs (live-build).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5511

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
Turned out that the excludes-file should NOT have a leading '/' when you want to exclude '/var/cache/*'.

Also added comments and references (in the excludes-file) that points to squashfs-tools readme (version 3.3) which more in detail explains with examples on how to properly use wildcards when defining files and directories to be excluded from the squashfs-file.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
ISO-file will be properly built without this error (as PR406 gave):

```
P: Preparing squashfs image...
P: This may take a while.
FATAL ERROR: /, ./ and ../ prefixed excludes not supported with -wildcards or -regex options
E: An unexpected failure occurred, exiting...
P: Begin unmounting filesystems...
P: Saving caches...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
