### PR TITLE
T6173: Fix build error when "--version" value contains "/"

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -530,7 +530,6 @@ Pin-Priority: 600
     if local_packages:
         for f in local_packages:
             shutil.copy(f, os.path.join(defaults.LOCAL_PACKAGES_PATH, os.path.basename(f)))
-
     ## Build the image
     print("I: Starting image build")
     if debug:
@@ -539,6 +538,11 @@ Pin-Priority: 600
     if res > 0:
         sys.exit(res)
 
+    # Replace "/" in --version string since that would cause the
+    # "Copy the image" step to throw errors
+    out_version = version_data["version"].replace("/", "_")
+    out_filename = "vyos-{0}-{1}.iso".format(out_version, build_config["architecture"])
+
     # Copy the image
     shutil.copy("live-image-{0}.hybrid.iso".format(build_config["architecture"]),
-      "vyos-{0}-{1}.iso".format(version_data["version"], build_config["architecture"]))
+      out_filename)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
`vyos-build-image` script
## Proposed changes
<!--- Describe your changes in detail -->
Instead of not checking for any `/` in the `--version` string, it now replaces `/` to `_` so that the copy image step does not throw any error
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
I have ran the build script after applying the changes to the build script, and confirmed that it fixes the issue stated above.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
