### PR TITLE
T5511: Cleanup of unused directories (and files) in order to shrink image-size

### DIFF
--- a/data/live-build-config/hooks/live/20-rm_ddclient_hook.chroot
+++ b/data/live-build-config/hooks/live/20-rm_ddclient_hook.chroot
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-if [ -f /etc/dhcp/dhclient-exit-hooks.d/ddclient ]; then
-  rm -f /etc/dhcp/dhclient-exit-hooks.d/ddclient
-fi
+# Made obsolete by T5511, use rootfs/excludes instead.
+#
+#if [ -f /etc/dhcp/dhclient-exit-hooks.d/ddclient ]; then
+#  rm -f /etc/dhcp/dhclient-exit-hooks.d/ddclient
+#fi
+#
+#if [ -f /etc/ddclient.conf ]; then
+#  rm -f /etc/ddclient.conf
+#fi
 
-if [ -f /etc/ddclient.conf ]; then
-  rm -f /etc/ddclient.conf
-fi

--- a/data/live-build-config/hooks/live/22-rm_cron_atop.chroot
+++ b/data/live-build-config/hooks/live/22-rm_cron_atop.chroot
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-if [ -f /etc/cron.d/atop ]; then
-  rm -f /etc/cron.d/atop
-fi
+# Made obsolete by T5511, use rootfs/excludes instead.
+#
+#if [ -f /etc/cron.d/atop ]; then
+#  rm -f /etc/cron.d/atop
+#fi
 

--- a/data/live-build-config/hooks/live/80-delete-docs.chroot
+++ b/data/live-build-config/hooks/live/80-delete-docs.chroot
@@ -1,42 +1,44 @@
 #!/bin/bash
 
-# Delete various unused files and directories in order free some space and shrink imagesize.
-
-# We do not need any documentation on the system.
-# Copyright/licenses files are ignored for deletion.
-shopt -s extglob
-rm -rf /usr/share/doc/*/!(copyright*|README*) /usr/share/doc-base
-
-# We do not need any manpages on the system since man-binary is missing.
-rm -rf /usr/local/man
-rm -rf /usr/local/share/man
-rm -rf /usr/share/man
-
-# We do not need any games on the system.
-rm -rf /usr/games
-rm -rf /usr/local/games
-
-# We do not need any caches on the system (will be recreated when needed).
-rm -rf /var/cache/*
-
-# We do not need any log-files on the system (will be recreated when needed).
-rm -rf /var/log/alternatives.log
-rm -rf /var/log/bootstrap.log
-rm -rf /var/log/dpkg.log
-rm -rf /var/log/apt/history.log
-rm -rf /var/log/apt/term.log
-rm -rf /var/log/nginx/access.log
-rm -rf /var/log/nginx/error.log
-rm -rf /var/log/squidguard/squidGuard.log
-rm -rf /var/log/stunnel4/stunnel.log
-
-# We do not need any backup-files on the system.
-rm -rf /etc/sudoers.bak
-rm -rf /etc/xml/catalog.old
-rm -rf /etc/xml/polkitd.xml.old
-rm -rf /etc/xml/xml-core.xml.old
-rm -rf /root/.gnupg/pubring.kbx~
-rm -rf /var/lib/dpkg/diversions-old
-rm -rf /var/lib/dpkg/status-old
-rm -rf /var/lib/sgml-base/supercatalog.old
+# Made obsolete by T5511, use rootfs/excludes instead.
+#
+## Delete various unused files and directories in order free some space and shrink imagesize.
+#
+## We do not need any documentation on the system.
+## Copyright/licenses files are ignored for deletion.
+#shopt -s extglob
+#rm -rf /usr/share/doc/*/!(copyright*|README*) /usr/share/doc-base
+#
+## We do not need any manpages on the system since man-binary is missing.
+#rm -rf /usr/local/man
+#rm -rf /usr/local/share/man
+#rm -rf /usr/share/man
+#
+## We do not need any games on the system.
+#rm -rf /usr/games
+#rm -rf /usr/local/games
+#
+## We do not need any caches on the system (will be recreated when needed).
+#rm -rf /var/cache/*
+#
+## We do not need any log-files on the system (will be recreated when needed).
+#rm -f /var/log/alternatives.log
+#rm -f /var/log/bootstrap.log
+#rm -f /var/log/dpkg.log
+#rm -f /var/log/apt/history.log
+#rm -f /var/log/apt/term.log
+#rm -f /var/log/nginx/access.log
+#rm -f /var/log/nginx/error.log
+#rm -f /var/log/squidguard/squidGuard.log
+#rm -f /var/log/stunnel4/stunnel.log
+#
+## We do not need any backup-files on the system.
+#rm -f /etc/sudoers.bak
+#rm -f /etc/xml/catalog.old
+#rm -f /etc/xml/polkitd.xml.old
+#rm -f /etc/xml/xml-core.xml.old
+#rm -f /root/.gnupg/pubring.kbx~
+#rm -f /var/lib/dpkg/diversions-old
+#rm -f /var/lib/dpkg/status-old
+#rm -f /var/lib/sgml-base/supercatalog.old
 

