### PR TITLE
T5589: Nonstripped binaries exists in VyOS

### DIFF
--- a/data/live-build-config/hooks/live/99-strip-symbols.chroot
+++ b/data/live-build-config/hooks/live/99-strip-symbols.chroot
@@ -27,16 +27,23 @@ STRIPDIR_UNNEEDED="
 /usr/libx32
 /usr/sbin
 "
+STRIP_EXCLUDE=`dpkg-query -L libbinutils | grep '.so'`
 
 # Perform stuff.
 echo "Stripping symbols..."
+
+# List excluded files.
+echo "Exclude files: ${STRIP_EXCLUDE}"
 
 # CMD: strip
 for DIR in ${STRIPDIR_REGULAR}; do
   echo "Parse dir (strip): ${DIR}"
   find ${DIR} -type f -exec file {} \; | grep 'not stripped' | cut -d ":" -f 1 | while read FILE; do
-    echo "Strip file (strip): ${FILE}"
-    ${STRIPCMD_REGULAR} ${FILE}
+    echo "${STRIP_EXCLUDE}" | grep -F -q -w "${FILE}"
+    if [ $? -ne 0 ]; then
+      echo "Strip file (strip): ${FILE}"
+      ${STRIPCMD_REGULAR} ${FILE}
+    fi
   done
 done
 
@@ -44,8 +51,11 @@ done
 for DIR in ${STRIPDIR_DEBUG}; do
   echo "Parse dir (strip-debug): ${DIR}"
   find ${DIR} -type f -exec file {} \; | grep 'not stripped' | cut -d ":" -f 1 | while read FILE; do
-    echo "Strip file (strip-debug): ${FILE}"
-    ${STRIPCMD_DEBUG} ${FILE}
+    echo "${STRIP_EXCLUDE}" | grep -F -q -w "${FILE}"
+    if [ $? -ne 0 ]; then
+      echo "Strip file (strip-debug): ${FILE}"
+      ${STRIPCMD_DEBUG} ${FILE}
+    fi
   done
 done
 
@@ -53,8 +63,11 @@ done
 for DIR in ${STRIPDIR_UNNEEDED}; do
   echo "Parse dir (strip-unneeded: ${DIR}"
   find ${DIR} -type f -exec file {} \; | grep 'not stripped' | cut -d ":" -f 1 | while read FILE; do
-    echo "Strip file (strip-unneeded): ${FILE}"
-    ${STRIPCMD_UNNEEDED} ${FILE}
+    echo "${STRIP_EXCLUDE}" | grep -F -q -w "${FILE}"
+    if [ $? -ne 0 ]; then
+      echo "Strip file (strip-unneeded): ${FILE}"
+      ${STRIPCMD_UNNEEDED} ${FILE}
+    fi
   done
 done
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add capability to exclude files from being stripped by `data/live-build-config/hooks/live/99-strip-symbols.chroot`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5589

Follow up on:

* https://github.com/vyos/vyos-build/pull/426

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->

Turns out that package binutils contains libraries who have not been stripped according to Debian policy:

```
Parse dir (strip-unneeded: /usr/lib/x86_64-linux-gnu
Strip file (strip-unneeded): /usr/lib/x86_64-linux-gnu/libsframe.so.0.0.0
/root/99-strip-symbols.chroot: line 53: 52424 Segmentation fault      (core dumped) ${STRIPCMD_UNNEEDED} ${FILE}
Strip file (strip-unneeded): /usr/lib/x86_64-linux-gnu/libusdm_drv_s.so
Parse dir (strip-unneeded: /usr/lib32
```

This commit add variable `STRIP_EXCLUDE` to exclude files from being stripped by the `99-strip-symbols.chroot` script.

Currently the files to be excluded are added dynamically to be compatible with future updates of the libbinutils package (installed by package binutils):

```
STRIP_EXCLUDE=`dpkg-query -L libbinutils | grep '.so'`
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

During build of ISO the log output should look something like this (good):

```
Exclude files: /usr/lib/x86_64-linux-gnu/libbfd-2.40-system.so
/usr/lib/x86_64-linux-gnu/libopcodes-2.40-system.so
/usr/lib/x86_64-linux-gnu/libsframe.so.0.0.0
/usr/lib/x86_64-linux-gnu/libsframe.so.0
Parse dir (strip-debug): /usr/lib/modules
...
Parse dir (strip-unneeded: /usr/lib/x86_64-linux-gnu
Strip file (strip-unneeded): /usr/lib/x86_64-linux-gnu/libusdm_drv_s.so
Parse dir (strip-unneeded: /usr/lib32
```

rather than this (bad):

```
Parse dir (strip-unneeded: /usr/lib/x86_64-linux-gnu
Strip file (strip-unneeded): /usr/lib/x86_64-linux-gnu/libsframe.so.0.0.0
/root/99-strip-symbols.chroot: line 53: 52424 Segmentation fault      (core dumped) ${STRIPCMD_UNNEEDED} ${FILE}
Strip file (strip-unneeded): /usr/lib/x86_64-linux-gnu/libusdm_drv_s.so
Parse dir (strip-unneeded: /usr/lib32
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
