### PR TITLE
linux-kernel: T6485: build modules for thunderbolt and thunderbolt-net

### DIFF
--- a/packages/linux-kernel/arch/arm64/configs/vyos_defconfig
+++ b/packages/linux-kernel/arch/arm64/configs/vyos_defconfig
@@ -6053,7 +6053,8 @@ CONFIG_THUNDERX2_PMU=m
 # end of Performance monitor support
 
 CONFIG_RAS=y
-# CONFIG_USB4 is not set
+CONFIG_USB4=m
+CONFIG_USB4_NET=m
 
 #
 # Android

--- a/packages/linux-kernel/arch/x86/configs/vyos_defconfig
+++ b/packages/linux-kernel/arch/x86/configs/vyos_defconfig
@@ -5315,7 +5315,8 @@ CONFIG_IDLE_INJECT=y
 
 CONFIG_RAS=y
 # CONFIG_RAS_CEC is not set
-# CONFIG_USB4 is not set
+CONFIG_USB4=m
+CONFIG_USB4_NET=m
 
 #
 # Android


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This is the first step in order to have Thunderbolt Networking support in VyOS.

I have been successfully using a custom built kernel for this for a few months now, and with this change it will still require manual setup of the PCIe address within `systemd` and `udev` rules that I plan on implementing as a proper interface in the CLI next.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T6485

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

linux-kernel

## Proposed changes
<!--- Describe your changes in detail -->

Add modules for `thunderbolt` and `thunderbolt-net`

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

If anyone would like to actually enable this to test, at the moment you would create the interface file `/etc/systemd/network/00-=thhunderbolt0.link` as follows:

```
[Match]
Path=pci-0000:04:00.1
Driver=thunderbolt-net
[Link]
MACAddressPolicy=none
Name=thunderbolt0
```

Replacing the Path with the PCIe address of the Thunderbolt controller port.

If you wan to have the interface come up when a cable is connected, you would also need to add this udev rule `/etc/udev/rules.d/60-thunderbolt-network-interfaces.rules` as follows:

```
ACTION=="add", SUBSYSTEM=="net", KERNEL=="thunderbolt0", RUN+="/usr/sbin/ifconfig thunderbolt0 up"
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
