### PR TITLE
Kernel: T861: use find over ls when probing for Kernel signing public keys

### DIFF
--- a/packages/linux-kernel/build-kernel.sh
+++ b/packages/linux-kernel/build-kernel.sh
@@ -35,7 +35,7 @@ done
 TRUSTED_KEYS_FILE=trusted_keys.pem
 # start with empty key file
 echo -n "" > $TRUSTED_KEYS_FILE
-CERTS=$(ls ../../../data/live-build-config/includes.chroot/var/lib/shim-signed/mok/*.pem)
+CERTS=$(find ../../../data/live-build-config/includes.chroot/var/lib/shim-signed/mok -name "*.pem" -type f)
 if [ ! -z "${CERTS}" ]; then
   # add known public keys to Kernel certificate chain
   for file in $CERTS; do


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fix Jenkins build error when it early bails out during error

`20:32:38  ls: cannot access '../../../data/live-build-config/includes.chroot/var/lib/shim-signed/mok/*.pem': No such file or directory`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T861

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
Kernel Build

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
