### PR TITLE
pmacct: T5618: Added build rules for custom pmacct package

### DIFF
--- a/packages/pmacct/Jenkinsfile
+++ b/packages/pmacct/Jenkinsfile
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 VyOS maintainers and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// in order to easy exprort images built to "external" world
+// it under the terms of the GNU General Public License version 2 or later as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+@NonCPS
+
+// Using a version specifier library, use 'current' branch. The underscore (_)
+// is not a typo! You need this underscore if the line immediately after the
+// @Library annotation is not an import statement!
+@Library('vyos-build@current')_
+
+def package_name = 'pmacct'
+
+def pkgList = [
+    ['name': "${package_name}",
+     'scmCommit': 'debian/1.7.7-1',
+     'scmUrl': 'https://salsa.debian.org/debian/pmacct.git',
+     'buildCmd': "../build.py"],
+]
+
+// Start package build using library function from https://github.com/vyos/vyos-build
+buildPackage("${package_name}", pkgList, null, true, "**/packages/pmacct/**")

--- a/packages/pmacct/build.py
+++ b/packages/pmacct/build.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from shutil import copy as copy_file
+from subprocess import run
+
+
+# copy patches
+def apply_deb_patches() -> None:
+    """Apply patches to sources directory
+    """
+    patches_dir = Path('../patches')
+    current_dir: str = Path.cwd().as_posix()
+    if patches_dir.exists():
+        patches_list = list(patches_dir.iterdir())
+        patches_list.sort()
+        series_file = Path(f'{current_dir}/debian/patches/series')
+        series_data = ''
+        for patch_file in patches_list:
+            print(f'Applying patch: {patch_file.name}')
+            copy_file(patch_file, f'{current_dir}/debian/patches/')
+            if series_file.exists():
+                series_data: str = series_file.read_text()
+            series_data = f'{series_data}\n{patch_file.name}'
+            series_file.write_text(series_data)
+
+
+def build_package() -> bool:
+    """Build a package
+
+    Returns:
+        bool: build status
+    """
+    build_cmd: list[str] = ['dpkg-buildpackage', '-uc', '-us', '-tc', '-b']
+    build_status: int = run(build_cmd).returncode
+
+    if not build_status:
+        return False
+    return True
+
+
+# build a package
+if __name__ == '__main__':
+    apply_deb_patches()
+
+    if not build_package():
+        exit(1)
+
+    exit()

--- a/packages/pmacct/patches/0001-fix-pmacctd-SEGV-when-ICMP-ICMPv6-traffic-was-proces.patch
+++ b/packages/pmacct/patches/0001-fix-pmacctd-SEGV-when-ICMP-ICMPv6-traffic-was-proces.patch
@@ -1,0 +1,49 @@
+From 58900c9d0f98f224577c28dc2323061d33823f39 Mon Sep 17 00:00:00 2001
+From: Paolo Lucente <pl+github@pmacct.net>
+Date: Fri, 4 Mar 2022 22:07:29 +0000
+Subject: [PATCH] * fix, pmacctd: SEGV when ICMP/ICMPv6 traffic was processed
+ and 'flows' primitive was enabled. To address Issue #586
+
+---
+ src/nl.c | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
+
+diff --git a/src/nl.c b/src/nl.c
+index c42689ed..6a3da94b 100644
+--- a/src/nl.c
++++ b/src/nl.c
+@@ -1,6 +1,6 @@
+ /*
+     pmacct (Promiscuous mode IP Accounting package)
+-    pmacct is Copyright (C) 2003-2021 by Paolo Lucente
++    pmacct is Copyright (C) 2003-2022 by Paolo Lucente
+ */
+ 
+ /*
+@@ -293,10 +293,7 @@ int ip_handler(register struct packet_ptrs *pptrs)
+       }
+     }
+     else {
+-      if (pptrs->l4_proto != IPPROTO_ICMP) {
+-        pptrs->tlh_ptr = dummy_tlhdr;
+-      }
+-
++      pptrs->tlh_ptr = dummy_tlhdr;
+       if (off < caplen) pptrs->payload_ptr = ptr;
+     }
+ 
+@@ -479,10 +476,7 @@ int ip6_handler(register struct packet_ptrs *pptrs)
+       }
+     }
+     else {
+-      if (pptrs->l4_proto != IPPROTO_ICMPV6) {
+-        pptrs->tlh_ptr = dummy_tlhdr;
+-      }
+-
++      pptrs->tlh_ptr = dummy_tlhdr;
+       if (off < caplen) pptrs->payload_ptr = ptr;
+     }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added build rules for custom pmacct package

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5618

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
pmacct

## Proposed changes
<!--- Describe your changes in detail -->
The current version of pmacct in Debian (`1.7.7-1`) contains the bug which leads to a crash when IMT is enabled and ICMP traffic is forwarded through a router.

This PR adds our build with an extra patch, which solves the problem: https://github.com/pmacct/pmacct/commit/73af9545ea33cd87846306f648f634063ac41765

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration for tests:
```
set system flow-accounting interface 'eth0'
set system flow-accounting netflow server 192.168.139.1 port '2055'
```

Without the patched pmacct version, as soon as `eth0` receives an ICMP packet pmacct will crash.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
