### PR TITLE
smoketest: T5607: adjust for non-deterministic scsi device probing

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -453,12 +453,12 @@ try:
         c.expect(op_mode_prompt)
 
         log.info('Re-format new RAID member')
-        c.sendline('format disk sda like sdb')
+        c.sendline('format by-id disk drive-hd1 like drive-hd2')
         c.sendline('yes')
         c.expect(op_mode_prompt)
 
         log.info('Add member to RAID1 (md0)')
-        c.sendline('add raid md0 member sda1')
+        c.sendline('add raid md0 by-id member drive-hd1-part1')
         c.expect(op_mode_prompt)
 
         log.info('Now we need to wait for re-sync to complete')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

To be merged after https://github.com/vyos/vyos-1x/pull/2298 to resolve bug.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5607

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
