### PR TITLE
build: T6653: fix a manifest generation error when using --reuse-iso

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -355,10 +355,18 @@ if __name__ == "__main__":
     # not to the vyos-build repository root.
     os.chdir(defaults.BUILD_DIR)
 
+    ## Initialize build manifest
+    manifest = {
+      'build_config' : build_config,
+      'artifacts' : [],
+      'pre_build_config' : pre_build_config
+    }
+
     iso_file = None
 
     if build_config["reuse_iso"]:
         iso_file = build_config["reuse_iso"]
+        manifest["artifacts"] = [iso_file]
     else:
         ## Create the version file
 
@@ -547,13 +555,6 @@ if __name__ == "__main__":
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, 'w') as f:
                 f.write(build_config["default_config"])
-
-        ## Initialize build manifest
-        manifest = {
-            'build_config' : build_config,
-            'artifacts' : [iso_file],
-            'pre_build_config' : pre_build_config
-        }
 
         ## Configure live-build
         lb_config_tmpl = jinja2.Template("""


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Move manifest initialization before building the ISO so that the manifest file is generated correctly when a build is done with `--reuse-iso` to save build time.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Build scripts.

## Proposed changes
<!--- Describe your changes in detail -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
