### PR TITLE
T5695: Add LUA script to build FRR

### DIFF
--- a/packages/frr/build-frr.sh
+++ b/packages/frr/build-frr.sh
@@ -29,8 +29,12 @@ if [ -d $PATCH_DIR ]; then
     done
 fi
 
+echo "I: Ensure Debian build dependencies are met"
+sudo apt-get -y install chrpath gawk install-info libcap-dev libjson-c-dev
+sudo apt-get -y install libpam-dev libprotobuf-c-dev libpython3-dev:native libsnmp-dev protobuf-c-compiler python3-dev:native texinfo lua5.3
+
 # Build Debian FRR package
 echo "I: Build Debian FRR Package"
 # extract "real" git commit for FRR version identifier
 dch -v "$(git describe | cut -c5-)" "VyOS build - FRR"
-dpkg-buildpackage -us -uc -tc -b -Ppkg.frr.rtrlib
+dpkg-buildpackage -us -uc -tc -b -Ppkg.frr.rtrlib,pkg.frr.lua


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Build FRR with LUA scripts --enable-scripting option.
I think it also requires dependencies which in example
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5695

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
FRR, build
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
sudo apt install chrpath gawk install-info libcap-dev libjson-c-dev
sudo apt install libpam-dev libprotobuf-c-dev libpython3-dev:native libsnmp-dev protobuf-c-compiler python3-dev:native texinfo lua5.3

./build-frr.sh
```
FRR
```
r4# conf t
r4(config)# 
r4(config)# 
r4(config)# route-map FOO permit 100
r4(config-route-map)# 
r4(config-route-map)# match script 
  WORD  The script name to run, without .lua; e.g. 'myroutemap' to run myroutemap.lua

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
