### PR TITLE
T6033: bump hsflowd version v2.0.55-1 extended PCAP capabilities

### DIFF
--- a/packages/hsflowd/Jenkinsfile
+++ b/packages/hsflowd/Jenkinsfile
@@ -23,7 +23,7 @@
 // and not via a DEB package
 def pkgList = [
     ['name': 'host-sflow',
-     'scmCommit': 'v2.0.52-1',
+     'scmCommit': 'v2.0.55-1',
      'scmUrl': 'https://github.com/sflow/host-sflow.git',
      'buildCmd': 'cd ..; ./build.sh'],
 ]


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Bump the `hsflowd` version to `v2.0.55-1`
Fixed and extended PCAP capabilities for not hardware/bridge interfaces (like GRE tunnel interface).

It fixes crashes the daemon if you use tunnel interfaces

```
hsflowd[9160]: PCAP: tun0 has no supported datalink encapsulaton
hsflowd[9160]: Received signal 11
hsflowd[9160]: SIGSEGV, faulty address is (nil)
```
The correct commit fix in https://github.com/sflow/host-sflow/commit/62346aa67240ced0fb16b6725f16d8fa40eaea60

Updated version starts the hsflowd without issues
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): bump `hsflowd` version

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6033

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
sflow
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
```
set interfaces tunnel tun0 address '203.0.113.1/27'
set interfaces tunnel tun0 encapsulation 'gre'
set interfaces tunnel tun0 remote '192.0.2.2'
set interfaces tunnel tun0 source-address '192.0.2.1'
set service ids ddos-protection mode 'sflow'
set service ids ddos-protection sflow listen-address '127.0.0.1'

set system sflow agent-interface 'tun0'
set system sflow interface 'tun0'
set system sflow sampling-rate '1000'
set system sflow server 127.0.0.1

```
With current `v2.0.52-1`
```
Mar 29 12:23:21 r4 systemd[1]: hsflowd.service: Scheduled restart job, restart counter is at 168.
Mar 29 12:23:21 r4 systemd[1]: Stopped hsflowd.service - Host sFlow.
Mar 29 12:23:21 r4 systemd[1]: Started hsflowd.service - Host sFlow.
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(log_backtrace+0x2e)[0x56027cafecce]
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(+0x11ed9)[0x56027cafeed9]
Mar 29 12:23:21 r4 hsflowd[9160]: /lib/x86_64-linux-gnu/libc.so.6(+0x3c050)[0x7f1381330050]
Mar 29 12:23:21 r4 hsflowd[9160]: /etc/hsflowd/modules/mod_pcap.so(+0x1954)[0x7f13814d8954]
Mar 29 12:23:21 r4 hsflowd[9160]: /etc/hsflowd/modules/mod_pcap.so(+0x1d3f)[0x7f13814d8d3f]
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(EVEventTx+0xf7)[0x56027caffbb7]
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(+0x12d59)[0x56027caffd59]
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(+0x1316a)[0x56027cb0016a]
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(+0x13340)[0x56027cb00340]
Mar 29 12:23:21 r4 hsflowd[9160]: /lib/x86_64-linux-gnu/libc.so.6(+0x89134)[0x7f138137d134]
Mar 29 12:23:21 r4 hsflowd[9160]: /lib/x86_64-linux-gnu/libc.so.6(+0x1097dc)[0x7f13813fd7dc]
Mar 29 12:23:21 r4 hsflowd[9160]: SIGSEGV, faulty address is (nil)
Mar 29 12:23:21 r4 hsflowd[9160]: current bus: packet
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(log_backtrace+0x2e)[0x56027cafecce]
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(+0x11eeb)[0x56027cafeeeb]
Mar 29 12:23:21 r4 hsflowd[9160]: /lib/x86_64-linux-gnu/libc.so.6(+0x3c050)[0x7f1381330050]
Mar 29 12:23:21 r4 hsflowd[9160]: /etc/hsflowd/modules/mod_pcap.so(+0x1954)[0x7f13814d8954]
Mar 29 12:23:21 r4 hsflowd[9160]: /etc/hsflowd/modules/mod_pcap.so(+0x1d3f)[0x7f13814d8d3f]
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(EVEventTx+0xf7)[0x56027caffbb7]
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(+0x12d59)[0x56027caffd59]
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(+0x1316a)[0x56027cb0016a]
Mar 29 12:23:21 r4 hsflowd[9160]: /usr/sbin/hsflowd(+0x13340)[0x56027cb00340]
Mar 29 12:23:21 r4 hsflowd[9160]: /lib/x86_64-linux-gnu/libc.so.6(+0x89134)[0x7f138137d134]
Mar 29 12:23:21 r4 hsflowd[9160]: /lib/x86_64-linux-gnu/libc.so.6(+0x1097dc)[0x7f13813fd7dc]
Mar 29 12:23:21 r4 hsflowd[9160]: PCAP: tun0 has no supported datalink encapsulaton
Mar 29 12:23:21 r4 hsflowd[9160]: Received signal 11
Mar 29 12:23:21 r4 hsflowd[9160]: SIGSEGV, faulty address is (nil)
Mar 29 12:23:21 r4 hsflowd[9160]: current bus: packet
Mar 29 12:23:21 r4 systemd[1]: hsflowd.service: Main process exited, code=exited, status=11/n/a
Mar 29 12:23:21 r4 systemd[1]: hsflowd.service: Failed with result 'exit-code'.
```
With updated version:
```
vyos@r4# sudo systemctl status hsflowd
● hsflowd.service - Host sFlow
     Loaded: loaded (/lib/systemd/system/hsflowd.service; disabled; preset: enabled)
    Drop-In: /run/systemd/system/hsflowd.service.d
             └─override.conf
     Active: active (running) since Fri 2024-03-29 13:35:18 EET; 15min ago
   Main PID: 14446 (hsflowd)
      Tasks: 2 (limit: 18713)
     Memory: 668.0K
        CPU: 841ms
     CGroup: /system.slice/hsflowd.service
             └─14446 /usr/sbin/hsflowd -m 166cfd257d3a4eca9ef60b655c9acf0f -d -f /run/sflow/hsflowd.conf

Mar 29 13:35:18 r4 systemd[1]: Started hsflowd.service - Host sFlow.
[edit]
vyos@r4# 

```
dump:
```
vyos@r4# sudo tcpdump -nti lo port 6343
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on lo, link-type EN10MB (Ethernet), snapshot length 262144 bytes

IP 127.0.0.1.57661 > 127.0.0.1.6343: sFlowv5, IPv4 agent 203.0.113.1, agent-id 100000, length 792
IP 127.0.0.1.57661 > 127.0.0.1.6343: sFlowv5, IPv4 agent 203.0.113.1, agent-id 100000, length 160

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
