### PR TITLE
T6064: add build error if branch information from Git repository is missing

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -290,10 +290,9 @@ if __name__ == "__main__":
         # Retrieve git branch name
         git_branch = repo.active_branch.name
     except Exception as e:
-      print("Could not retrieve information from git: {0}".format(str(e)))
+      exit(f'Could not retrieve information from git: {e}')
       build_git = ""
       git_branch = ""
-      git_commit = ""
 
     # Create the build version string
     if build_config['build_type'] == 'development':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This was discussed in slack, where a user was missing the Git commit ID in his custom build

Reason is/was: `git clone --single-branch -b 1.4.0-epa1 https://github.com/vyos/vyos-build`

Checks out the 1.4.0-epa1 tag as HEAD and does not clone any branch information. This results in:

```
>>> import git
>>> repo = git.Repo('.')
>>> repo.head.object.hexsha[:14]
'bcac2eb1f9b49c'
>>> git_branch = repo.active_branch.name
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/git/repo/base.py", line 881, in active_branch
    return self.head.reference
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/git/refs/symbolic.py", line 311, in _get_reference
    raise TypeError("%s is a detached symbolic reference as it points to %r" % (self, sha))
TypeError: HEAD is a detached symbolic reference as it points to 'bcac2eb1f9b49cc15ebda65838e5465543dbb9c6' during the build. The exception handler resets the branch and commit name to an empty string: https://github.com/vyos/vyos-build/blob/a3e60a00b400a1bad8609d5ce1abb0bb7abed7bc/scripts/build-vyos-image#L281-L296
```

This now adds a proper error message during build so it fails early.
```
(07:46) vyos_bld 08278c5a1172:/vyos/vyos-build # isobuild -test Building custom VyOS version: 1.5-test-202402250746 I: Checking if packages required for VyOS image build are installed build/config
Could not retrieve information from git: HEAD is a detached symbolic reference as it points to '39612f541e55bea19868f50f16d7a6c6e0034ed2'
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6064

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

See steps to reproduce above

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
