### PR TITLE
T6334: build: adds option to use unsigned repos

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -226,6 +226,9 @@ if __name__ == "__main__":
     # Build flavor is a positional argument
     parser.add_argument('build_flavor', help='Build flavor', nargs='?', action='store')
 
+    # Allow unsigned Vyos mirror
+    parser.add_argument('--unsigned-vyos-mirror', help='Vyos mirror is not signed', action='store_true'),
+
     args = vars(parser.parse_args())
 
     debug = args["debug"]
@@ -496,7 +499,8 @@ if __name__ == "__main__":
         # Add the additional repositories to package lists
         print("I: Setting up additional APT entries")
         vyos_repo_entry = "deb {vyos_mirror} {vyos_branch} main\n".format(**build_config)
-
+        if build_config['unsigned_vyos_mirror']:
+            vyos_repo_entry = "deb [trusted=yes] {vyos_mirror} {vyos_branch} main\n".format(**build_config)
         apt_file = defaults.VYOS_REPO_FILE
 
         if debug:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow unsigned vyos mirror
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6334
## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build
## Proposed changes
<!--- Describe your changes in detail -->
adds new option to allow for unsigned vyos mirrors to be used. 
I implemented it this way because of this:
https://manpages.debian.org/buster/apt/sources.list.5.en.html
•Trusted (trusted) is a tri-state value which defaults to APT deciding if a source is considered trusted or if warnings should be raised before e.g. packages are installed from this source. This option can be used to override that decision. The value yes tells APT always to consider this source as trusted, even if it doesn't pass authentication checks. It disables parts of [apt-secure(8)](https://manpages.debian.org/buster/apt/apt-secure.8.en.html), and should therefore only be used in a local and trusted context (if at all) as otherwise security is breached. The value no does the opposite, causing the source to be handled as untrusted even if the authentication checks passed successfully. **The default value can't be set explicitly.**
## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
-->
```
vyos_bld@514053f60efd:/vyos$ sudo ./build-vyos-image iso --architecture amd64 --build-by "florin"
I: Checking if packages required for VyOS image build are installed
I: using build flavors directory data/build-flavors
W: Could not build a version string specific to git branch, falling back to default: 'T6334-allow-unsigned-mirrors'
I: Cleaning the build workspace
[2024-05-14 07:05:15] lb clean
...
vyos_bld@514053f60efd:/vyos$ cat build/config/archives/vyos.list.chroot
deb https://rolling-packages.vyos.net/current current main
```

```
vyos_bld@514053f60efd:/vyos$ sudo ./build-vyos-image iso --architecture amd64 --build-by "florin"  --unsigned-vyos-mirror
I: Checking if packages required for VyOS image build are installed
I: using build flavors directory data/build-flavors
W: Could not build a version string specific to git branch, falling back to default: 'T6334-allow-unsigned-mirrors'
I: Cleaning the build workspace
....
vyos_bld@514053f60efd:/vyos$ cat build/config/archives/vyos.list.chroot
deb [trusted=yes] https://rolling-packages.vyos.net/current current main
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
