### PR TITLE
T6484: Smoketest: Increase KVM memory limit

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -150,7 +150,7 @@ def get_qemu_cmd(name, enable_kvm, enable_uefi, disk_img, raid=None, iso_img=Non
         -smp {cpucount},sockets=1,cores={cpucount},threads=1 \
         -cpu host \
         {uefi} \
-        -m 3G \
+        -m 4G \
         -vga none \
         -nographic \
         -machine accel=kvm \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6484

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
smoketest

## Proposed changes
<!--- Describe your changes in detail -->
When running smoketests in the vyos-build container, an error message similar to the following appears:

`DEBUG - test_fastnetmon (__main__.TestServiceIDS.test_fastnetmon) ... [ 4213.579433] Out of memory: Killed process 543005 (fastnetmon) total-vm:2301048kB, anon-rss:7432kB, file-rss:1812608kB, shmem-rss:0kB, UID:0 pgtables:3804kB oom_score_adj:0`

Further investigation reveals that the KVM created for the smoketests is [limited](https://github.com/vyos/vyos-build/blob/current/scripts/check-qemu-install#L153) to 3GB of memory. Increasing this to 4GB allows the smoketests to complete and pass.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Run smoketests with `make test` after building ISO. When the KVM memory limit is set to 3GB, the smoketests will fail as `fastnetmon` is OOM killed. When it is set to 4GB, the smoketests pass.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
