### PR TITLE
build-script: T3664: Allowed all options in both config file and comm…

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -26,8 +26,6 @@ import uuid
 import glob
 import json
 import shutil
-import getpass
-import platform
 import argparse
 import datetime
 import functools
@@ -130,12 +128,9 @@ except OSError as e:
 def field_to_option(s):
     return re.sub(r'_', '-', s)
 
-def get_default_build_by():
-    return "{user}@{host}".format(user= getpass.getuser(), host=platform.node())
-
 def get_validator(optdict, name):
     try:
-        return optdict[name][2]
+        return optdict[name][1]
     except KeyError:
         return None
 
@@ -190,38 +185,35 @@ if __name__ == "__main__":
     # Options dict format:
     # '$option_name_without_leading_dashes': { ('$help_string', $default_value_generator_thunk, $value_checker_thunk) }
     options = {
-       'architecture': ('Image target architecture (amd64 or arm64)', None, lambda x: x in ['amd64', 'arm64', None]),
-       'build-by': ('Builder identifier (e.g. jrandomhacker@example.net)', get_default_build_by, None),
-       'debian-mirror': ('Debian repository mirror', None, None),
-       'debian-security-mirror': ('Debian security updates mirror', None, None),
-       'pbuilder-debian-mirror': ('Debian repository mirror for pbuilder env bootstrap', None, None),
-       'vyos-mirror': ('VyOS package mirror', None, None),
-       'build-type': ('Build type, release or development', None, lambda x: x in ['release', 'development']),
-       'version': ('Version number (release builds only)', None, None),
-       'build-comment': ('Optional build comment', lambda: '', None)
+       'architecture': ('Image target architecture (amd64 or arm64)', lambda x: x in ['amd64', 'arm64', None]),
+       'build-by': ('Builder identifier (e.g. jrandomhacker@example.net)', None),
+       'debian-mirror': ('Debian repository mirror', None),
+       'debian-security-mirror': ('Debian security updates mirror', None),
+       'pbuilder-debian-mirror': ('Debian repository mirror for pbuilder env bootstrap', None),
+       'vyos-mirror': ('VyOS package mirror', None),
+       'build-type': ('Build type, release or development', lambda x: x in ['release', 'development']),
+       'version': ('Version number (release builds only)', None),
+       'build-comment': ('Optional build comment', None)
     }
 
     # Create the option parser
     parser = argparse.ArgumentParser()
     for k, v in options.items():
-        help_string, default_value_thunk = v[0], v[1]
-        if default_value_thunk is None:
-            parser.add_argument('--' + k, type=str, help=help_string)
-        else:
-            parser.add_argument('--' + k, type=str, help=help_string, default=default_value_thunk())
+        help_string = v[0]
+        parser.add_argument('--' + k, type=str, help=help_string)
 
     # Debug options
     parser.add_argument('--debug', help='Enable debug output', action='store_true')
     parser.add_argument('--dry-run', help='Check build configuration and exit', action='store_true')
 
     # Custom APT entry and APT key options can be used multiple times
-    parser.add_argument('--custom-apt-entry', help="Custom APT entry", action='append', default=[])
-    parser.add_argument('--custom-apt-key', help="Custom APT key file", action='append', default=[])
-    parser.add_argument('--custom-package', help="Custom package to install from repositories", action='append', default=[])
+    parser.add_argument('--custom-apt-entry', help="Custom APT entry", action='append')
+    parser.add_argument('--custom-apt-key', help="Custom APT key file", action='append')
+    parser.add_argument('--custom-package', help="Custom package to install from repositories", action='append')
 
     # Options relevant for non-ISO format flavors
-    parser.add_argument('--reuse-iso', help='Use an existing ISO file to build additional image formats', type=str, action='store', default=None)
-    parser.add_argument('--disk-size', help='Disk size for non-ISO image formats', type=int, action='store', default=10)
+    parser.add_argument('--reuse-iso', help='Use an existing ISO file to build additional image formats', type=str, action='store')
+    parser.add_argument('--disk-size', help='Disk size for non-ISO image formats', type=int, action='store')
 
     # Build flavor is a positional argument
     parser.add_argument('build_flavor', help='Build flavor', nargs='?', action='store')
@@ -295,8 +287,11 @@ if __name__ == "__main__":
     args['build_dir'] = defaults.BUILD_DIR
     args['pbuilder_config'] = os.path.join(defaults.BUILD_DIR, defaults.PBUILDER_CONFIG)
 
+    ## Add hardcoded defaults
+    build_config = merge_defaults(defaults.HARDCODED_BUILD, defaults={})
+
     ## Combine the arguments with non-configurable defaults
-    build_config = copy.deepcopy(build_defaults)
+    build_config = merge_defaults(build_defaults, defaults=build_config)
 
     ## Load correct mix-ins
     with open(make_toml_path(defaults.BUILD_TYPES_DIR, pre_build_config["build_type"]), 'rb') as f:

--- a/scripts/image-build/defaults.py
+++ b/scripts/image-build/defaults.py
@@ -17,6 +17,11 @@
 
 
 import os
+import getpass
+import platform
+
+def get_default_build_by():
+    return "{user}@{host}".format(user= getpass.getuser(), host=platform.node())
 
 # Default boot settings
 boot_settings: dict[str, str] = {
@@ -25,6 +30,17 @@ boot_settings: dict[str, str] = {
     'console_num': '0',
     'console_speed': '115200',
     'bootmode': 'normal'
+}
+
+# Hardcoded default values
+HARDCODED_BUILD = {
+    'custom_apt_entry': [],
+    'custom_apt_key': [],
+    'custom_package': [],
+    'reuse_iso': None,
+    'disk_size': 10,
+    'build_by': get_default_build_by(),
+    'build_comment': '',
 }
 
 # Relative to the repository directory


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allowed all options in both config file and command args

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T3664

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build-script

## Proposed changes
<!--- Describe your changes in detail -->
Moved defaults away from argparser to `defaults.py`. This unlocks the ability to pass values that can be defined as command line arguments via a config file.

With this change logic looks like this (in order of overrides).

Pre-build config:
`data/defaults.toml` -> `build-flavors/<flavor>.toml` -> `--<command line argument>`

Build config:
`defaults.py` -> `data/defaults.toml` -> `build-types/<type>.toml` -> `architectures/<architecture>.toml` -> `build-flavors/<flavor>.toml` -> `--<command line argument>`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
