### PR TITLE
T6014: Bump keepalived version to v2.2.8

### DIFF
--- a/packages/keepalived/Jenkinsfile
+++ b/packages/keepalived/Jenkinsfile
@@ -23,7 +23,7 @@
 // and not via a DEB package
 def pkgList = [
     ['name': 'keepalived',
-     'scmCommit': '8af889bc',
+     'scmCommit': 'v2.2.8',
      'scmUrl': 'https://github.com/acassen/keepalived',
      'buildCmd': 'cd ..; ./build.sh'],
 ]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Bump keepalived version to `v2.2.8`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6014

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
vrrp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
vyos@r15:~$ /usr/libexec/vyos/tests/smoke/cli/test_ha_vrrp.py
test_01_default_values (__main__.TestVRRP) ... ok
test_02_simple_options (__main__.TestVRRP) ... ok
test_03_sync_group (__main__.TestVRRP) ... ok
test_04_exclude_vrrp_interface (__main__.TestVRRP) ... ok

----------------------------------------------------------------------
Ran 4 tests in 15.270s

OK
vyos@r15:~$ show ver

Version:          VyOS 1.3-stable-202402020442
Release train:    equuleus

Built by:         autobuild@vyos.net
Built on:         Fri 02 Feb 2024 04:42 UTC
Build UUID:       e8a83aed-4750-493a-be76-921673418622
Build commit ID:  7ca43c83bce8a0

Architecture:     x86_64
Boot via:         installed image
System type:      KVM guest

Hardware vendor:  QEMU
Hardware model:   Standard PC (Q35 + ICH9, 2009)
Hardware S/N:     
Hardware UUID:    48cbb22e-1784-48c3-8421-212128c620e3

Copyright:        VyOS maintainers and contributors
vyos@r15:~$ 
vyos@r15:~$ show ver all | match keepa
ii  keepalived                           1:2.2.8                        amd64        Failover and monitoring daemon for LVS clusters
vyos@r15:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
