### PR TITLE
T5511: Cleanup of unused directories (and files) in order to shrink image-size

### DIFF
--- a/data/live-build-config/rootfs/excludes
+++ b/data/live-build-config/rootfs/excludes
@@ -11,70 +11,49 @@
 
 # Txxx: Drop isc-dhcp helper files from /etc/default.
 # We use systemd to control ISC daemons from within vyos-1x.
-# Was: hooks/live/81-cleanup-etc-defaults.chroot
 etc/default/isc-dhcp-server
 etc/default/isc-dhcp-relay
 
 # T2185: Clean leftover files (ddclient) from base package.
-# Was: hooks/live/20-rm_ddclient_hook.chroot
 etc/dhcp/dhclient-exit-hooks.d/ddclient
 etc/ddclient.conf
 
 # T3242: Add hook to prevent link_config redundancy call in systemd-udev.
 # 99-default.link rule always calls link_config thats trying to set autonegotiation and duplex even for PPP interfaces.
 # Need to delete this rule to prevent overhead on interface creation stage.
-# Was: hooks/live/82-cleanup-udev-rules.chroot
 lib/systemd/network/99-default.link
 
 # T3774: Disabled atop services.
-# Was: hooks/live/22-rm_cron_atop.chroot
 etc/cron.d/atop
 
 # T3912: Remove superfluous motd.d kernel version shell script.
-# Was: hooks/live/83-cleanup-etc-motd-d.chroot
 etc/update-motd.d/10-uname
 
 # T4415: We do not need any documentation on the system.
 # Copyright/licenses files are ignored for deletion.
-# Was: hooks/live/80-delete-docs.chroot
 usr/share/doc/*/!(copyright*|README*)
 usr/share/doc-base
 
 # T5468: We do not need any manpages on the system since man-binary is missing.
-# Was: hooks/live/80-delete-docs.chroot
 usr/local/man/*
 usr/local/share/man/*
 usr/share/man/*
 
 # T5511: We do not need any games on the system.
-# Was: hooks/live/80-delete-docs.chroot
 usr/games/*
 usr/local/games/*
 
 # T5511: We do not need any caches on the system (will be recreated when needed).
-# Was: hooks/live/80-delete-docs.chroot
 var/cache/*
 
 # T5511: We do not need any log-files on the system (will be recreated when needed).
-# Was: hooks/live/80-delete-docs.chroot
-var/log/alternatives.log
-var/log/bootstrap.log
-var/log/dpkg.log
-var/log/apt/history.log
-var/log/apt/term.log
-var/log/nginx/access.log
-var/log/nginx/error.log
-var/log/squidguard/squidGuard.log
-var/log/stunnel4/stunnel.log
+var/log/*.log
+var/log/*/*.log
+var/log/*/*.log.xz
 
-# T5511: We do not need any backup-files on the system.
-# Was: hooks/live/80-delete-docs.chroot
-etc/sudoers.bak
-etc/xml/catalog.old
-etc/xml/polkitd.xml.old
-etc/xml/xml-core.xml.old
-root/.gnupg/pubring.kbx~
-var/lib/dpkg/diversions-old
-var/lib/dpkg/status-old
-var/lib/sgml-base/supercatalog.old
+# T5511: We do not need any backup-files on the system (will be recreated when needed).
+... *.bak
+... *.old
+... *.kbx~
+var/lib/dpkg/*-old
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Followup on T5511 and PR413.

Final cleanup and optimization of rootfs/exclude-file.

c-po took care of deleting the now obsolete hooks/live-scripts (mentioned in PR413) which this rootfs/exclude-file replaces.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5511
* https://github.com/vyos/vyos-build/pull/413

Includes updates of how the deletes are performed in following tasks:

https://vyos.dev/T2185
https://vyos.dev/T3242
https://vyos.dev/T3774
https://vyos.dev/T3912
https://vyos.dev/T4415
https://vyos.dev/T5468

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
This PR further optimizes the rootfs/excludes-file used by PR413 and PR407.

Main changes are comment cleanups and better use of wildcards to exclude *.log files in /var/log along with *.bak, *.old and others globally in chroot-directory.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
After build completes verify that the excluded files and directories no longer exists in the image.

Should be done either by mounting the squashfs-file or by extracting it (as example below).

Dont do the find from within a running VyOS because several files are recreated during runtime (and stored in persistence directory by overlayfs on the local drive).

The find below verifies that the files and directories that are supposed to be excluded have been properly excluded from the squashfs-file.

```
sudo unsquashfs filesystem.squashfs
sudo find ./squashfs-root -iname "*.log"
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
