### PR TITLE
T6115: Fix tagged builds from detached Git HEAD

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -286,8 +286,12 @@ if __name__ == "__main__":
         if repo.is_dirty():
             build_git += "-dirty"
 
-        # Retrieve git branch name
-        git_branch = repo.active_branch.name
+        # Retrieve git branch name or current tag
+        # Building a tagged release might leave us checking out a git tag that is not the tip of a named branch (detached HEAD)
+        # Check if the current HEAD is associated with a tag and use its name instead of an unavailable branch name.
+        git_branch = next((tag.name for tag in repo.tags if tag.commit == repo.head.commit), None)
+        if git_branch is None:
+            git_branch = repo.active_branch.name
     except Exception as e:
       exit(f'Could not retrieve information from git: {e}')
       build_git = ""


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Hello everyone!

<details>
  <summary>Build commands:</summary>

```
    - git clone -b sagitta --single-branch https://github.com/vyos/vyos-build
    - git checkout 1.4.0-epa1
    - cd vyos-build
    - export VYOS_VERSION=1.4.0-epa1
    - make clean
    - |
      ./build-vyos-image iso \
        --architecture amd64 \
        --build-by xxxx \
        --build-type release \
        --build-comment "VyOS with packages ready for prometheus node exporter and ansible" \
        --version "${VYOS_VERSION}-rolling-$(date +%Y-%m-%d-%H-%M)" \
        --custom-package bmon \
        --custom-package htop \
        --custom-package git \
        --custom-package ansible

```

</details>

Last night I tried to build sagitta from `1.4.0-epa1` but it failed due to the following error message:
```
build/config
Could not retrieve information from git: HEAD is a detached symbolic reference as it points to 'bcac2eb1f9b49cc15ebda65838e5465543dbb9c6'
```

I looked further into it and found the issue https://github.com/gitpython-developers/GitPython/issues/633. Working in a detached HEAD, when trying to build from a tagged commit for example, we are not exactly on a branch and therefore `build-vyos-image` fails to determine the active branch. My fix checks if the current checked out commit ID matches an available git tag and if that's the case, `git_branch` will be the name of the tag. 

Keep in mind that detached HEADs unrelated to tags are still likely to fail.

While fixing I also adjusted some indentations.

Check it out and let me know what you think. I'm happy to receive feedback.

Thanks in advance!
Sebastian

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/Txxxx

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
