### PR TITLE
Jenkins: select proper source version of build pipeline library

### DIFF
--- a/packages/ethtool/Jenkinsfile
+++ b/packages/ethtool/Jenkinsfile
@@ -18,7 +18,7 @@
 // Using a version specifier library, use 'current' branch. The underscore (_)
 // is not a typo! You need this underscore if the line immediately after the
 // @Library annotation is not an import statement!
-@Library('vyos-build@current')_
+@Library('vyos-build@sagitta')_
 
 def pkgList = [
     ['name': 'ethtool',

--- a/packages/isc-dhcp/Jenkinsfile
+++ b/packages/isc-dhcp/Jenkinsfile
@@ -17,7 +17,7 @@
 // Using a version specifier library, use 'current' branch. The underscore (_)
 // is not a typo! You need this underscore if the line immediately after the
 // @Library annotation is not an import statement!
-@Library('vyos-build@current')_
+@Library('vyos-build@sagitta')_
 
 // NOTE: we can build with -d as the libbpf dependency is installed manually
 // and not via a DEB package

--- a/packages/pmacct/Jenkinsfile
+++ b/packages/pmacct/Jenkinsfile
@@ -18,7 +18,7 @@
 // Using a version specifier library, use 'current' branch. The underscore (_)
 // is not a typo! You need this underscore if the line immediately after the
 // @Library annotation is not an import statement!
-@Library('vyos-build@current')_
+@Library('vyos-build@sagitta')_
 
 def package_name = 'pmacct'
 // "sudo apt-get remove git -y" is necessary for solving this issue https://vyos.dev/T5663


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Packages got backported from current, but we need to select the proper pipeline version from sagitta branch.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Jenkins files

## Proposed changes
<!--- Describe your changes in detail -->