--- a/data/live-build-config/hooks/live/81-cleanup-etc-defaults.chroot
+++ b/data/live-build-config/hooks/live/81-cleanup-etc-defaults.chroot
@@ -1,11 +1,14 @@
 #!/bin/sh
 
-# we use systemd to control ISC daemons from within vyos-1x
-FILES="/etc/default/isc-dhcp-server /etc/default/isc-dhcp-relay"
+# Made obsolete by T5511, use rootfs/excludes instead.
+#
+## we use systemd to control ISC daemons from within vyos-1x
+#FILES="/etc/default/isc-dhcp-server /etc/default/isc-dhcp-relay"
+#
+#for FILE in ${FILES}
+#do
+#    if [ -f ${FILE} ]; then
+#        rm -f ${FILE}
+#    fi
+#done
 
-for FILE in ${FILES}
-do
-    if [ -f ${FILE} ]; then
-        rm -f ${FILE}
-    fi
-done

--- a/data/live-build-config/hooks/live/82-cleanup-udev-rules.chroot
+++ b/data/live-build-config/hooks/live/82-cleanup-udev-rules.chroot
@@ -1,7 +1,10 @@
 #!/bin/sh
 
-# 99-default.link rule always calls link_config that trying to set
-# autonegotiation and duplex even for PPP interfaces.
-# Need to delete this rule to prevent overhead on interface creation stage
+# Made obsolete by T5511, use rootfs/excludes instead.
+#
+## 99-default.link rule always calls link_config that trying to set
+## autonegotiation and duplex even for PPP interfaces.
+## Need to delete this rule to prevent overhead on interface creation stage
+#
+#rm /lib/systemd/network/99-default.link
 
-rm /lib/systemd/network/99-default.link

--- a/data/live-build-config/hooks/live/83-cleanup-etc-motd-d.chroot
+++ b/data/live-build-config/hooks/live/83-cleanup-etc-motd-d.chroot
@@ -1,4 +1,8 @@
 #!/bin/sh
-if [ -f /etc/update-motd.d/10-uname ]; then
-    rm -f /etc/update-motd.d/10-uname
-fi
+
+# Made obsolete by T5511, use rootfs/excludes instead.
+#
+#if [ -f /etc/update-motd.d/10-uname ]; then
+#    rm -f /etc/update-motd.d/10-uname
+#fi
+

--- a/data/live-build-config/rootfs/excludes
+++ b/data/live-build-config/rootfs/excludes
@@ -9,6 +9,72 @@
 # - root starts without leading '/'.
 #
 
