### PR TITLE
Jenkins: T6249: remove debian-mirror configure option

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,6 @@ pipeline {
                     sh """
                         ./configure \
                             --build-by "${params.BUILD_BY}" \
-                            --debian-mirror http://deb.debian.org/debian/ \
                             --build-type release \
                             --version "${VYOS_VERSION}" ${CUSTOM_PACKAGES}
                         sudo make iso


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Debian Backports does not support LTS, therefore buster-backports is unsupported since August 1st 2022. Despite of the documentation buster-backport was still available on the mirrors, that changed recently with the archival of buster-backports.

https://backports.debian.org/news/Removal_of_buster-backports_from_the_debian_archive/

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
