### PR TITLE
initramfs: T5824: Added `openssl.cnf` to initramfs

### DIFF
--- a/data/live-build-config/includes.chroot/etc/initramfs-tools/hooks/10-vyos-addons
+++ b/data/live-build-config/includes.chroot/etc/initramfs-tools/hooks/10-vyos-addons
@@ -33,3 +33,4 @@ copy_exec /usr/sbin/fsck.ext4
 
 # copy other files ("other" here is a file type, so do not delete this keyword)
 copy_file other /etc/ssl/certs/ca-certificates.crt
+copy_file other /etc/ssl/openssl.cnf


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Added `openssl.cnf` to initramfs

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5824

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
initramfs, openssl, busybox

## Proposed changes
<!--- Describe your changes in detail -->
Without `openssl.cnf` software that uses `libssl` (for example busybox) has issues with connections to some HTTPS servers.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Boot to initramfs and use `wget` command to fetch data from HTTPS servers with specific security settings.

```
(initramfs) busybox wget https://.../
```

Without config, a server can reset the connection:
```
wget: TLS error from peer (alert code 40): handshake failure
wget: error getting response: Connection reset by peer
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
