### PR TITLE
docker, build: T6119: use python3-tomli instead of python3-toml

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,6 +101,7 @@ RUN apt-get update && apt-get install -y \
       python3-pip \
       python3-flake8 \
       python3-autopep8 \
+      python3-tomli \
       yq \
       debootstrap \
       live-build

--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -32,12 +32,12 @@ import functools
 import json
 
 try:
-    import toml
+    import tomli
     import jinja2
     import git
 except ModuleNotFoundError as e:
     print(f"Cannot load a required library: {e}")
-    print("Please make sure the following Python3 modules are installed: toml jinja2 git")
+    print("Please make sure the following Python3 modules are installed: tomli jinja2 git")
 
 import vyos_build_utils as utils
 import vyos_build_defaults as defaults
@@ -120,8 +120,8 @@ if __name__ == "__main__":
 
     ## Load the file with default build configuration options
     try:
-        with open(defaults.DEFAULTS_FILE, 'r') as f:
-            build_defaults = toml.load(f)
+        with open(defaults.DEFAULTS_FILE, 'rb') as f:
+            build_defaults = tomli.load(f)
     except Exception as e:
         print("Failed to open the defaults file {0}: {1}".format(defaults.DEFAULTS_FILE, e))
         sys.exit(1)
@@ -213,16 +213,16 @@ if __name__ == "__main__":
     build_config = merge_dicts(args, build_defaults)
 
     ## Load the flavor file and mix-ins
-    with open(make_toml_path(defaults.BUILD_TYPES_DIR, build_config["build_type"]), 'r') as f:
-        build_type_config = toml.load(f)
+    with open(make_toml_path(defaults.BUILD_TYPES_DIR, build_config["build_type"]), 'rb') as f:
+        build_type_config = tomli.load(f)
         build_config = merge_dicts(build_type_config, build_config)
 
-    with open(make_toml_path(defaults.BUILD_ARCHES_DIR, build_config["architecture"]), 'r') as f:
-        build_arch_config = toml.load(f)
+    with open(make_toml_path(defaults.BUILD_ARCHES_DIR, build_config["architecture"]), 'rb') as f:
+        build_arch_config = tomli.load(f)
         build_config = merge_dicts(build_arch_config, build_config)
 
-    with open(make_toml_path(defaults.BUILD_FLAVORS_DIR, build_config["build_flavor"]), 'r') as f:
-        flavor_config = toml.load(f)
+    with open(make_toml_path(defaults.BUILD_FLAVORS_DIR, build_config["build_flavor"]), 'rb') as f:
+        flavor_config = tomli.load(f)
         build_config = merge_dicts(flavor_config, build_config)
 
     ## Rename and merge some fields for simplicity

--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -42,7 +42,7 @@ import random
 import traceback
 import logging
 import re
-import toml
+import tomli
 
 from io import BytesIO
 from io import StringIO
@@ -78,8 +78,8 @@ parser.add_argument('--qemu-cmd', help='Only generate QEMU launch command',
 
 args = parser.parse_args()
 
-with open('data/defaults.toml') as f:
-    vyos_defaults = toml.load(f)
+with open('data/defaults.toml', 'rb') as f:
+    vyos_defaults = tomli.load(f)
 
 class StreamToLogger(object):
     """


### PR DESCRIPTION


## Change Summary


Use a compliant and more actively maintained TOML implementation. In particular, it fixes the bug with handling triple-quoted strings that can lead to data corruption if someone tries to use an empty pair of quotes inside a triple-quoted string in an include — that's especially relevant for including custom config files in flavors.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T6119

## Component(s) name


Dockerfile, build scripts.

## How to test


The task has a reproducing procedure for the triple  quotes bug.

## Checklist:



- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
