### PR TITLE
docker: arm: T6474: Initial support for dynamic arch toml loading

### DIFF
--- a/data/architectures/armhf.toml
+++ b/data/architectures/armhf.toml
@@ -1,2 +1,6 @@
+additional_repositories = [
+  "deb [arch=armhf] https://repo.saltproject.io/py3/debian/11/armhf/3005 bullseye main"
+]
+
 # Packages included in armhf images by default
 packages = ["grub-efi-arm"]

--- a/docker-vyos/Dockerfile
+++ b/docker-vyos/Dockerfile
@@ -37,30 +37,32 @@ RUN apt-get update && apt-get install -y \
 
 # Copy installer script and default build settings
 COPY [ "data/defaults.toml", \
-       "data/architectures/amd64.toml", \
        "data/live-build-config/archives/*", \
        "docker-vyos/vyos_install_common.sh", \
        "docker-vyos/vyos_install_stage_01.sh", \
        "/tmp/"]
+COPY [ "data/architectures/*", "/tmp/architectures_triage/" ]
 COPY [ "data/live-build-config/hooks/live/*", "/tmp/hooks/" ]
 
 # Install VyOS dependencies
 WORKDIR /tmp
+RUN bash -c 'mv /tmp/architectures_triage/$(dpkg --print-architecture).toml /tmp && rm -rf /tmp/architectures_triage'
 RUN bash /tmp/vyos_install_stage_01.sh
 
 
 # Install VyOS specific software
 COPY [ "data/defaults.toml", \
-       "data/architectures/amd64.toml", \
        "docker-vyos/vyos_install_common.sh", \
        "docker-vyos/vyos_install_stage_02.sh", "/tmp/" ]
+COPY [ "data/architectures/*", "/tmp/architectures_triage/" ]
+RUN bash -c 'mv /tmp/architectures_triage/$(dpkg --print-architecture).toml /tmp && rm -rf /tmp/architectures_triage'
 RUN bash /tmp/vyos_install_stage_02.sh
 
 
 # Tune system for VyOS
 COPY [ "docker-vyos/vyos_install_common.sh", "docker-vyos/vyos_install_stage_03.sh", "/tmp/" ]
 # Copy default config
-COPY data/live-build-config/includes.chroot/opt/vyatta/etc/config.boot.default /opt/vyatta/etc/
+COPY tools/container/config.boot.default /opt/vyatta/etc/
 
 RUN bash /tmp/vyos_install_stage_03.sh
 

--- a/docker-vyos/vyos_install_common.sh
+++ b/docker-vyos/vyos_install_common.sh
@@ -25,7 +25,7 @@ function prepare_apt() {
     # Add VyOS repository to the system
     local APT_VYOS_MIRROR=$(tomlq --raw-output .vyos_mirror /tmp/defaults.toml)
     local APT_VYOS_BRANCH=$(tomlq --raw-output .vyos_branch /tmp/defaults.toml)
-    local APT_ADDITIONAL_REPOS=$(tomlq --raw-output .additional_repositories[] /tmp/amd64.toml)
+    local APT_ADDITIONAL_REPOS=$(tomlq --raw-output .additional_repositories[] /tmp/$(dpkg --print-architecture).toml)
     local RELEASE_TRAIN=$(tomlq --raw-output .release_train /tmp/defaults.toml)
 
     echo "APT_VYOS_MIRROR      : $APT_VYOS_MIRROR"

--- a/tools/container/config.boot.default
+++ b/tools/container/config.boot.default
@@ -1,0 +1,40 @@
+system {
+    host-name vyos
+    login {
+        user vyos {
+            authentication {
+                encrypted-password "*"
+                plaintext-password ""
+            }
+            level admin
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level info
+            }
+            facility protocols {
+                level debug
+            }
+        }
+    }
+    ntp {
+        server "time1.vyos.net"
+        server "time2.vyos.net"
+        server "time3.vyos.net"
+    }
+    console {
+        device ttyS0 {
+            speed 115200
+        }
+    }
+    config-management {
+        commit-revisions 100
+    }
+}
+
+interfaces {
+    loopback lo {
+    }
+}


### PR DESCRIPTION
## Change Summary

This PR improves Docker image building system to allow dynamic arch toml loading.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6474

## Component(s) name
* arm
* docker

## Proposed changes
This changes uses `dpkg --print-architecture` to move the proper toml file to `/tmp` folder.

## How to test

Follow the Docker build guidelines.

## Checklist:

- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
