### PR TITLE
T6009-6019: fix hour decoding when timezone offset is negative; bump libnftnl and nftables version.

### DIFF
--- a/packages/netfilter/.gitignore
+++ b/packages/netfilter/.gitignore
@@ -1,3 +1,3 @@
-pkg-libnftnl/
-pkg-nftables/
+/pkg-libnftnl/
+/pkg-nftables/
 

--- a/packages/netfilter/Jenkinsfile
+++ b/packages/netfilter/Jenkinsfile
@@ -22,17 +22,17 @@
 def pkgList = [
     // libnftnl
     ['name': 'pkg-libnftnl',
-     'scmCommit': 'debian/1.2.6-1',
+     'scmCommit': 'debian/1.2.6-2',
      'scmUrl': 'https://salsa.debian.org/pkg-netfilter-team/pkg-libnftnl.git',
      'buildCmd': 'sudo mk-build-deps --install --tool "apt-get --yes --no-install-recommends"; dpkg-buildpackage -uc -us -tc -b'],
 
     // nftables
     ['name': 'pkg-nftables',
-     'scmCommit': 'debian/1.0.8-1',
+     'scmCommit': 'debian/1.0.9-1',
      'scmUrl': 'https://salsa.debian.org/pkg-netfilter-team/pkg-nftables.git',
      'buildCmd': '''sudo dpkg -i ../libnftnl*.deb;
                     sudo mk-build-deps --install --tool "apt-get --yes --no-install-recommends";
-                    dpkg-buildpackage -uc -us -tc -b'''],
+                    ../build.py'''],
 ]
 
 // Start package build using library function from https://github.com/vyos/vyos-build

--- a/packages/netfilter/build.py
+++ b/packages/netfilter/build.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from shutil import copy as copy_file
+from subprocess import run
+
+
+# copy patches
+def apply_deb_patches() -> None:
+    """Apply patches to sources directory
+    """
+    package_dir: str = Path.cwd().name
+    current_dir: str = Path.cwd().as_posix()
+    patches_dir = Path(f'../patches/{package_dir}')
+    patches_dir_dst = Path(f'{current_dir}/debian/patches')
+    if not patches_dir_dst.exists():
+        patches_dir_dst.mkdir(parents = True)
+    if patches_dir.exists():
+        patches_list = list(patches_dir.iterdir())
+        patches_list.sort()
+        series_file = Path(f'{patches_dir_dst.as_posix()}/series')
+        if series_file.exists():
+            series_data: str = series_file.read_text()
+        else:
+
+            series_data = ''
+        for patch_file in patches_list:
+            print(f'Applying patch: {patch_file.name}')
+            copy_file(patch_file, f'{patches_dir_dst.as_posix()}')
+            series_data = f'{series_data}\n{patch_file.name}'
+        series_file.write_text(series_data)
+
+
+def build_package() -> bool:
+    """Build a package
+    Returns:
+        bool: build status
+    """
+    build_cmd: list[str] = ['dpkg-buildpackage', '-uc', '-us', '-tc', '-b']
+    build_status: int = run(build_cmd).returncode
+
+    if build_status:
+        return False
+    return True
+
+
+# build a package
+if __name__ == '__main__':
+    apply_deb_patches()
+
+    if not build_package():
+        exit(1)
+
+    exit()
+

--- a/packages/netfilter/patches/pkg-nftables/0001-meta-fix-hour-decoding.patch
+++ b/packages/netfilter/patches/pkg-nftables/0001-meta-fix-hour-decoding.patch
@@ -1,0 +1,118 @@
+From d392ddf243dcbf8a34726c777d2c669b1e8bfa85 Mon Sep 17 00:00:00 2001
+From: Florian Westphal <fw@strlen.de>
+Date: Thu, 2 Nov 2023 15:34:13 +0100
+Subject: meta: fix hour decoding when timezone offset is negative
+
+Brian Davidson says:
+
+ meta hour rules don't display properly after being created when the
+ hour is on or after 00:00 UTC. The netlink debug looks correct for
+ seconds past midnight UTC, but displaying the rules looks like an
+ overflow or a byte order problem. I am in UTC-0400, so today, 20:00
+ and later exhibits the problem, while 19:00 and earlier hours are
+ fine.
+
+meta.c only ever worked when the delta to UTC is positive.
+We need to add in case the second counter turns negative after
+offset adjustment.
+
+Also add a test case for this.
+
+Fixes: f8f32deda31d ("meta: Introduce new conditions 'time', 'day' and 'hour'")
+Reported-by: Brian Davidson <davidson.brian@gmail.com>
+Signed-off-by: Florian Westphal <fw@strlen.de>
+---
+ src/meta.c                                         | 11 ++++-
+ .../shell/testcases/listing/dumps/meta_time.nodump |  0
+ tests/shell/testcases/listing/meta_time            | 52 ++++++++++++++++++++++
+ 3 files changed, 61 insertions(+), 2 deletions(-)
+ create mode 100644 tests/shell/testcases/listing/dumps/meta_time.nodump
+ create mode 100755 tests/shell/testcases/listing/meta_time
+
+diff --git a/src/meta.c b/src/meta.c
+index b578d5e2..7846aefe 100644
+--- a/src/meta.c
++++ b/src/meta.c
+@@ -495,9 +495,16 @@ static void hour_type_print(const struct expr *expr, struct output_ctx *octx)
+
+ 	/* Obtain current tm, so that we can add tm_gmtoff */
+ 	ts = time(NULL);
+-	if (ts != ((time_t) -1) && localtime_r(&ts, &cur_tm))
+-		seconds = (seconds + cur_tm.tm_gmtoff) % SECONDS_PER_DAY;
++	if (ts != ((time_t) -1) && localtime_r(&ts, &cur_tm)) {
++		int32_t adj = seconds + cur_tm.tm_gmtoff;
+
++		if (adj < 0)
++			adj += SECONDS_PER_DAY;
++		else if (adj >= SECONDS_PER_DAY)
++			adj -= SECONDS_PER_DAY;
++
++		seconds = adj;
++	}
+ 	minutes = seconds / 60;
+ 	seconds %= 60;
+ 	hours = minutes / 60;
+diff --git a/tests/shell/testcases/listing/dumps/meta_time.nodump b/tests/shell/testcases/listing/dumps/meta_time.nodump
+new file mode 100644
+index 00000000..e69de29b
+diff --git a/tests/shell/testcases/listing/meta_time b/tests/shell/testcases/listing/meta_time
+new file mode 100755
+index 00000000..a9761998
+--- /dev/null
++++ b/tests/shell/testcases/listing/meta_time
+@@ -0,0 +1,52 @@
++#!/bin/bash
++
++set -e
++
++TMP1=$(mktemp)
++TMP2=$(mktemp)
++
++cleanup()
++{
++	rm -f "$TMP1"
++	rm -f "$TMP2"
++}
++
++check_decode()
++{
++	TZ=$1 $NFT list chain t c | grep meta > "$TMP2"
++	diff -u "$TMP1" "$TMP2"
++}
++
++trap cleanup EXIT
++
++$NFT -f - <<EOF
++table t {
++	chain c {
++	}
++}
++EOF
++
++for i in $(seq -w 0 23); do
++	TZ=UTC $NFT add rule t c meta hour "$i:00"-"$i:59"
++done
++
++# Check decoding in UTC, this mirrors 1:1 what should have been added.
++for i in $(seq 0 23); do
++	printf "\t\tmeta hour \"%02d:%02d\"-\"%02d:%02d\"\n" $i 0 $i 59 >> "$TMP1"
++done
++
++check_decode UTC
++
++printf "\t\tmeta hour \"%02d:%02d\"-\"%02d:%02d\"\n" 23 0 23 59 > "$TMP1"
++for i in $(seq 0 22); do
++	printf "\t\tmeta hour \"%02d:%02d\"-\"%02d:%02d\"\n" $i 0 $i 59 >> "$TMP1"
++done
++check_decode UTC+1
++
++printf "\t\tmeta hour \"%02d:%02d\"-\"%02d:%02d\"\n" 1 0 1 59 > "$TMP1"
++for i in $(seq 2 23); do
++	printf "\t\tmeta hour \"%02d:%02d\"-\"%02d:%02d\"\n" $i 0 $i 59 >> "$TMP1"
++done
++printf "\t\tmeta hour \"%02d:%02d\"-\"%02d:%02d\"\n" 0 0 0 59 >> "$TMP1"
++
++check_decode UTC-1
+-- 
+cgit v1.2.3
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
fix hour decoding when timezone offset is negative; bump libnftnl and nftables version.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
Package upgrade
## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6009
* https://vyos.dev/T6019

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/2991

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ show config comm | grep firewall
set firewall ipv4 input filter rule 1 action 'accept'
set firewall ipv4 input filter rule 1 description 'Good'
set firewall ipv4 input filter rule 1 time starttime '00:00:00'
set firewall ipv4 input filter rule 1 time stoptime '15:00:25'
set firewall ipv4 input filter rule 2 action 'accept'
set firewall ipv4 input filter rule 2 description 'Good, using latest value accepted'
set firewall ipv4 input filter rule 2 time starttime '17:00:01'
set firewall ipv4 input filter rule 2 time stoptime '20:59:59'
set firewall ipv4 input filter rule 3 action 'accept'
set firewall ipv4 input filter rule 3 description 'StopTime 23 plus utc 3 >> than 24. not ok'
set firewall ipv4 input filter rule 3 time starttime '06:00:00'
set firewall ipv4 input filter rule 3 time stoptime '23:00:00'
set firewall ipv4 input filter rule 4 action 'accept'
set firewall ipv4 input filter rule 4 description 'Both time would be bigger than 24 in UTC.. Not OK'
set firewall ipv4 input filter rule 4 time starttime '21:00:00'
set firewall ipv4 input filter rule 4 time stoptime '23:30:00'
set firewall ipv4 input filter rule 10 action 'accept'
vyos@vyos:~$ sudo nft -s list chain ip vyos_filter VYOS_INPUT_filter
table ip vyos_filter {
(reversechain VYOS_INPUT_filter { -s list chain ip vyos_filter VYOS_INPUT_filter 
                type filter hook input priority filter; policy accept;
                meta hour >= "00:00" meta hour < "15:00:25" counter accept comment "ipv4-INP-filter-1"
                meta hour >= "17:00:01" meta hour < "20:59:59" counter accept comment "ipv4-INP-filter-2"
                meta hour >= "06:00" meta hour < "23:00" counter accept comment "ipv4-INP-filter-3"
                meta hour >= "21:00" meta hour < "23:30" counter accept comment "ipv4-INP-filter-4"
                ct state new ct status == dnat counter accept comment "ipv4-INP-filter-10"
                counter accept comment "INP-filter default-action accept"
        }
}
vyos@vyos:~$ date
Mon Feb 12 08:51:45 AM -03 2024
vyos@vyos:~$ show config comm | grep zone
set system time-zone 'America/Argentina/Buenos_Aires'
vyos@vyos:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
