### PR TITLE
T6231: Mellanox OFED

### DIFF
--- a/packages/linux-kernel/.gitignore
+++ b/packages/linux-kernel/.gitignore
@@ -23,3 +23,5 @@ vyos-intel-*/
 vyos-linux-firmware*/
 kernel-vars
 r8152-*.tar.bz2
+/MLNX_OFED_SRC*
+/vyos-mellanox-ofed*

--- a/packages/linux-kernel/Jenkinsfile
+++ b/packages/linux-kernel/Jenkinsfile
@@ -62,6 +62,9 @@ def pkgList = [
     // Intel IXGBEVF
     ['name': 'ixgbevf', 'buildCmd': 'cd ..; ./build-intel-ixgbevf.sh'],
 
+    // Mellanox OFED
+    ['name': 'ofed', 'buildCmd': 'cd ..; ./build-mellanox-ofed.sh'],
+
     // Jool
     ['name': 'jool', 'buildCmd': 'cd ..; ./build-jool.py'],
 

--- a/packages/linux-kernel/build-mellanox-ofed.sh
+++ b/packages/linux-kernel/build-mellanox-ofed.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+DROP_DEV_DBG_DEBS=1
+DEB_DISTRO='debian12.1'
+CWD=$(pwd)
+KERNEL_VAR_FILE=${CWD}/kernel-vars
+
+if ! dpkg-architecture -iamd64; then
+    echo "Mellanox OFED is only buildable on amd64 platforms"
+    exit 0
+fi
+
+if [ ! -f ${KERNEL_VAR_FILE} ]; then
+    echo "Kernel variable file '${KERNEL_VAR_FILE}' does not exist, run ./build_kernel.sh first"
+    exit 1
+fi
+
+. ${KERNEL_VAR_FILE}
+
+url="https://www.mellanox.com/downloads/ofed/MLNX_OFED-24.04-0.6.6.0/MLNX_OFED_SRC-debian-24.04-0.6.6.0.tgz"
+
+cd ${CWD}
+
+DRIVER_FILE=$(basename ${url} | sed -e s/tar_0/tar/)
+DRIVER_DIR="${DRIVER_FILE%.tgz}"
+DRIVER_NAME="ofed"
+DRIVER_PRFX="MLNX_OFED"
+DRIVER_VERSION=$(echo ${DRIVER_DIR} | awk -F${DRIVER_PRFX} '{print $2}' | sed 's/^-//;s|_SRC-debian-||')
+DRIVER_VERSION_EXTRA=""
+
+# Build up Debian related variables required for packaging
+DEBIAN_ARCH=$(dpkg --print-architecture)
+DEBIAN_DIR="${CWD}/vyos-mellanox-${DRIVER_NAME}_${DRIVER_VERSION}_${DEBIAN_ARCH}"
+DEBIAN_CONTROL="${DEBIAN_DIR}/DEBIAN/control"
+DEBIAN_POSTINST="${CWD}/vyos-mellanox-ofed.postinst"
+
+# Fetch OFED driver source from Nvidia
+if [ -e ${DRIVER_FILE} ]; then
+    rm -f ${DRIVER_FILE}
+fi
+curl -L -o ${DRIVER_FILE} ${url}
+if [ "$?" -ne "0" ]; then
+    exit 1
+fi
+
+# Unpack archive
+if [ -d ${DRIVER_DIR} ]; then
+    rm -rf ${DRIVER_DIR}
+fi
+mkdir -p ${DRIVER_DIR}
+tar -C ${DRIVER_DIR} --strip-components=1 -xf ${DRIVER_FILE}
+
+# Build/install debs
+cd ${DRIVER_DIR}
+if [ -z $KERNEL_DIR ]; then
+    echo "KERNEL_DIR not defined"
+    exit 1
+fi
+
+sudo ./install.pl \
+  --basic --dpdk \
+  --without-dkms \
+  --without-mlnx-nvme-modules \
+  --with-vma --vma-vpi --vma-eth \
+  --guest --hypervisor \
+  --builddir $DEBIAN_DIR/mlx \
+  --distro $DEB_DISTRO \
+  -s $KERNEL_DIR \
+  -k $KERNEL_VERSION
+
+if [ $DROP_DEV_DBG_DEBS -eq 1 ]; then
+  echo "I: Removing development and debug packages"
+  sudo rm $(find $CWD/$DRIVER_DIR/DEBS/$DEB_DISTRO -type f | grep -E '\-dev|\-dbg')
+fi
+
+cp $(find $CWD/$DRIVER_DIR/DEBS/$DEB_DISTRO -type f | grep '\.deb$') "$CWD/"
+
+echo "I: Cleanup ${DRIVER_NAME} source"
+cd ${CWD}
+if [ -e ${DRIVER_FILE} ]; then
+    rm -f ${DRIVER_FILE}
+fi
+if [ -d ${DRIVER_DIR} ]; then
+    sudo rm -rf ${DRIVER_DIR}
+fi
+if [ -d ${DEBIAN_DIR} ]; then
+    sudo rm -rf ${DEBIAN_DIR}
+fi

--- a/packages/linux-kernel/build-mellanox-ofed.sh
+++ b/packages/linux-kernel/build-mellanox-ofed.sh
@@ -65,6 +65,33 @@ if [ -z $KERNEL_DIR ]; then
     exit 1
 fi
 
+rm -f SOURCES/ibarr_0.1.3.orig.tar.gz
+rm -f SOURCES/ibdump_6.0.0.orig.tar.gz
+rm -f SOURCES/ibsim_0.12.orig.tar.gz
+rm -f SOURCES/iser_24.04.OFED.24.04.0.6.6.1.orig.tar.gz
+rm -f SOURCES/isert_24.04.OFED.24.04.0.6.6.1.orig.tar.gz
+rm -f SOURCES/kernel-mft_4.28.0.92.orig.tar.gz
+rm -f SOURCES/knem_1.1.4.90mlnx3.orig.tar.gz
+rm -f SOURCES/libvma_9.8.60.orig.tar.gz
+rm -f SOURCES/libxlio_3.30.5.orig.tar.gz
+rm -f SOURCES/mlnx-ethtool_6.7.orig.tar.gz
+rm -f SOURCES/mlnx-iproute2_6.7.0.orig.tar.gz
+rm -f SOURCES/mlnx-nfsrdma_24.04.OFED.24.04.0.6.6.1.orig.tar.gz
+rm -f SOURCES/mlnx-nvme_24.04.OFED.24.04.0.6.6.1.orig.tar.gz
+rm -f SOURCES/mlx-steering-dump_1.0.0.orig.tar.gz
+rm -f SOURCES/mpitests_3.2.23.orig.tar.gz
+rm -f SOURCES/mstflint_4.16.1.orig.tar.gz
+rm -f SOURCES/ofed-scripts_24.04.OFED.24.04.0.6.6.orig.tar.gz
+rm -f SOURCES/openmpi_4.1.7a1.orig.tar.gz
+rm -f SOURCES/openvswitch_2.17.8.orig.tar.gz
+rm -f SOURCES/perftest_24.04.0.orig.tar.gz
+rm -f SOURCES/rdma-core_2404mlnx51.orig.tar.gz
+rm -f SOURCES/rshim_2.0.28.orig.tar.gz
+rm -f SOURCES/sockperf_3.10.orig.tar.gz
+rm -f SOURCES/srp_24.04.OFED.24.04.0.6.6.1.orig.tar.gz
+rm -f SOURCES/ucx_1.17.0.orig.tar.gz
+
+
 sudo ./install.pl \
   --basic --dpdk \
   --without-dkms \

--- a/packages/linux-kernel/build-mellanox-ofed.sh
+++ b/packages/linux-kernel/build-mellanox-ofed.sh
@@ -71,10 +71,10 @@ sudo ./install.pl \
   --without-mlnx-nvme-modules \
   --with-vma --vma-vpi --vma-eth \
   --guest --hypervisor \
-  --builddir $DEBIAN_DIR/mlx \
-  --distro $DEB_DISTRO \
-  -s $KERNEL_DIR \
-  -k $KERNEL_VERSION
+  --builddir ${DEBIAN_DIR}/mlx \
+  --distro ${DEB_DISTRO} \
+  --kernel-sources ${KERNEL_DIR} \
+  --kernel ${KERNEL_VERSION}${KERNEL_SUFFIX}
 
 if [ $DROP_DEV_DBG_DEBS -eq 1 ]; then
   echo "I: Removing development and debug packages"

--- a/packages/linux-kernel/build-mellanox-ofed.sh
+++ b/packages/linux-kernel/build-mellanox-ofed.sh
@@ -21,6 +21,8 @@ url="https://www.mellanox.com/downloads/ofed/MLNX_OFED-24.04-0.6.6.0/MLNX_OFED_S
 cd ${CWD}
 
 DRIVER_FILE=$(basename ${url} | sed -e s/tar_0/tar/)
+DRIVER_SHA1="003c1c022f9f6558d45750eacc0a64d06cf9cd42"
+
 DRIVER_DIR="${DRIVER_FILE%.tgz}"
 DRIVER_NAME="ofed"
 DRIVER_PRFX="MLNX_OFED"
@@ -39,6 +41,13 @@ if [ -e ${DRIVER_FILE} ]; then
 fi
 curl -L -o ${DRIVER_FILE} ${url}
 if [ "$?" -ne "0" ]; then
+    exit 1
+fi
+
+# Verify integrity
+echo "${DRIVER_SHA1} ${DRIVER_FILE}" | sha1sum -c -
+if [[ $? != 0 ]]; then
+    echo SHA1 checksum missmatch
     exit 1
 fi
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
[T6231](https://vyos.dev/T6231)
## Component(s) name
Mellanox (Nvidia) OFED kernel and userspace

## Proposed changes
<!--- Describe your changes in detail -->
OFED stack: drivers, userspace utilities, libraries, and DPDK/VPP interfaces.

## How to test
1. run included script in build stack
2. deploy the debs with the kernel built from the referenced sources
3. boot on host with ConnectX card
4. verify which module is loaded and features available

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
