### PR TITLE
build: T3664: fix the chroot includes path

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -344,8 +344,15 @@ if __name__ == "__main__":
     BUG_REPORT_URL="{build_defaults['bugtracker_url']}"
     """
 
-    chroot_includes_dir = os.path.join(defaults.BUILD_DIR, defaults.CHROOT_INCLUDES_DIR)
-    binary_includes_dir = os.path.join(defaults.BUILD_DIR, defaults.BINARY_INCLUDES_DIR)
+    # Switch to the build directory, this is crucial for the live-build work
+    # because the efective build config files etc. are there.
+    #
+    # All directory paths from this point must be relative to BUILD_DIR,
+    # not to the vyos-build repository root.
+    os.chdir(defaults.BUILD_DIR)
+
+    chroot_includes_dir = defaults.CHROOT_INCLUDES_DIR
+    binary_includes_dir = defaults.BINARY_INCLUDES_DIR
     vyos_data_dir = os.path.join(chroot_includes_dir, "usr/share/vyos")
     os.makedirs(vyos_data_dir, exist_ok=True)
     with open(os.path.join(vyos_data_dir, 'version.json'), 'w') as f:
@@ -365,11 +372,6 @@ if __name__ == "__main__":
     os.makedirs(os.path.join(chroot_includes_dir, 'usr/lib/'), exist_ok=True)
     with open(os.path.join(chroot_includes_dir, 'usr/lib//os-release'), 'w') as f:
         print(os_release, file=f)
-
-
-    ## Switch to the build directory, this is crucial for the live-build work work
-    ## because the efective build config files etc. are there
-    os.chdir(defaults.BUILD_DIR)
 
     ## Clean up earlier build state and artifacts
     print("I: Cleaning the build workspace")
@@ -428,10 +430,11 @@ if __name__ == "__main__":
     if has_nonempty_key(build_config, "includes_chroot"):
         for i in build_config["includes_chroot"]:
             file_path = os.path.join(chroot_includes_dir, i["path"])
+            if debug:
+                print(f"D: Creating chroot include file: {file_path}")
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, 'w') as f:
                 f.write(i["data"])
-
 
     ## Configure live-build
     lb_config_tmpl = jinja2.Template("""


### PR DESCRIPTION

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fix a mixup with the current working dir that led to chroot includes placed at an incorrect path.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3664

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Build script.

## Proposed changes
<!--- Describe your changes in detail -->

Change the working dir to `build/` early and use paths relative to it right away to avoid.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Build any flavor that uses the includes mechanism, like:

```
[[includes_chroot]]
  path = 'usr/share/doc/vyos-test'
  data = 'This is a test file!"
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
