### PR TITLE
build: T6653: add build/manifest.json file

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -549,6 +549,13 @@ if __name__ == "__main__":
             with open(file_path, 'w') as f:
                 f.write(build_config["default_config"])
 
+        ## Initialize build manifest
+        manifest = {
+            'build_config' : build_config,
+            'artifacts' : [iso_file],
+            'pre_build_config' : pre_build_config
+        }
+
         ## Configure live-build
         lb_config_tmpl = jinja2.Template("""
         lb config noauto \
@@ -627,6 +634,7 @@ Pin-Priority: 600
     # if the flavor calls for them
     if build_config["image_format"] != ["iso"]:
         raw_image = raw_image.create_raw_image(build_config, iso_file, "tmp/")
+        manifest['artifacts'].append(raw_image)
 
         if has_nonempty_key(build_config, "post_build_hook"):
             # Some flavors require special procedures that aren't covered by qemu-img
@@ -644,3 +652,7 @@ Pin-Priority: 600
                 target = f"{os.path.splitext(raw_image)[0]}.{image_ext}"
                 print(f"I: Building {f} file {target}")
                 cmd(f"qemu-img convert -f raw -O {f} {image_opts} {raw_image} {target}")
+                manifest['artifacts'].append(target)
+
+    with open('manifest.json', 'w') as f:
+        f.write(json.dumps(manifest))


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

For a release workflow, we need to know the build artifact name.

We can save that data to `build/manifest.json` with a list of artifacts.

```json
{
  "build_config": {
    "custom_apt_entry": [
      "deb [arch=amd64] https://repo.saltproject.io/py3/debian/11/amd64/3005 bullseye main"
    ],
    "custom_apt_key": [],
    "reuse_iso": null,
    "disk_size": 10,
    "build_by": "christian@breunig.cc",
    "build_comment": "",
    "build_type": "release",
    "architecture": "amd64",
    "debian_distribution": "bookworm",
    "debian_mirror": "http://deb.debian.org/debian",
    "debian_security_mirror": "http://deb.debian.org/debian-security",
    "debian_archive_areas": "main contrib non-free non-free-firmware",
    "vyos_mirror": "https://rolling-packages.vyos.net/current",
    "vyos_branch": "current",
    "release_train": "current",
    "kernel_version": "6.6.45",
    "bootloaders": "syslinux,grub-efi",
    "squashfs_compression_type": "xz -Xbcj x86 -b 256k -always-use-fragments -no-recovery",
    "website_url": "https://vyos.io",
    "support_url": "https://support.vyos.io",
    "bugtracker_url": "https://vyos.dev",
    "documentation_url": "https://docs.vyos.io/en/latest",
    "project_news_url": "https://blog.vyos.io",
    "additional_repositories": [
      "deb [arch=amd64] https://repo.saltproject.io/py3/debian/11/amd64/3005 bullseye main"
    ],
    "kernel_flavor": "amd64-vyos",
    "packages": [
      "qemu-guest-agent",
      "vyos-xe-guest-utilities",
      "grub2",
      "grub-pc",
      "vyos-linux-firmware",
      "vyos-intel-qat",
      "vyos-intel-ixgbe",
      "vyos-intel-ixgbevf",
      "mlnx-ofed-kernel-modules",
      "mlnx-tools",
      "openvpn-dco",
      "telegraf",
      "strace vim tmux git mc vyos-1x-smoketest",
      "hyperv-daemons",
      "vyos-1x-vmware"
    ],
    "image_format": [
      "iso"
    ],
    "architectures": {
      "amd64": {
        "packages": [
          "hyperv-daemons",
          "vyos-1x-vmware"
        ]
      }
    },
    "pbuilder_debian_mirror": "http://deb.debian.org/debian",
    "version": "1.5-foo-202408191937",
    "debug": false,
    "dry_run": false,
    "build_flavor": "generic",
    "build_dir": "build",
    "pbuilder_config": "build/pbuilderrc",
    "boot_settings": {
      "timeout": "5",
      "console_type": "tty",
      "console_num": "0",
      "console_speed": "115200",
      "bootmode": "normal"
    }
  },
  "artifacts": [
    "vyos-1.5-foo-202408191937-generic-amd64.iso"
  ],
  "pre_build_config": {
    "build_type": "release",
    "architecture": "amd64",
    "debian_distribution": "bookworm",
    "debian_mirror": "http://deb.debian.org/debian",
    "debian_security_mirror": "http://deb.debian.org/debian-security",
    "debian_archive_areas": "main contrib non-free non-free-firmware",
    "vyos_mirror": "https://rolling-packages.vyos.net/current",
    "vyos_branch": "current",
    "release_train": "current",
    "kernel_version": "6.6.45",
    "bootloaders": "syslinux,grub-efi",
    "squashfs_compression_type": "xz -Xbcj x86 -b 256k -always-use-fragments -no-recovery",
    "website_url": "https://vyos.io",
    "support_url": "https://support.vyos.io",
    "bugtracker_url": "https://vyos.dev",
    "documentation_url": "https://docs.vyos.io/en/latest",
    "project_news_url": "https://blog.vyos.io",
    "image_format": "iso",
    "packages": [
      "qemu-guest-agent",
      "vyos-xe-guest-utilities"
    ],
    "architectures": {
      "amd64": {
        "packages": [
          "hyperv-daemons",
          "vyos-1x-vmware"
        ]
      }
    },
    "build_by": "christian@breunig.cc",
    "pbuilder_debian_mirror": "http://deb.debian.org/debian",
    "version": "1.5-foo-202408191937",
    "build_comment": null,
    "debug": false,
    "dry_run": false,
    "custom_apt_entry": null,
    "custom_apt_key": null,
    "custom_package": [
      "strace vim tmux git mc vyos-1x-smoketest"
    ],
    "reuse_iso": null,
    "disk_size": null,
    "build_flavor": "generic"
  }
}
```

And get the resulting image (ISO) name using:

```console
helix:~/vyos-build/build [artifacts-T6653] # jq -r .artifacts[0] manifest.json
vyos-1.5-foo-202408191937-generic-amd64.iso
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6653

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build scripts

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
