### PR TITLE
pmacct: T5663: the garbage headers issue fix

### DIFF
--- a/packages/pmacct/Jenkinsfile
+++ b/packages/pmacct/Jenkinsfile
@@ -21,12 +21,12 @@
 @Library('vyos-build@current')_
 
 def package_name = 'pmacct'
-
+// "sudo apt-get remove git -y" is necessary for solving this issue https://vyos.dev/T5663
 def pkgList = [
     ['name': "${package_name}",
      'scmCommit': 'debian/1.7.7-1',
      'scmUrl': 'https://salsa.debian.org/debian/pmacct.git',
-     'buildCmd': 'sudo mk-build-deps --install --tool "apt-get --yes --no-install-recommends"; ../build.py'],
+     'buildCmd': 'sudo mk-build-deps --install --tool "apt-get --yes --no-install-recommends"; sudo apt-get remove git -y; ../build.py'],
 ]
 
 // Start package build using library function from https://github.com/vyos/vyos-build


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Unwanted files under \*/src/external_libs/rootfs/\* were excluded from a resulting deb package
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5663

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* pmacct
## Proposed changes
<!--- Describe your changes in detail -->
Remove a git package from the VyOS-build container to forcefully fix the automake deep bug.
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
dpkg -c pmacct_1.7.7-1_amd64.deb
```
There is should be no files under \*/src/external_libs/rootfs/\* path.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
