### PR TITLE
build: T1449: add default_config field support in flavor files to allow people to easily include a custom default config

### DIFF
--- a/scripts/build-vyos-image
+++ b/scripts/build-vyos-image
@@ -441,6 +441,15 @@ DOCUMENTATION_URL="{build_config['documentation_url']}"
             with open(file_path, 'w') as f:
                 f.write(i["data"])
 
+    ## Create the default config
+    ## Technically it's just another includes.chroot entry,
+    ## but it's special enough to warrant making it easier for flavor writers
+    if has_nonempty_key(build_config, "default_config"):
+        file_path = os.path.join(chroot_includes_dir, "opt/vyatta/etc/config.boot.default")
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, 'w') as f:
+            f.write(build_config["default_config"])
+
     ## Configure live-build
     lb_config_tmpl = jinja2.Template("""
     lb config noauto \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add a new field `default_config` to flavor files — simpler than the generic `includes_chroot` mechanism, and will work even when we get rid of `/opt/vyatta/etc`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T1449

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Build scripts.


## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Sample flavor with a custom config:

```
# Generic (aka "universal") ISO image

image_format = "iso"

# Include these packages in the image regardless of the architecture
packages = [
  # QEMU and Xen guest tools exist for multiple architectures
  "qemu-guest-agent",
  "vyos-xe-guest-utilities",
]

default_config = '''
system {
    host-name totally-not-vyos
    login {
        user vyos {
            authentication {
                encrypted-password $6$QxPS.uk6mfo$9QBSo8u1FkH16gMyAVhus6fU3LOzvLR9Z9.82m3tiHFAxTtIkhaZSWssSgzt4v4dGAL8rhVQxTg0oAG9/q11h/
                plaintext-password ""
            }
        }
    }
'''
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
