### PR TITLE
keepalived:T5402:Added patch with arp_ignore to 1 on IPv6 VMACs

### DIFF
--- a/packages/keepalived/.gitignore
+++ b/packages/keepalived/.gitignore
@@ -1,0 +1,1 @@
+keepalived/

--- a/packages/keepalived/Jenkinsfile
+++ b/packages/keepalived/Jenkinsfile
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 VyOS maintainers and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// in order to easy exprort images built to "external" world
+// it under the terms of the GNU General Public License version 2 or later as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+@NonCPS
+
+// Using a version specifier library, use 'current' branch. The underscore (_)
+// is not a typo! You need this underscore if the line immediately after the
+// @Library annotation is not an import statement!
+@Library('vyos-build@current')_
+
+def package_name = 'keepalived'
+
+def pkgList = [
+    ['name': "${package_name}",
+     'scmCommit': 'debian/1%2.2.7-1',
+     'scmUrl': 'https://salsa.debian.org/debian/pkg-keepalived.git',
+     'buildCmd': 'sudo mk-build-deps --install --tool "apt-get --yes --no-install-recommends"; ../build.py'],
+]
+
+// Start package build using library function from https://github.com/vyos/vyos-build
+buildPackage("${package_name}", pkgList, null, true, "**/packages/${package_name}/**")

--- a/packages/keepalived/build.py
+++ b/packages/keepalived/build.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from shutil import copy as copy_file
+from subprocess import run
+
+
+# copy patches
+def apply_deb_patches() -> None:
+    """Apply patches to sources directory
+    """
+    patches_dir = Path('../patches')
+    current_dir: str = Path.cwd().as_posix()
+    if patches_dir.exists():
+        patches_list = list(patches_dir.iterdir())
+        patches_list.sort()
+        Path(f'{current_dir}/debian/patches').mkdir(parents=True, exist_ok=True)
+        series_file = Path(f'{current_dir}/debian/patches/series')
+        series_data = ''
+        for patch_file in patches_list:
+            print(f'Applying patch: {patch_file.name}')
+            copy_file(patch_file, f'{current_dir}/debian/patches/')
+            if series_file.exists():
+                series_data: str = series_file.read_text()
+            series_data = f'{series_data}\n{patch_file.name}'
+            series_file.write_text(series_data)
+
+
+def build_package() -> bool:
+    """Build a package
+
+    Returns:
+        bool: build status
+    """
+    build_cmd: list[str] = ['dpkg-buildpackage', '-uc', '-us', '-tc', '-b']
+    build_status: int = run(build_cmd).returncode
+
+    if build_status:
+        return False
+    return True
+
+
+# build a package
+if __name__ == '__main__':
+    apply_deb_patches()
+
+    if not build_package():
+        exit(1)
+
+    exit()

