### PR TITLE
build: T3664: use explicit defaults argument in the dict merging function

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -21,6 +21,7 @@
 import re
 import os
 import sys
+import copy
 import uuid
 import glob
 import json
@@ -138,21 +139,22 @@ def get_validator(optdict, name):
     except KeyError:
         return None
 
-def merge_dicts(source, destination, skip_none=False):
-    """ Merge two dictionaries and return a new dict which has the merged key/value pairs.
+def merge_defaults(source, defaults={}, skip_none=False):
+    """ Merge a dict with values from a defaults dict.
     Merging logic is as follows:
       Sub-dicts are merged.
       List values are combined.
-      Scalar values are set to those from the source dict.
+      Scalar values are set to those from the source dict,
+      if they exist there.
     """
     from copy import deepcopy
-    tmp = deepcopy(destination)
+    tmp = deepcopy(defaults)
 
     for key, value in source.items():
         if key not in tmp:
             tmp[key] = value
         elif isinstance(source[key], dict):
-            tmp[key] = merge_dicts(source[key], tmp[key])
+            tmp[key] = merge_defaults(source[key], tmp[key])
         elif isinstance(source[key], list):
             tmp[key] = source[key] + tmp[key]
         elif not skip_none or source[key] is not None:
@@ -245,7 +247,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     ## Try to get correct architecture and build type from build flavor and CLI arguments
-    pre_build_config = merge_dicts({}, build_defaults)
+    pre_build_config = copy.deepcopy(build_defaults)
 
     flavor_config = {}
     build_flavor = args["build_flavor"]
@@ -253,7 +255,7 @@ if __name__ == "__main__":
         toml_flavor_file = make_toml_path(flavor_dir, args["build_flavor"])
         with open(toml_flavor_file, 'rb') as f:
             flavor_config = tomli.load(f)
-            pre_build_config = merge_dicts(flavor_config, pre_build_config)
+            pre_build_config = merge_defaults(flavor_config, defaults=pre_build_config)
     except FileNotFoundError:
         print(f"E: Flavor '{build_flavor}' does not exist")
         sys.exit(1)
@@ -262,7 +264,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     ## Combine configs args > flavor > defaults
-    pre_build_config = merge_dicts(args, pre_build_config, skip_none=True)
+    pre_build_config = merge_defaults(args, defaults=pre_build_config, skip_none=True)
 
     # Some fixup for mirror settings.
     # The idea is: if --debian-mirror is specified but --pbuilder-debian-mirror is not,
@@ -294,20 +296,20 @@ if __name__ == "__main__":
     args['pbuilder_config'] = os.path.join(defaults.BUILD_DIR, defaults.PBUILDER_CONFIG)
 
     ## Combine the arguments with non-configurable defaults
-    build_config = merge_dicts({}, build_defaults)
+    build_config = copy.deepcopy(build_defaults)
 
     ## Load correct mix-ins
     with open(make_toml_path(defaults.BUILD_TYPES_DIR, pre_build_config["build_type"]), 'rb') as f:
         build_type_config = tomli.load(f)
-        build_config = merge_dicts(build_type_config, build_config)
+        build_config = merge_defaults(build_type_config, defaults=build_config)
 
     with open(make_toml_path(defaults.BUILD_ARCHES_DIR, pre_build_config["architecture"]), 'rb') as f:
         build_arch_config = tomli.load(f)
-        build_config = merge_dicts(build_arch_config, build_config)
+        build_config = merge_defaults(build_arch_config, defaults=build_config)
 
     ## Override with flavor and then CLI arguments
-    build_config = merge_dicts(flavor_config, build_config)
-    build_config = merge_dicts(args, build_config, skip_none=True)
+    build_config = merge_defaults(flavor_config, defaults=build_config)
+    build_config = merge_defaults(args, defaults=build_config, skip_none=True)
 
     ## Rename and merge some fields for simplicity
     ## E.g. --custom-packages is for the user, but internally
@@ -333,7 +335,7 @@ if __name__ == "__main__":
     if "boot_settings" not in build_config:
         build_config["boot_settings"] = defaults.boot_settings
     else:
-        build_config["boot_settings"] = merge_dicts(defaults.boot_settings, build_config["boot_settings"])
+        build_config["boot_settings"] = merge_defaults(build_config["boot_settings"], defaults=defaults.boot_settings)
 
     ## Convert the image_format field to a single-item list if it's a scalar
     ## (like `image_format = "iso"`)


### PR DESCRIPTION
Use explicit defaults argument in the dict merging function to make it clear what is merged into what,
and correct some instances of incorrect argument order along the way.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Build scripts.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

```
$ cat data/build-flavors/raw-test.toml

image_format = "raw"

packages = ["sl"]

[boot_settings]
  console_type = "ttyS"
  console_speed = 9600

[[includes_chroot]]
  path = "etc/test"
  data = "TEST!"

$ sudo ./build-vyos-image --debug --dry-run raw
I: Checking if packages required for VyOS image build are installed
I: using build flavors directory data/build-flavors
D: Effective build config:

{
    "build_type": "development",
    "architecture": "amd64",
    "debian_distribution": "bookworm",
    "debian_mirror": "http://deb.debian.org/debian",
    "debian_security_mirror": "http://deb.debian.org/debian-security",
    "debian_archive_areas": "main contrib non-free non-free-firmware",
    "vyos_mirror": "https://rolling-packages.vyos.net/current",
    "vyos_branch": "current",
    "release_train": "current",
    "kernel_version": "6.6.30",
    "bootloaders": "syslinux,grub-efi",
    "squashfs_compression_type": "xz -Xbcj x86 -b 256k -always-use-fragments -no-recovery",
    "website_url": "https://vyos.io",
    "support_url": "https://support.vyos.io",
    "bugtracker_url": "https://vyos.dev",
    "documentation_url": "https://docs.vyos.io/en/latest",
    "project_news_url": "https://blog.vyos.io",
    "packages": [
        "sl",
        "grub2",
        "grub-pc",
        "vyos-linux-firmware",
        "vyos-intel-qat",
        "vyos-intel-ixgbe",
        "vyos-intel-ixgbevf",
        "openvpn-dco",
        "telegraf",
        "gdb",
        "strace",
        "apt-rdepends",
        "tshark",
        "vim",
        "vyos-1x-smoketest"
    ],
    "additional_repositories": [
        "deb [arch=amd64] https://repo.saltproject.io/py3/debian/11/amd64/3005 bullseye main"
    ],
    "kernel_flavor": "amd64-vyos",
    "image_format": [
        "raw"
    ],
    "boot_settings": {
        "timeout": "5",
        "console_type": "ttyS",
        "console_num": "0",
        "console_speed": 9600,
        "bootmode": "normal"
    },
    "includes_chroot": [
        {
            "path": "etc/test",
            "data": "TEST!"
        }
    ],
    "build_by": "root@aa73acc27c0d",
    "pbuilder_debian_mirror": "http://deb.debian.org/debian",
    "version": null,
    "build_comment": "",
    "debug": true,
    "dry_run": true,
    "custom_apt_entry": [],
    "custom_apt_key": [],
    "custom_package": [],
    "reuse_iso": null,
    "disk_size": 10,
    "build_flavor": "raw",
    "build_dir": "build",
    "pbuilder_config": "build/pbuilderrc"
}
W: Could not build a version string specific to git branch, falling back to default: 'T3664-dict-merge-fixes'
I: Cleaning the build workspace
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
