### PR TITLE
smoketest: live: T5568: Option to specify smoketests to run, serial boot option to live ISO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ checkiso:
 .PHONY: test
 .ONESHELL:
 test: checkiso
-	scripts/check-qemu-install --debug --uefi build/live-image-amd64.hybrid.iso
+	scripts/check-qemu-install --debug --match="$(MATCH)" --uefi build/live-image-amd64.hybrid.iso
 
 .PHONY: test-no-interfaces
 .ONESHELL:
 test-no-interfaces: checkiso
-	scripts/check-qemu-install --debug --no-interfaces build/live-image-amd64.hybrid.iso
+	scripts/check-qemu-install --debug --match="$(MATCH)" --no-interfaces build/live-image-amd64.hybrid.iso
 
 .PHONY: testd
 .ONESHELL:

--- a/data/live-build-config/hooks/live/01-live-serial.binary
+++ b/data/live-build-config/hooks/live/01-live-serial.binary
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+GRUB_PATH=boot/grub/grub.cfg
+ISOLINUX_PATH=isolinux/live.cfg
+
+KVM_CONSOLE="console=ttyS0,115200 console=tty0"
+SERIAL_CONSOLE="console=tty0 console=ttyS0,115200"
+
+# Grub.cfg Update
+GRUB_MENUENTRY=$(sed -e '/menuentry.*hotkey.*/,/^}/!d' -e 's/--hotkey=l//g' $GRUB_PATH)
+
+# Update KVM menuentry name
+sed -i 's/"Live system \((.*-vyos)\)"/"Live system \1 - KVM console"/' $GRUB_PATH
+
+# Insert serial menuentry
+echo "$GRUB_MENUENTRY" | sed \
+    -e 's/"Live system \((.*-vyos)\)"/"Live system \1 - Serial console"/' \
+    -e "s/$KVM_CONSOLE/$SERIAL_CONSOLE/g" >> $GRUB_PATH
+
+# Live.cfg Update
+ISOLINUX_MENUENTRY=$(sed -e '/label live-\(.*\)-vyos$/,/^\tappend.*/!d' $ISOLINUX_PATH)
+
+# Update KVM menuentry name
+sed -i 's/Live system \((.*-vyos)\)/Live system \1 - KVM console/' $ISOLINUX_PATH
+
+# Insert serial menuentry
+echo "\n$ISOLINUX_MENUENTRY" | sed \
+    -e 's/live-\(.*\)-vyos/live-\1-vyos-serial/' \
+    -e '/^\tmenu default/d' \
+    -e 's/Live system \((.*-vyos)\)/Live system \1 - Serial console/' \
+    -e "s/$KVM_CONSOLE/$SERIAL_CONSOLE/g" >> $ISOLINUX_PATH

--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -63,6 +63,7 @@ parser.add_argument('--silent', help='Do not show output on stdout unless an err
 parser.add_argument('--debug', help='Send all debug output to stdout',
                                action='store_true', default=False)
 parser.add_argument('--logfile', help='Log to file')
+parser.add_argument('--match', help='Smoketests to run')
 parser.add_argument('--uefi', help='Boot using UEFI', action='store_true', default=False)
 parser.add_argument('--raid', help='Perform a RAID-1 install', action='store_true', default=False)
 parser.add_argument('--no-kvm', help='Disable use of kvm', action='store_true', default=False)
@@ -486,6 +487,11 @@ try:
 
     elif not args.configtest:
         # run default smoketest suite
+        if args.match:
+            # Remove tests that we don't want to run
+            match_str = '-o '.join([f'-name "test_*{name}*.py" ' for name in args.match.split("|")]).strip()
+            c.sendline(f'sudo find /usr/libexec/vyos/tests/smoke/cli/test_* -type f ! \( {match_str} \) -delete')
+            c.expect(op_mode_prompt)
         if args.no_interfaces:
             # remove interface tests as they consume a lot of time
             c.sendline('sudo rm -f /usr/libexec/vyos/tests/smoke/cli/test_interfaces_*')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- Updates Makefile to allow for specifying a pattern to run smoketests
- Update live ISO adding grub/isolinux option for serial console

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5568

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest, live-build

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Smoketest example: `make test MATCH="interfaces|policy"` will only run smoketests containing "interfaces" or "policy" in the filename

ISO update:
![image](https://github.com/vyos/vyos-build/assets/965089/0a8dbb69-60a3-4471-be48-0d715e3afa39)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
