### PR TITLE
T5589: Nonstripped binaries exists in VyOS

### DIFF
--- a/data/live-build-config/hooks/live/99-strip-symbols.chroot
+++ b/data/live-build-config/hooks/live/99-strip-symbols.chroot
@@ -20,6 +20,8 @@ STRIPDIR_DEBUG="
 STRIPDIR_UNNEEDED="
 /etc/hsflowd/modules
 /usr/bin
+/usr/lib/openvpn
+/usr/lib/x86_64-linux-gnu
 /usr/lib32
 /usr/lib64
 /usr/libx32

--- a/data/live-build-config/hooks/live/99-strip-symbols.chroot
+++ b/data/live-build-config/hooks/live/99-strip-symbols.chroot
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+#
+# Discard symbols and other data from object files.
+#
+# Reference:
+# https://www.linuxfromscratch.org/lfs/view/systemd/chapter08/stripping.html
+# https://www.debian.org/doc/debian-policy/ch-files.html
+#
+
+# Set variables.
+STRIPCMD_REGULAR="strip --remove-section=.comment --remove-section=.note --preserve-dates"
+STRIPCMD_DEBUG="strip --strip-debug --remove-section=.comment --remove-section=.note --preserve-dates"
+STRIPCMD_UNNEEDED="strip --strip-unneeded --remove-section=.comment --remove-section=.note --preserve-dates"
+STRIPDIR_REGULAR="
+"
+STRIPDIR_DEBUG="
+/usr/lib/modules
+"
+STRIPDIR_UNNEEDED="
+/etc/hsflowd/modules
+/usr/bin
+/usr/lib32
+/usr/lib64
+/usr/libx32
+/usr/sbin
+"
+
+# Perform stuff.
+echo "Stripping symbols..."
+
+# CMD: strip
+for DIR in ${STRIPDIR_REGULAR}; do
+  echo "Parse dir (strip): ${DIR}"
+  find ${DIR} -type f -exec file {} \; | grep 'not stripped' | cut -d ":" -f 1 | while read FILE; do
+    echo "Strip file (strip): ${FILE}"
+    ${STRIPCMD_REGULAR} ${FILE}
+  done
+done
+
+# CMD: strip --strip-debug
+for DIR in ${STRIPDIR_DEBUG}; do
+  echo "Parse dir (strip-debug): ${DIR}"
+  find ${DIR} -type f -exec file {} \; | grep 'not stripped' | cut -d ":" -f 1 | while read FILE; do
+    echo "Strip file (strip-debug): ${FILE}"
+    ${STRIPCMD_DEBUG} ${FILE}
+  done
+done
+
+# CMD: strip --strip-unneeded
+for DIR in ${STRIPDIR_UNNEEDED}; do
+  echo "Parse dir (strip-unneeded: ${DIR}"
+  find ${DIR} -type f -exec file {} \; | grep 'not stripped' | cut -d ":" -f 1 | while read FILE; do
+    echo "Strip file (strip-unneeded): ${FILE}"
+    ${STRIPCMD_UNNEEDED} ${FILE}
+  done
+done
+
+# Remove binutils package.
+apt-get -y purge --autoremove binutils
+

--- a/data/live-build-config/package-lists/vyos-utils.list.chroot
+++ b/data/live-build-config/package-lists/vyos-utils.list.chroot
@@ -2,3 +2,4 @@ systemd-sysv
 systemd-bootchart
 ncurses-term
 kitty-terminfo
+binutils


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Running `rmlint -p -T "nonstripped" /path` shows that there exists some binaries (and libraries/modules) which arent stripped from symbols and other data yet.

This adds the capability to the build-process as a final hook within chroot to perform strip on non-stripped binaries/libraries/modules.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5589

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
1. Modified `data/live-build-config/package-lists/vyos-utils.list.chroot` to include package `binutils` who contains the `strip` binary.

2. Added file `data/live-build-config/hooks/live/99-strip-symbols.chroot` who performs the actual work of finding and properly stripping binaries/libraries/modules.

Note that kernel-modules are dealt by "strip --strip-debug".

There are three different variables to define which directories to scan with which method: `STRIPDIR_REGULAR`, `STRIPDIR_DEBUG` and `STRIPDIR_UNNEEDED`.

During scan the `file` utility is used to identify non-stripped files and by that only attempt `strip` on "not stripped" files.

Except for removing unwanted symbols and other data from the binaries/libraries/modules this also shrinks the total imagesize by approx 1 megabyte (from approx 391MB down to approx 390MB).

References:
https://www.linuxfromscratch.org/lfs/view/systemd/chapter08/stripping.html
https://www.debian.org/doc/debian-policy/ch-files.html

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Build 1.5-rolling with these changes and perform successful smoketests:

```
DEBUG - vyos@vyos:~$ echo EXITCODE:$?
DEBUG - echo EXITCODE:$?
DEBUG - EXITCODE:0
 INFO - Smoketest finished successfully!
 INFO - Powering off system
DEBUG - poweroff now
 INFO - Shutting down virtual machine
 INFO - Waiting for shutdown...
DEBUG - poweroff now
 INFO - Waiting for shutdown...
DEBUG - poweroff now
 INFO - VM is shut down!
 INFO - Cleaning up
 INFO - Removing disk file: testinstall-20230926-182601-5fec.img
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
