### PR TITLE
build: T3664: modify the module-level template path instead of setting an environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all:
 	@echo "The most common target is 'iso'"
 
 %:
-	VYOS_TEMPLATE_DIR=`pwd`/packages/vyos-1x/data/templates/ ./build-vyos-image $*
+	./build-vyos-image $*
 
 .PHONY: checkiso
 .ONESHELL:

--- a/scripts/image-build/raw_image.py
+++ b/scripts/image-build/raw_image.py
@@ -22,6 +22,10 @@ import traceback
 
 import vyos.utils.process
 
+import vyos.template
+
+vyos.template.DEFAULT_TEMPLATE_DIR = os.path.join(os.getcwd(), 'build/vyos-1x/data/templates')
+
 SQUASHFS_FILE = 'live/filesystem.squashfs'
 VERSION_FILE = 'version.json'
 
@@ -138,7 +142,6 @@ def setup_grub_configuration(build_config, root_dir) -> None:
     Args:
         root_dir (str): a path to the root of target filesystem
     """
-    from vyos.template import render
     from vyos.system import grub
 
     print('I: Installing GRUB configuration files')
@@ -149,13 +152,13 @@ def setup_grub_configuration(build_config, root_dir) -> None:
     grub_cfg_options = f'{root_dir}/{grub.CFG_VYOS_OPTIONS}'
 
     # create new files
-    render(grub_cfg_main, grub.TMPL_GRUB_MAIN, {})
+    vyos.template.render(grub_cfg_main, grub.TMPL_GRUB_MAIN, {})
     grub.common_write(root_dir)
     grub.vars_write(grub_cfg_vars, build_config["boot_settings"])
     grub.modules_write(grub_cfg_modules, [])
     grub.write_cfg_ver(1, root_dir)
-    render(grub_cfg_menu, grub.TMPL_GRUB_MENU, {})
-    render(grub_cfg_options, grub.TMPL_GRUB_OPTS, {})
+    vyos.template.render(grub_cfg_menu, grub.TMPL_GRUB_MENU, {})
+    vyos.template.render(grub_cfg_options, grub.TMPL_GRUB_OPTS, {})
 
 def install_grub(con, version):
     from re import match


### PR DESCRIPTION


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): internal change.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

Companion PR: vyos/vyos-1x#3415

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Build scripts.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
# No env var needed anymore!
./build-vyos-image <flavor>
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
