### PR TITLE
T5593: Further shrink VyOS imagesize, part 2/2

### DIFF
--- a/data/live-build-config/hooks/live/99-copy-linux-kernel.binary
+++ b/data/live-build-config/hooks/live/99-copy-linux-kernel.binary
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#
+# Copy Linux-kernel files from chroot/boot to binary/live.
+#
+
+# Set variables.
+CHROOTDIR="../chroot/boot/"
+LIVEDIR="./live/"
+
+# Perform stuff.
+echo "Copying kernel-files..."
+
+cp -a ${CHROOTDIR}/config-* ${LIVEDIR}
+cp -a ${CHROOTDIR}/initrd.img ${LIVEDIR}
+cp -a ${CHROOTDIR}/initrd.img-* ${LIVEDIR}
+cp -a ${CHROOTDIR}/System.map-* ${LIVEDIR}
+cp -a ${CHROOTDIR}/vmlinuz ${LIVEDIR}
+cp -a ${CHROOTDIR}/vmlinuz-* ${LIVEDIR}
+

--- a/data/live-build-config/hooks/live/99-copy-linux-kernel.binary
+++ b/data/live-build-config/hooks/live/99-copy-linux-kernel.binary
@@ -6,7 +6,10 @@
 
 # Set variables.
 CHROOTDIR="../chroot/boot/"
+ISOLINUXDIR="./isolinux/"
 LIVEDIR="./live/"
+BOOT_KERNEL="$(basename ${CHROOTDIR}/vmlinuz-*)"
+BOOT_INITRD="$(basename ${CHROOTDIR}/initrd.img-*)"
 
 # Perform stuff.
 echo "Copying kernel-files..."
@@ -17,4 +20,9 @@ cp -a ${CHROOTDIR}/initrd.img-* ${LIVEDIR}
 cp -a ${CHROOTDIR}/System.map-* ${LIVEDIR}
 cp -a ${CHROOTDIR}/vmlinuz ${LIVEDIR}
 cp -a ${CHROOTDIR}/vmlinuz-* ${LIVEDIR}
+
+echo "Updating isolinux/live.cfg..."
+
+sed -i "s/vmlinuz/${BOOT_KERNEL}/g" ${ISOLINUXDIR}/live.cfg
+sed -i "s/initrd.img/${BOOT_INITRD}/g" ${ISOLINUXDIR}/live.cfg
 

--- a/data/live-build-config/rootfs/excludes
+++ b/data/live-build-config/rootfs/excludes
@@ -57,3 +57,6 @@ var/log/*/*.log.xz
 ... *.kbx~
 var/lib/dpkg/*-old
 
+# T5593: Linux kernel exists in /live-path of the ISO and is copied during install.
+boot/!(initrd.img|vmlinuz)
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Further shrink VyOS imagesize (ISO) by moving Linux kernel-files out of the filesystem.squashfs and into the live-directory of the ISO.

This will save (according to tests) approx 31MB (the resulting nightly build should shrink from 391MB down to approx 360MB).

Note! There is a part 1/2 of this for vyatta-cfg-system that must be merged at the same time.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5593

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
In order to further shrink the VyOS imagesize (ISO) the Linux kernel-files have moved out of the filesystem.squashfs and into the live-directory of the ISO.

For this to properly work the Linux kernel-files have to be copied to the persistent boot-directory during install/upgrade.

Note! There is a part 1/2 of this for vyatta-cfg-system that must be merged at the same time.

For this to work following files have been modified:

* data/live-build-config/rootfs/excludes
Excludes all files in chroot/boot except the symlinks for initrd.img and vmlinuz from the filesystem.squashfs.

* data/live-build-config/hooks/live/99-copy-linux-kernel.binary
New file that makes sure to copy Linux-kernel files from chroot/boot to binary/live during the binary phase (creating ISO) when building VyOS.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Build 1.5-rolling where both part 1 and 2 are included and verify that all smoketests are successful like so:

```
DEBUG - vyos@vyos:~$ echo EXITCODE:$?
DEBUG - echo EXITCODE:$?
DEBUG - EXITCODE:0
 INFO - Smoketest finished successfully!
 INFO - Powering off system
DEBUG - vyos@vyos:~$ poweroff now
 INFO - Shutting down virtual machine
 INFO - Waiting for shutdown...
DEBUG - poweroff now
 INFO - Waiting for shutdown...
DEBUG - poweroff now
 INFO - VM is shut down!
 INFO - Cleaning up
 INFO - Removing disk file: testinstall-20230926-233250-071e.img
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
