### PR TITLE
build: T3664: improve support for custom build hooks

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -95,7 +95,7 @@ else:
 import utils
 import raw_image
 
-from utils import cmd
+from utils import cmd, rc_cmd
 
 ## Check if there are missing build dependencies
 deps = {
@@ -192,7 +192,8 @@ if __name__ == "__main__":
        'vyos-mirror': ('VyOS package mirror', None),
        'build-type': ('Build type, release or development', lambda x: x in ['release', 'development']),
        'version': ('Version number (release builds only)', None),
-       'build-comment': ('Optional build comment', None)
+       'build-comment': ('Optional build comment', None),
+       'build-hook-opts': ('Custom options for the post-build hook', None)
     }
 
     # Create the option parser
@@ -630,29 +631,43 @@ Pin-Priority: 600
         # Copy the image
         shutil.copy("live-image-{0}.hybrid.iso".format(build_config["architecture"]), iso_file)
 
-    # Build additional flavors from the ISO,
-    # if the flavor calls for them
+    # If the flavor has `image_format = "iso"`, then the work is done.
+    # If not, build additional flavors from the ISO.
     if build_config["image_format"] != ["iso"]:
+        # For all non-iso formats, we always build a raw image first
         raw_image = raw_image.create_raw_image(build_config, iso_file, "tmp/")
         manifest['artifacts'].append(raw_image)
 
-        if has_nonempty_key(build_config, "post_build_hook"):
-            # Some flavors require special procedures that aren't covered by qemu-img
-            # (most notably, the VMware OVA that requires a custom tool to make and sign the image).
-            # For those cases, we support running a post-build hook on the raw image.
-            # The image_format field should be 'raw' if a post-build hook is used.
-            hook_path = build_config["post_build_hook"]
-            cmd(f"{hook_path} {raw_image}")
-        else:
-            # Most other formats, thankfully, can be produced with just `qemu-img convert`
-            other_formats = filter(lambda x: x not in ["iso", "raw"], build_config["image_format"])
-            for f in other_formats:
-                image_ext = build_config.get("image_ext", f)
-                image_opts = build_config.get("image_opts", "")
-                target = f"{os.path.splitext(raw_image)[0]}.{image_ext}"
-                print(f"I: Building {f} file {target}")
-                cmd(f"qemu-img convert -f raw -O {f} {image_opts} {raw_image} {target}")
-                manifest['artifacts'].append(target)
+        # If there are other formats in the flavor, the assumptions is that
+        # they can be produced from a raw image with `qemu-img convert`
+        other_formats = filter(lambda x: x not in ["iso", "raw"], build_config["image_format"])
+        for f in other_formats:
+            image_ext = build_config.get("image_ext", f)
+            image_opts = build_config.get("image_opts", "")
+            target = f"{os.path.splitext(raw_image)[0]}.{image_ext}"
+            print(f"I: Building {f} file {target}")
+            cmd(f"qemu-img convert -f raw -O {f} {image_opts} {raw_image} {target}")
+            manifest['artifacts'].append(target)
+
+        # Finally, there are formats that require special procedures.
+        # For example, a VMware OVA needs a custom tool for image building and signing.
+        # For those cases, we support custom build hooks that run on raw images.
+        # A post-build hook is a script embedded in the flavor file
+        # that must return the artifact name via stdout.
+        if has_nonempty_key(build_config, "build_hook"):
+            hook_source = build_config["build_hook"]
+
+            with open('build_hook', 'w') as f:
+                f.write(hook_source)
+            os.chmod('build_hook', 0o755)
+
+            if has_nonempty_key(build_config, "build_hook_opts"):
+                hook_opts = build_config["build_hook_opts"]
+            else:
+                hook_opts = ""
+            custom_image = rc_cmd(f"./build_hook {raw_image} {build_config['version']} \
+              {build_config['architecture']} {hook_opts}")
+            manifest['artifacts'].append(custom_image)
 
     with open('manifest.json', 'w') as f:
         f.write(json.dumps(manifest))

--- a/scripts/image-build/utils.py
+++ b/scripts/image-build/utils.py
@@ -82,3 +82,10 @@ def cmd(command):
     res = vyos.utils.process.call(command, shell=True)
     if res > 0:
         raise OSError(f"Command '{command}' failed")
+
+def rc_cmd(command):
+    code, out = vyos.utils.process.rc_cmd(command, shell=True)
+    if code > 0:
+        raise OSError(f"Command '{command}' failed")
+    else:
+        return out


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Make build hooks embedded in flavors and improve their flexibility.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Image build scripts.

## Proposed changes
<!--- Describe your changes in detail -->

I'm taking advantage of the fact that we don't have any official flavors that use that mechanism yet, and I haven't seen anyone using it in the community either. The changes are breaking but I believe necessary to make the custom hook mechanism powerful enough for its intended purpose.

1. The option is now `build_hook` rather than `post_build_hook` — the motivation is that it's a part of the build processes. The hook builds artifacts that built-in functionality cannot build, the fact that it operates on a raw images produced by a built-in function is an implementation detail.

2. Image version and architecture are passed to the hook as arguments.

3. There's a way to pass custom arguments to the hook script as well, via `--build-hook-opts`/`build_hook_opts` option. 

4. The hook script is now embedded in the flavor file. This solves the problem of how to distribute hook scripts and where to store them and how to put them in `$PATH`. People in the community can just share single-file flavors, and our CI workflows can also just take single TOML files.

For example, this is how one could re-create building a qcow2 image with a hook:

```toml
build_hook = '''
RAW_IMAGE=$1
VERSION=$2
ARCH=$3
OPTS=$4

qemu-img convert -f raw -O qcow2 $OPTS $RAW_IMAGE vyos-$VERSION-$ARCH-qemu.qcow2
'''

$./build-vyos-image --build-hook-opts "-c" my-qcow2
```

5. The build script takes the image name from the hook output and adds it to the artifact list in the build manifest.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