-# We do not need any caches on the system (will be recreated when needed).
+# Txxx: Drop isc-dhcp helper files from /etc/default.
+# We use systemd to control ISC daemons from within vyos-1x.
+# Was: hooks/live/81-cleanup-etc-defaults.chroot
+etc/default/isc-dhcp-server
+etc/default/isc-dhcp-relay
+
+# T2185: Clean leftover files (ddclient) from base package.
+# Was: hooks/live/20-rm_ddclient_hook.chroot
+etc/dhcp/dhclient-exit-hooks.d/ddclient
+etc/ddclient.conf
+
+# T3242: Add hook to prevent link_config redundancy call in systemd-udev.
+# 99-default.link rule always calls link_config thats trying to set autonegotiation and duplex even for PPP interfaces.
+# Need to delete this rule to prevent overhead on interface creation stage.
+# Was: hooks/live/82-cleanup-udev-rules.chroot
+lib/systemd/network/99-default.link
+
+# T3774: Disabled atop services.
+# Was: hooks/live/22-rm_cron_atop.chroot
+etc/cron.d/atop
+
+# T3912: Remove superfluous motd.d kernel version shell script.
+# Was: hooks/live/83-cleanup-etc-motd-d.chroot
+etc/update-motd.d/10-uname
+
+# T4415: We do not need any documentation on the system.
+# Copyright/licenses files are ignored for deletion.
+# Was: hooks/live/80-delete-docs.chroot
+usr/share/doc/*/!(copyright*|README*)
+usr/share/doc-base
+
+# T5468: We do not need any manpages on the system since man-binary is missing.
+# Was: hooks/live/80-delete-docs.chroot
+usr/local/man/*
+usr/local/share/man/*
+usr/share/man/*
+
+# T5511: We do not need any games on the system.
+# Was: hooks/live/80-delete-docs.chroot
+usr/games/*
+usr/local/games/*
+
+# T5511: We do not need any caches on the system (will be recreated when needed).
+# Was: hooks/live/80-delete-docs.chroot
 var/cache/*
+
+# T5511: We do not need any log-files on the system (will be recreated when needed).
+# Was: hooks/live/80-delete-docs.chroot
+var/log/alternatives.log
+var/log/bootstrap.log
+var/log/dpkg.log
+var/log/apt/history.log
+var/log/apt/term.log
+var/log/nginx/access.log
+var/log/nginx/error.log
+var/log/squidguard/squidGuard.log
+var/log/stunnel4/stunnel.log
+
+# T5511: We do not need any backup-files on the system.
+# Was: hooks/live/80-delete-docs.chroot
+etc/sudoers.bak
+etc/xml/catalog.old
+etc/xml/polkitd.xml.old
+etc/xml/xml-core.xml.old
+root/.gnupg/pubring.kbx~
+var/lib/dpkg/diversions-old
+var/lib/dpkg/status-old
+var/lib/sgml-base/supercatalog.old
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Continued work of T5511 and PR407.

Now when rootfs/excludes-file is verified to function as intended its time to remove hooks/live-scripts that removes files and directories so they will instead be excluded by the rootfs/excludes-file instead.

As a first attempt the original hooks/live-scripts have also been disabled (by commenting out their content).

If/when nightly build succeeds then the original hooks/live-scripts will be deleted in the next PR.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5511
* https://github.com/vyos/vyos-build/pull/407

Updates how the deletes are performed in following tasks:

* https://vyos.dev/T2185
* https://vyos.dev/T3242
* https://vyos.dev/T3774
* https://vyos.dev/T3912
* https://vyos.dev/T4415
* https://vyos.dev/T5468

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
To consolidate where "deletes", or as in this case "excludes", are performed to remove files and directories that are included in the final filesystem.squashfs the file rootfs/excludes will be used instead.

This makes the following hooks/live-scripts obsolete:

* hooks/live/20-rm_ddclient_hook.chroot
* hooks/live/22-rm_cron_atop.chroot
* hooks/live/80-delete-docs.chroot
* hooks/live/81-cleanup-etc-defaults.chroot
* hooks/live/82-cleanup-udev-rules.chroot
* hooks/live/83-cleanup-etc-motd-d.chroot

This PR moved all the "deletes" into rootfs/excludes-file (incl comments and references to tasks) and disabled the content of above hooks-live-scripts.

Next PR will also delete the above hooks/live-scripts.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
After build completes verify that the excluded files and directories no longer exists in the image.

Either by booting the system or extract the content of filesystem.squashfs by using "sudo unsquashfs filesystem.squashfs".

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
