### PR TITLE
ixgbe: T6155: always enable allow_unsupported_sfp for all NICs by default

### DIFF
--- a/packages/linux-kernel/build-intel-ixgbe.sh
+++ b/packages/linux-kernel/build-intel-ixgbe.sh
@@ -57,6 +57,10 @@ echo "I: remove pci_enable_pcie_error_reporting() code no longer present in Kern
 sed -i '/.*pci_disable_pcie_error_reporting(pdev);/d' ixgbe_main.c
 sed -i '/.*pci_enable_pcie_error_reporting(pdev);/d' ixgbe_main.c
 
+# See https://vyos.dev/T6155
+echo "I: always enable allow_unsupported_sfp for all NICs by default"
+patch -l -p1 < ../../patches/ixgbe/allow_unsupported_sfp.patch
+
 echo "I: Compile Kernel module for Intel ${DRIVER_NAME} driver"
 make KSRC=${KERNEL_DIR} INSTALL_MOD_PATH=${DEBIAN_DIR} INSTALL_FW_PATH=${DEBIAN_DIR} -j $(getconf _NPROCESSORS_ONLN) install
 

--- a/packages/linux-kernel/patches/ixgbe/allow_unsupported_sfp.patch
+++ b/packages/linux-kernel/patches/ixgbe/allow_unsupported_sfp.patch
@@ -1,0 +1,36 @@
+From 7a95d34570377e46d5fdadb9b1c742db62e0256d Mon Sep 17 00:00:00 2001
+From: Christian Breunig <christian@breunig.cc>
+Date: Fri, 22 Mar 2024 08:37:54 +0100
+Subject: [PATCH] param: always enable allow_unsupported_sfp
+
+---
+ ixgbe_param.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/ixgbe_param.c b/ixgbe_param.c
+index 71197b7..30c21bd 100644
+--- a/ixgbe_param.c
++++ b/ixgbe_param.c
+@@ -307,7 +307,7 @@ IXGBE_PARAM(LRO, "Large Receive Offload (0,1), default 0 = off");
+  * Default Value: 0
+  */
+ IXGBE_PARAM(allow_unsupported_sfp, "Allow unsupported and untested "
+-	    "SFP+ modules on 82599 based adapters, default 0 = Disable");
++	    "SFP+ modules on 82599 based adapters, default 1 = Enable");
+ 
+ /* Enable/disable support for DMA coalescing
+  *
+@@ -1133,8 +1133,8 @@ void ixgbe_check_options(struct ixgbe_adapter *adapter)
+ 	struct ixgbe_option opt = {
+ 			.type = enable_option,
+ 			.name = "allow_unsupported_sfp",
+-			.err  = "defaulting to Disabled",
+-			.def  = OPTION_DISABLED
++			.err  = "defaulting to Enabled",
++			.def  = OPTION_ENABLED
+ 		};
+ #ifdef module_param_array
+ 		if (num_allow_unsupported_sfp > bd) {
+-- 
+2.39.2
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

In-tree vs. Out-Of-Tree drivers differ in the way how unsupported transceivers are defined (uint vs array of int) for the Kernel module parameters.

This results in:

```
kernel: ixgbe 0000:5e:00.0: failed to initialize because an unsupported SFP+ module type was detected.
kernel: ixgbe 0000:5e:00.0: Reload the driver after installing a supported module.
kernel: ixgbe 0000:5e:00.0: removed PHC on eth6
```

This patch always enables unsupported SFP+ modules as wo do anyway from the userspace but only for the first port.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T6155

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

Have multiple IXGBE network interfaces in a system

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
