### PR TITLE
T5809: live-build-config: insmod gzio for vmlinuz kernels on arm64

### DIFF
--- a/data/live-build-config/bootloaders/grub-pc/grub.cfg
+++ b/data/live-build-config/bootloaders/grub-pc/grub.cfg
@@ -4,6 +4,7 @@ set timeout=10
 insmod serial
 serial --unit=0 --speed=115200
 
+insmod gzio
 insmod part_msdos
 insmod ext2
 insmod efi_gop


### PR DESCRIPTION
## Change Summary
Without this, GRUB will report a 'invalid magic' or 'missing UEFI stub' error when loading kernels on arm64.

This change has no effect on x86-64 systems.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

https://vyos.dev/T5809

## Component(s) name
grub, live-build
(A separate patch may be required for vyos-1x for GRUB when installed to disk, I will check this)

## Proposed changes
This change enables the `gzio` (gzip support) module in grub, allowing it to decompress
gzip compressed kernel images (vmlinuz), which is the default kernel binary on Arm64 systems.
Adding gzio does not have any side effects on x86-64.

## How to test
Build a VyOS ISO and boot it on both a arm64 and amd64(x86-64) system.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
