### PR TITLE
T6635: add policy.json to podman package

### DIFF
--- a/packages/podman/build.sh
+++ b/packages/podman/build.sh
@@ -26,6 +26,6 @@ fpm --input-type dir --output-type deb --name podman \
     --version $VERSION --deb-compression gz \
     --maintainer "VyOS Package Maintainers <maintainers@vyos.net>" \
     --description "Engine to run OCI-based containers in Pods" \
-    --depends conmon --depends crun --depends netavark --depends libgpgme11 \
+    --depends conmon --depends crun --depends netavark --depends libgpgme11 --depends golang-github-containers-common \
     --license "Apache License 2.0" -C podman-v$VERSION --package ..
 


### PR DESCRIPTION
## Change Summary
Adds default policy.json for Podman

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6635

## Component(s) name
container

## Proposed changes
Custom Podman package needs to provide /etc/containers/policy.json otherwise running containers fails.

## How to test
```
add container image adguard/adguardhome:v0.107.52
```

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
