### PR TITLE
T6065: Remove duplicated lines from build-vyos-image script causing script to fail

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -357,13 +357,6 @@ if __name__ == "__main__":
         print(os_release, file=f)
 
 
-    # Switch to the build directory, this is crucial for the live-build work
-    # because the efective build config files etc. are there.
-    #
-    # All directory paths from this point must be relative to BUILD_DIR,
-    # not to the vyos-build repository root.
-    os.chdir(defaults.BUILD_DIR)
-
     ## Clean up earlier build state and artifacts
     print("I: Cleaning the build workspace")
     os.system("lb clean")


### PR DESCRIPTION
## Change Summary
In a recent commit #273d624 the build-vyos-image script was modified but lines 334-339 were identical to lines 361-366, which is causing the build to fail with the following error:

> Traceback (most recent call last):
>   File "/__w/vyos-build/vyos-build/vyos-build/./build-vyos-image", line 366, in <module>
>     os.chdir(defaults.BUILD_DIR)
> FileNotFoundError: [Errno 2] No such file or directory: 'build'
> Error: Process completed with exit code 1.

Essentially the script will attempt twice to chdir to 'build' which succeeds the first time but fails the 2nd as it is already in the build directory.

This commit removes the duplicated lines so that the build can succeed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T6065

## Component(s) name
Build script

## Proposed changes
Remove duplicate lines only.

## How to test
Re-run build script and it will no longer error.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