--- a/packages/keepalived/patches/0001-vrrp-Set-sysctl-arp_ignore-to-1-on-IPv6-VMACs.patch
+++ b/packages/keepalived/patches/0001-vrrp-Set-sysctl-arp_ignore-to-1-on-IPv6-VMACs.patch
@@ -1,0 +1,129 @@
+From af4aa758c3512bec8233549e138b03741c5404f9 Mon Sep 17 00:00:00 2001
+From: Quentin Armitage <quentin@armitage.org.uk>
+Date: Sat, 14 Oct 2023 15:37:19 +0100
+Subject: [PATCH] vrrp: Set sysctl arp_ignore to 1 on IPv6 VMACs
+
+Setting arp_ignore to 1 ensures that the VMAC interface does not respond
+to ARP requests for IPv4 addresses not configured on the VMAC.
+
+Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>
+---
+ keepalived/include/vrrp_if_config.h |  2 +-
+ keepalived/vrrp/vrrp_if_config.c    | 28 ++++++++++++++++++++--------
+ keepalived/vrrp/vrrp_vmac.c         |  5 ++---
+ 3 files changed, 23 insertions(+), 12 deletions(-)
+
+diff --git a/keepalived/include/vrrp_if_config.h b/keepalived/include/vrrp_if_config.h
+index 35465cd..c35e56e 100644
+--- a/keepalived/include/vrrp_if_config.h
++++ b/keepalived/include/vrrp_if_config.h
+@@ -34,7 +34,7 @@ extern void set_promote_secondaries(interface_t*);
+ extern void reset_promote_secondaries(interface_t*);
+ #ifdef _HAVE_VRRP_VMAC_
+ extern void restore_rp_filter(void);
+-extern void set_interface_parameters(const interface_t*, interface_t*);
++extern void set_interface_parameters(const interface_t*, interface_t*, sa_family_t);
+ extern void reset_interface_parameters(interface_t*);
+ extern void link_set_ipv6(const interface_t*, bool);
+ #endif
+diff --git a/keepalived/vrrp/vrrp_if_config.c b/keepalived/vrrp/vrrp_if_config.c
+index cfce7e2..fbfd34c 100644
+--- a/keepalived/vrrp/vrrp_if_config.c
++++ b/keepalived/vrrp/vrrp_if_config.c
+@@ -81,6 +81,11 @@ static sysctl_opts_t vmac_sysctl[] = {
+ 	{ 0, 0}
+ };
+ 
++static sysctl_opts_t vmac_sysctl_6[] = {
++	{ IPV4_DEVCONF_ARP_IGNORE, 1 },
++	{ 0, 0}
++};
++
+ #endif
+ #endif
+ 
+@@ -216,11 +221,14 @@ netlink_set_interface_flags(unsigned ifindex, const sysctl_opts_t *sys_opts)
+ 
+ #ifdef _HAVE_VRRP_VMAC_
+ static inline int
+-netlink_set_interface_parameters(const interface_t *ifp, interface_t *base_ifp)
++netlink_set_interface_parameters(const interface_t *ifp, interface_t *base_ifp, sa_family_t family)
+ {
+-	if (netlink_set_interface_flags(ifp->ifindex, vmac_sysctl))
++	if (netlink_set_interface_flags(ifp->ifindex, family == AF_INET6 ? vmac_sysctl_6 : vmac_sysctl))
+ 		return -1;
+ 
++	if (family == AF_INET6)
++		return 0;
++
+ 	/* If the underlying interface is a MACVLAN that has been moved into
+ 	 * a separate network namespace from the parent, we can't access the
+ 	 * parent. */
+@@ -271,9 +279,9 @@ netlink_reset_interface_parameters(const interface_t* ifp)
+ }
+ 
+ static inline void
+-set_interface_parameters_devconf(const interface_t *ifp, interface_t *base_ifp)
++set_interface_parameters_devconf(const interface_t *ifp, interface_t *base_ifp, sa_family_t family)
+ {
+-	if (netlink_set_interface_parameters(ifp, base_ifp))
++	if (netlink_set_interface_parameters(ifp, base_ifp, family))
+ 		log_message(LOG_INFO, "Unable to set parameters for %s", ifp->ifname);
+ }
+ 
+@@ -310,11 +318,15 @@ reset_promote_secondaries_devconf(interface_t *ifp)
+ 
+ #ifdef _HAVE_VRRP_VMAC_
+ static inline void
+-set_interface_parameters_sysctl(const interface_t *ifp, interface_t *base_ifp)
++set_interface_parameters_sysctl(const interface_t *ifp, interface_t *base_ifp, sa_family_t family)
+ {
+ 	unsigned val;
+ 
+ 	set_sysctl("net/ipv4/conf", ifp->ifname, "arp_ignore", 1);
++
++	if (family == AF_INET6)
++		return;
++
+ 	set_sysctl("net/ipv4/conf", ifp->ifname, "accept_local", 1);
+ 	set_sysctl("net/ipv4/conf", ifp->ifname, "rp_filter", 0);
+ 
+@@ -524,15 +536,15 @@ restore_rp_filter(void)
+ }
+ 
+ void
+-set_interface_parameters(const interface_t *ifp, interface_t *base_ifp)
++set_interface_parameters(const interface_t *ifp, interface_t *base_ifp, sa_family_t family)
+ {
+ 	if (all_rp_filter == UINT_MAX)
+ 		clear_rp_filter();
+ 
+ #ifdef _HAVE_IPV4_DEVCONF_
+-	set_interface_parameters_devconf(ifp, base_ifp);
++	set_interface_parameters_devconf(ifp, base_ifp, family);
+ #else
+-	set_interface_parameters_sysctl(ifp, base_ifp);
++	set_interface_parameters_sysctl(ifp, base_ifp, family);
+ #endif
+ }
+ 
+diff --git a/keepalived/vrrp/vrrp_vmac.c b/keepalived/vrrp/vrrp_vmac.c
+index e5ff0e9..021953a 100644
+--- a/keepalived/vrrp/vrrp_vmac.c
++++ b/keepalived/vrrp/vrrp_vmac.c
+@@ -407,10 +407,9 @@ netlink_link_add_vmac(vrrp_t *vrrp, const interface_t *old_interface)
+ 	if (!ifp->ifindex)
+ 		return false;
+ 
+-	if (vrrp->family == AF_INET && create_interface) {
++	if (create_interface) {
+ 		/* Set the necessary kernel parameters to make macvlans work for us */
+-// If this saves current base_ifp's settings, we need to be careful if multiple VMACs on same i/f
+-		set_interface_parameters(ifp, ifp->base_ifp);
++		set_interface_parameters(ifp, ifp->base_ifp, vrrp->family);
+ 	}
+ 
+ #ifdef _WITH_FIREWALL_
+-- 
+2.34.1
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added patch with commit '9ca8688' to pkg-keepalived 1:2.2.7-1 https://github.com/acassen/keepalived/commit/9ca8688c7fe591e1face259f19ee6169e20a3438 
Setting arp_ignore to 1 ensures that the VMAC interface does not respond to ARP requests for IPv4 addresses not configured on the VMAC.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5402

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
keepalived

## Proposed changes
<!--- Describe your changes in detail -->
Added patch with commit '9ca8688' to pkg-keepalived 1:2.2.7-1 https://github.com/acassen/keepalived/commit/9ca8688c7fe591e1face259f19ee6169e20a3438 
Setting arp_ignore to 1 ensures that the VMAC interface does not respond to ARP requests for IPv4 addresses not configured on the VMAC.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Configuration:
```
set high-availability vrrp group 10 address 10.0.0.1/24
set high-availability vrrp group 10 interface 'eth1'
set high-availability vrrp group 10 rfc3768-compatibility
set high-availability vrrp group 10 vrid '10'
set high-availability vrrp group 20 address 2001:fd01::1/64
set high-availability vrrp group 20 interface 'eth1'
set high-availability vrrp group 20 rfc3768-compatibility
set high-availability vrrp group 20 vrid '20'
set interfaces ethernet eth1 address '10.0.0.2/24'
set interfaces ethernet eth1 address '2001:fd01::2/64'
```
Before changes:
TCPDUMP output
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
12:34:52.498795 ARP, Request who-has 10.0.0.1 (Broadcast) tell 10.0.0.10, length 50
12:34:52.498848 ARP, Reply 10.0.0.1 is-at 00:00:5e:00:02:14 (oui IANA), length 28
12:34:52.498899 ARP, Reply 10.0.0.1 is-at 00:00:5e:00:01:0a (oui IANA), length 28
```

After changes:
TCPDUMP output
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
12:25:33.843113 ARP, Request who-has 10.0.0.1 (Broadcast) tell 10.0.0.10, length 50
12:25:33.843195 ARP, Reply 10.0.0.1 is-at 00:00:5e:00:01:0a (oui IANA), length 28
```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
