### PR TITLE
T6249: build: Change to archive.debian.org

### DIFF
--- a/data/defaults.json
+++ b/data/defaults.json
@@ -1,6 +1,6 @@
 {
   "architecture": "amd64",
-  "debian_mirror": "http://deb.debian.org/debian",
+  "debian_mirror": "http://archive.debian.org/debian",
   "debian_security_mirror": "http://deb.debian.org/debian-security",
   "debian_distribution": "buster",
   "vyos_mirror": "http://dev.packages.vyos.net/repositories/equuleus",

--- a/docker-vyos/vyos_install_common.sh
+++ b/docker-vyos/vyos_install_common.sh
@@ -39,7 +39,7 @@ function prepare_apt() {
     if [[ "${RELEASE_TRAIN}" == "equuleus" || "${RELEASE_TRAIN}" == "sagitta" ]]; then
         echo -e "deb ${APT_VYOS_MIRROR} ${APT_VYOS_BRANCH} main\n${APT_ADDITIONAL_REPOS}" > /etc/apt/sources.list.d/vyos.list
         # Add backports repository
-        echo -e "deb http://deb.debian.org/debian buster-backports main\ndeb http://deb.debian.org/debian buster-backports non-free" >> /etc/apt/sources.list.d/vyos.list
+        echo -e "deb http://archive.debian.org/debian buster-backports main\ndeb http://archive.debian.org/debian buster-backports non-free" >> /etc/apt/sources.list.d/vyos.list
     fi
 
     # Copy additional repositories and preferences, if persented


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Change default Debian repo URL to archive.debian.org

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6249

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
The buster-backports repository was [removed](https://backports.debian.org/news/Removal_of_buster-backports_from_the_debian_archive/) from the main repository server recently, causing equuleus builds to fail. This PR changes the Debian repo URL used by live-build to archive.debian.org, where buster-backports still exists.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Run the standard equuleus build process as documented [here](https://docs.vyos.io/en/equuleus/contributing/build-vyos.html). Without the patch, the build will fail. When the patch is applied, the build succeeds.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
