### PR TITLE
Kernel: T4928: add "set -e" to kernel build script (backport)

### DIFF
--- a/packages/linux-kernel/build-kernel.sh
+++ b/packages/linux-kernel/build-kernel.sh
@@ -2,6 +2,8 @@
 CWD=$(pwd)
 KERNEL_SRC=linux
 
+set -e
+
 if [ ! -d ${KERNEL_SRC} ]; then
     echo "Linux Kernel source directory does not exists, please 'git clone'"
     exit 1

--- a/packages/linux-kernel/patches/kernel/0001-linkstate-ip-device-attribute.patch
+++ b/packages/linux-kernel/patches/kernel/0001-linkstate-ip-device-attribute.patch
@@ -18,10 +18,10 @@ Backport of earlier Vyatta patch.
  8 files changed, 34 insertions(+)
 
 diff --git a/Documentation/networking/ip-sysctl.rst b/Documentation/networking/ip-sysctl.rst
-index e7b3fa7bb3f7..081b344ea52b 100644
+index b47b3d0ce559..a91044bd5afe 100644
 --- a/Documentation/networking/ip-sysctl.rst
 +++ b/Documentation/networking/ip-sysctl.rst
-@@ -1592,6 +1592,17 @@ src_valid_mark - BOOLEAN
+@@ -1609,6 +1609,17 @@ src_valid_mark - BOOLEAN
  
  	Default value is 0.
  
@@ -52,10 +52,10 @@ index ddb27fc0ee8c..8ee3191d9558 100644
  struct in_ifaddr {
  	struct hlist_node	hash;
 diff --git a/include/linux/ipv6.h b/include/linux/ipv6.h
-index 37dfdcfcdd54..d549006be04c 100644
+index 9a44de45cc1f..78f0896ae755 100644
 --- a/include/linux/ipv6.h
 +++ b/include/linux/ipv6.h
-@@ -83,6 +83,7 @@ struct ipv6_devconf {
+@@ -84,6 +84,7 @@ struct ipv6_devconf {
  	__u8		ndisc_evict_nocarrier;
  
  	struct ctl_table_header *sysctl_header;
@@ -64,10 +64,10 @@ index 37dfdcfcdd54..d549006be04c 100644
  
  struct ipv6_params {
 diff --git a/include/uapi/linux/ip.h b/include/uapi/linux/ip.h
-index 874a92349bf5..37a9c7c7b56c 100644
+index 283dec7e3645..8067941a635e 100644
 --- a/include/uapi/linux/ip.h
 +++ b/include/uapi/linux/ip.h
-@@ -172,6 +172,7 @@ enum
+@@ -173,6 +173,7 @@ enum
  	IPV4_DEVCONF_DROP_GRATUITOUS_ARP,
  	IPV4_DEVCONF_BC_FORWARDING,
  	IPV4_DEVCONF_ARP_EVICT_NOCARRIER,
@@ -76,19 +76,19 @@ index 874a92349bf5..37a9c7c7b56c 100644
  };
  
 diff --git a/include/uapi/linux/ipv6.h b/include/uapi/linux/ipv6.h
-index 81f4243bebb1..9e001ea84841 100644
+index 4fa8511b1e35..5eefcb61018b 100644
 --- a/include/uapi/linux/ipv6.h
 +++ b/include/uapi/linux/ipv6.h
-@@ -197,6 +197,7 @@ enum {
- 	DEVCONF_IOAM6_ID_WIDE,
+@@ -199,6 +199,7 @@ enum {
  	DEVCONF_NDISC_EVICT_NOCARRIER,
  	DEVCONF_ACCEPT_UNTRACKED_NA,
+ 	DEVCONF_ACCEPT_RA_MIN_LFT,
 +	DEVCONF_LINK_FILTER,
  	DEVCONF_MAX
  };
  
 diff --git a/net/ipv4/devinet.c b/net/ipv4/devinet.c
-index e8b9a9202fec..1bb48732e619 100644
+index 35d6e74be840..e67cf474630c 100644
 --- a/net/ipv4/devinet.c
 +++ b/net/ipv4/devinet.c
 @@ -2561,6 +2561,7 @@ static struct devinet_sysctl_table {
@@ -100,18 +100,18 @@ index e8b9a9202fec..1bb48732e619 100644
  };
  
 diff --git a/net/ipv6/addrconf.c b/net/ipv6/addrconf.c
-index 9c3f5202a97b..fbc072c3534e 100644
+index b8dc20fe7a4e..0d0aec97ba94 100644
 --- a/net/ipv6/addrconf.c
 +++ b/net/ipv6/addrconf.c
-@@ -5591,6 +5591,7 @@ static inline void ipv6_store_devconf(struct ipv6_devconf *cnf,
- 	array[DEVCONF_IOAM6_ID_WIDE] = cnf->ioam6_id_wide;
+@@ -5607,6 +5607,7 @@ static inline void ipv6_store_devconf(struct ipv6_devconf *cnf,
  	array[DEVCONF_NDISC_EVICT_NOCARRIER] = cnf->ndisc_evict_nocarrier;
  	array[DEVCONF_ACCEPT_UNTRACKED_NA] = cnf->accept_untracked_na;
+ 	array[DEVCONF_ACCEPT_RA_MIN_LFT] = cnf->accept_ra_min_lft;
 +	array[DEVCONF_LINK_FILTER] = cnf->link_filter;
  }
  
  static inline size_t inet6_ifla6_size(void)
-@@ -7016,6 +7017,13 @@ static const struct ctl_table addrconf_sysctl[] = {
+@@ -7035,6 +7036,13 @@ static const struct ctl_table addrconf_sysctl[] = {
  		.extra1		= (void *)SYSCTL_ZERO,
  		.extra2		= (void *)SYSCTL_ONE,
  	},
@@ -126,10 +126,10 @@ index 9c3f5202a97b..fbc072c3534e 100644
  		.procname	= "ioam6_id",
  		.data		= &ipv6_devconf.ioam6_id,
 diff --git a/net/ipv6/route.c b/net/ipv6/route.c
-index 2f355f0ec32a..388e0342c989 100644
+index 0bcdb675ba2c..dd770560d941 100644
 --- a/net/ipv6/route.c
 +++ b/net/ipv6/route.c
-@@ -675,6 +675,14 @@ static inline void rt6_probe(struct fib6_nh *fib6_nh)
+@@ -678,6 +678,14 @@ static inline void rt6_probe(struct fib6_nh *fib6_nh)
  }
  #endif
  
@@ -144,7 +144,7 @@ index 2f355f0ec32a..388e0342c989 100644
  /*
   * Default Router Selection (RFC 2461 6.3.6)
   */
-@@ -716,6 +724,8 @@ static int rt6_score_route(const struct fib6_nh *nh, u32 fib6_flags, int oif,
+@@ -719,6 +727,8 @@ static int rt6_score_route(const struct fib6_nh *nh, u32 fib6_flags, int oif,
  
  	if (!m && (strict & RT6_LOOKUP_F_IFACE))
  		return RT6_NUD_FAIL_HARD;
@@ -154,5 +154,5 @@ index 2f355f0ec32a..388e0342c989 100644
  	m |= IPV6_DECODE_PREF(IPV6_EXTRACT_PREF(fib6_flags)) << 2;
  #endif
 -- 
-2.30.2
+2.39.2
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Kernel build script should be called with `set -e` to error out on unclean patches.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T4928

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
