### PR TITLE
ddclient: T5792: Use Debian build from Trixie

### DIFF
--- a/packages/ddclient/Jenkinsfile
+++ b/packages/ddclient/Jenkinsfile
@@ -21,7 +21,7 @@
 
 def pkgList = [
     ['name': 'ddclient',
-     'scmCommit': '93bd643',
+     'scmCommit': 'debian/3.11.2-1',
      'scmUrl': 'https://salsa.debian.org/debian/ddclient',
      'buildCmd': 'sudo mk-build-deps --install --tool "apt-get --yes --no-install-recommends"; dpkg-buildpackage  -uc -us -tc -b'],
 ]


### PR DESCRIPTION
As part of "T5792: Upgrade to ddclient 3.11.2" in commit 368b89ef056, ddclient was built using build system from Debian Salsa and source code from upstream GitHub.

This was subsequently modified in commit 7f7030d9281 to use both build system and source code from Debian Salsa.

Now that Debian has finally released ddclient 3.11.2 for Trixie, we can use the Trixie build directly instead of the custom build.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T5792

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
service dns dynamic

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
smoketest

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
