### PR TITLE
T5619: Add out-of-tree Intel ixgbe driver

### DIFF
--- a/packages/linux-kernel/build-intel-ixgbe.sh
+++ b/packages/linux-kernel/build-intel-ixgbe.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+CWD=$(pwd)
+KERNEL_VAR_FILE=${CWD}/kernel-vars
+
+if ! dpkg-architecture -iamd64; then
+    echo "Intel ixgbe is only buildable on amd64 platforms"
+    exit 0
+fi
+
+if [ ! -f ${KERNEL_VAR_FILE} ]; then
+    echo "Kernel variable file '${KERNEL_VAR_FILE}' does not exist, run ./build_kernel.sh first"
+    exit 1
+fi
+
+. ${KERNEL_VAR_FILE}
+
+url="https://sourceforge.net/projects/e1000/files/ixgbe%20stable/5.19.6/ixgbe-5.19.6.tar.gz"
+
+cd ${CWD}
+
+DRIVER_FILE=$(basename ${url} | sed -e s/tar_0/tar/)
+DRIVER_DIR="${DRIVER_FILE%.tar.gz}"
+DRIVER_NAME="ixgbe"
+DRIVER_VERSION=$(echo ${DRIVER_DIR} | awk -F${DRIVER_NAME} '{print $2}' | sed 's/^-//')
+DRIVER_VERSION_EXTRA=""
+
+# Build up Debian related variables required for packaging
+DEBIAN_ARCH=$(dpkg --print-architecture)
+DEBIAN_DIR="${CWD}/vyos-intel-${DRIVER_NAME}_${DRIVER_VERSION}_${DEBIAN_ARCH}"
+DEBIAN_CONTROL="${DEBIAN_DIR}/DEBIAN/control"
+DEBIAN_POSTINST="${CWD}/vyos-intel-ixgbe.postinst"
+
+# Fetch Intel driver source from SourceForge
+if [ -e ${DRIVER_FILE} ]; then
+    rm -f ${DRIVER_FILE}
+fi
+curl -L -o ${DRIVER_FILE} ${url}
+if [ "$?" -ne "0" ]; then
+    exit 1
+fi
+
+# Unpack archive
+if [ -d ${DRIVER_DIR} ]; then
+    rm -rf ${DRIVER_DIR}
+fi
+mkdir -p ${DRIVER_DIR}
+tar -C ${DRIVER_DIR} --strip-components=1 -xf ${DRIVER_FILE}
+
+cd ${DRIVER_DIR}/src
+if [ -z $KERNEL_DIR ]; then
+    echo "KERNEL_DIR not defined"
+    exit 1
+fi
+
+echo "I: Compile Kernel module for Intel ${DRIVER_NAME} driver"
+make INSTALL_MOD_PATH=${DEBIAN_DIR} INSTALL_FW_PATH=${DEBIAN_DIR} -j $(getconf _NPROCESSORS_ONLN) install
+
+if [ "x$?" != "x0" ]; then
+    exit 1
+fi
+
+if [ -f ${DEBIAN_DIR}.deb ]; then
+    rm ${DEBIAN_DIR}.deb
+fi
+
+# build Debian package
+echo "I: Building Debian package vyos-intel-${DRIVER_NAME}"
+cd ${CWD}
+
+# delete non required files which are also present in the kernel package
+# und thus lead to duplicated files
+find ${DEBIAN_DIR} -name "modules.*" | xargs rm -f
+
+echo "#!/bin/sh" > ${DEBIAN_POSTINST}
+echo "/sbin/depmod -a ${KERNEL_VERSION}${KERNEL_SUFFIX}" >> ${DEBIAN_POSTINST}
+
+fpm --input-type dir --output-type deb --name vyos-intel-${DRIVER_NAME} \
+    --version ${DRIVER_VERSION} --deb-compression gz \
+    --maintainer "VyOS Package Maintainers <maintainers@vyos.net>" \
+    --description "Vendor based driver for Intel ${DRIVER_NAME}" \
+    --depends linux-image-${KERNEL_VERSION}${KERNEL_SUFFIX} \
+    --license "GPL2" -C ${DEBIAN_DIR} --after-install ${DEBIAN_POSTINST}
+
+echo "I: Cleanup ${DRIVER_NAME} source"
+cd ${CWD}
+if [ -e ${DRIVER_FILE} ]; then
+    rm -f ${DRIVER_FILE}
+fi
+if [ -d ${DRIVER_DIR} ]; then
+    rm -rf ${DRIVER_DIR}
+fi
+if [ -d ${DEBIAN_DIR} ]; then
+    rm -rf ${DEBIAN_DIR}
+fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Adding building ixgbe out-of-tree module to be included in kernel as the in-kernel one doesn't work with Intel X533.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5619

## Component(s) name
kernel

## Proposed changes

Build ixgbe out-of-tree driver and include it in resulting ISO

## How to test

This requires an ixgbe compatible nic, but I have tested it on my hardware and it works, however for the build to be successful, one needs to modify Intel's packaged common.mk to look for the right directory for the kernel sources, and there may be an issue in ixgbe_main.c that it will complain undefined VXLAN_HEADROOM variable.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
