### PR TITLE
build: T3664: fix the includes_chroot path for Sagitta

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2022 VyOS maintainers and contributors
+# Copyright (C) 2022-2024 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -331,7 +331,14 @@ if __name__ == "__main__":
     BUG_REPORT_URL="{build_defaults['bugtracker_url']}"
     """
 
-    chroot_includes_dir = os.path.join(defaults.BUILD_DIR, defaults.CHROOT_INCLUDES_DIR)
+    # Switch to the build directory, this is crucial for the live-build work
+    # because the efective build config files etc. are there.
+    #
+    # All directory paths from this point must be relative to BUILD_DIR,
+    # not to the vyos-build repository root.
+    os.chdir(defaults.BUILD_DIR)
+
+    chroot_includes_dir = defaults.CHROOT_INCLUDES_DIR
     vyos_data_dir = os.path.join(chroot_includes_dir, "usr/share/vyos")
     os.makedirs(vyos_data_dir, exist_ok=True)
     with open(os.path.join(vyos_data_dir, 'version.json'), 'w') as f:
@@ -351,8 +358,11 @@ if __name__ == "__main__":
         print(os_release, file=f)
 
 
-    ## Switch to the build directory, this is crucial for the live-build work work
-    ## because the efective build config files etc. are there
+    # Switch to the build directory, this is crucial for the live-build work
+    # because the efective build config files etc. are there.
+    #
+    # All directory paths from this point must be relative to BUILD_DIR,
+    # not to the vyos-build repository root.
     os.chdir(defaults.BUILD_DIR)
 
     ## Clean up earlier build state and artifacts


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

A manual backport of #505 (obsoletes #507). A full version will be included in the larger flavors PR.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T3664

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Build scripts.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
