### PR TITLE
T6231: update OFED version and fix build script

### DIFF
--- a/packages/linux-kernel/build-mellanox-ofed.sh
+++ b/packages/linux-kernel/build-mellanox-ofed.sh
@@ -16,12 +16,13 @@ fi
 
 . ${KERNEL_VAR_FILE}
 
-url="https://www.mellanox.com/downloads/ofed/MLNX_OFED-24.04-0.6.6.0/MLNX_OFED_SRC-debian-24.04-0.6.6.0.tgz"
+mlxver="24.07-0.6.1.0"
+url="https://www.mellanox.com/downloads/ofed/MLNX_OFED-${mlxver}/MLNX_OFED_SRC-debian-${mlxver}.tgz"
 
 cd ${CWD}
 
 DRIVER_FILE=$(basename ${url} | sed -e s/tar_0/tar/)
-DRIVER_SHA1="003c1c022f9f6558d45750eacc0a64d06cf9cd42"
+DRIVER_SHA1="c64defa8fb38dcbce153adc09834ab5cdcecd791"
 
 DRIVER_DIR="${DRIVER_FILE%.tgz}"
 DRIVER_NAME="ofed"
@@ -46,7 +47,7 @@ fi
 
 # Verify integrity
 echo "${DRIVER_SHA1} ${DRIVER_FILE}" | sha1sum -c -
-if [[ $? != 0 ]]; then
+if [ $? != 0 ]; then
     echo SHA1 checksum missmatch
     exit 1
 fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Push OFED to 24.07-0.6.1.0
Replace bash syntax for conditional check with sh syntax in OFED build script.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): OFED driver update

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
OFED

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
