### PR TITLE
T5689: Include librtr-dev in Debian dependencies to fix RPKI crash

### DIFF
--- a/packages/frr/build-frr.sh
+++ b/packages/frr/build-frr.sh
@@ -30,7 +30,7 @@ if [ -d $PATCH_DIR ]; then
 fi
 
 echo "I: Ensure Debian build dependencies are met"
-sudo apt-get -y install chrpath gawk install-info libcap-dev libjson-c-dev
+sudo apt-get -y install chrpath gawk install-info libcap-dev libjson-c-dev librtr-dev
 sudo apt-get -y install libpam-dev libprotobuf-c-dev libpython3-dev:native libsnmp-dev protobuf-c-compiler python3-dev:native texinfo lua5.3
 
 # Build Debian FRR package


### PR DESCRIPTION
This fixes FRR crashing on vtysh -c "show rpki $prefix" with the vyos build when librtr-dev was not available at FRR built time, see T5689.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added librtr-dev to frr build dependencies ensured via the build script.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5689

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
bgp

## Proposed changes
<!--- Describe your changes in detail -->
Add librtr-dev to build dependency installation

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
After rebuilding frr with this change, `show rpki $prefix` shold no longer crash bgpd, see https://vyos.dev/T5689.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
