### PR TITLE
radvd: T6118: add custom build support with recent source version

### DIFF
--- a/packages/radvd/.gitignore
+++ b/packages/radvd/.gitignore
@@ -1,0 +1,2 @@
+radvd/
+*.deb

--- a/packages/radvd/Jenkinsfile
+++ b/packages/radvd/Jenkinsfile
@@ -1,0 +1,30 @@
+// Copyright (C) 2024 VyOS maintainers and contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// in order to easy exprort images built to "external" world
+// it under the terms of the GNU General Public License version 2 or later as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+@NonCPS
+
+// Using a version specifier library, use 'current' branch. The underscore (_)
+// is not a typo! You need this underscore if the line immediately after the
+// @Library annotation is not an import statement!
+@Library('vyos-build@sagitta')_
+
+def pkgList = [
+    ['name': 'radvd',
+     'scmCommit': 'f2de4764559',
+     'scmUrl': 'https://github.com/radvd-project/radvd',
+     'buildCmd': 'cd ..; ./build.sh'],
+]
+
+// Start package build using library function from https://github.com/vyos/vyos-build
+buildPackage('radvd', pkgList, null, true, "**/packages/radvd/**")

--- a/packages/radvd/build.sh
+++ b/packages/radvd/build.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+SRC=radvd
+if [ ! -d $SRC ]; then
+    echo "source directory $SRC does not exist!"
+    echo "$ git clone https://github.com/radvd-project/radvd"
+    exit 1
+fi
+cd $SRC
+
+INSTALL_DIR=debian
+if [ -d $INSTALL_DIR ]; then
+    rm -rf $INSTALL_DIR
+fi
+
+./autogen.sh
+./configure
+make
+
+install --directory debian/lib/systemd/system debian/usr/sbin
+install --mode 0644 radvd.service debian/lib/systemd/system
+install --strip --mode 0755 radvd debian/usr/sbin
+
+# Version' field value 'v0.14-20-g613277f': version number does not start with digit
+# "cut" first character from version string
+fpm --input-type dir --output-type deb --name radvd \
+    --version $(git describe --always | cut -c2- | tr _ -) --deb-compression gz \
+    --maintainer "VyOS Package Maintainers <maintainers@vyos.net>" \
+    --description "RADVD router advertisement daemon" \
+    --license "RADVD" -C $INSTALL_DIR --package ..


### PR DESCRIPTION
(cherry picked from commit ed79a9fa939fdba80eb004a79989153d51eeea88)

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Package update

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6118

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
