### PR TITLE
T5624: add a hook for deleting /etc/debian_version

### DIFF
--- a/data/live-build-config/hooks/live/30-remove-debian-version.chroot
+++ b/data/live-build-config/hooks/live/30-remove-debian-version.chroot
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# The /etc/debian_version file contains the Debian release version number.
+#Since VyOS uses image-based upgrade, that file serves no useful purpose for us.
+#
+# However, security scanners love to jump to conclusions
+# and declare an "old Debian version" vulnerable
+# without checking if there may not be any packages from that version at all.
+# Removing that file is an easy way to get fewer false positives.
+
+echo "I: Deleting the Debian version file"
+
+rm -f /etc/debian_version


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Remove `/etc/debian_version` at build time since that file has no purpose in VyOS but frequently leads to security scanner false positives.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): internal change.

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5624


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
