### PR TITLE
build: T3664: add an option to specify artifact extensions

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -337,6 +337,17 @@ if __name__ == "__main__":
     if type(build_config["image_format"]) != list:
         build_config["image_format"] = [ build_config["image_format"] ]
 
+    ## If the user didn't explicitly specify what extensions build artifact should have,
+    ## assume that the list is the same as image formats.
+    ## One case when it's not the same is when a custom build hook is used
+    ## to build a format that our build script doesn't support natively.
+    if not has_nonempty_key(build_config, "artifact_format"):
+        build_config["artifact_format"] = build_config["image_format"]
+    else:
+        # If the option is there, also make it list if it's a scalar
+        if type(build_config["artifact_format"]) != list:
+            build_config["artifact_format"] = [ build_config["artifact_format"] ]
+
     ## Dump the complete config if the user enabled debug mode
     if debug:
         import json
@@ -631,6 +642,9 @@ Pin-Priority: 600
         # Copy the image
         shutil.copy("live-image-{0}.hybrid.iso".format(build_config["architecture"]), iso_file)
 
+        # Add the image to the manifest
+        manifest['artifacts'].append(iso_file)
+
     # If the flavor has `image_format = "iso"`, then the work is done.
     # If not, build additional flavors from the ISO.
     if build_config["image_format"] != ["iso"]:
@@ -668,6 +682,19 @@ Pin-Priority: 600
             custom_image = rc_cmd(f"./build_hook {raw_image} {build_config['version']} \
               {build_config['architecture']} {hook_opts}")
             manifest['artifacts'].append(custom_image)
+
+    # Filter out unwanted files from the artifact list
+    # and leave only those the user specified
+    # in either `artifact_format` or `image_format`.
+    #
+    # For example, with `image_format = "raw"`,
+    # the ISO image is just an intermediate object, not an target artifact.
+
+    # os.path.splitext returns extensions with dots,
+    # so we need to remove the dots, hence [1:]
+    is_artifact = lambda f: os.path.splitext(f)[-1][1:] in build_config['artifact_format']
+
+    manifest['artifacts'] = list(filter(is_artifact, manifest['artifacts']))
 
     with open('manifest.json', 'w') as f:
         f.write(json.dumps(manifest))


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add `artifact_format` option that allows the user to specify what to consider artifacts.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Build scripts.

## Proposed changes
<!--- Describe your changes in detail -->

Right now, the `artifacts` field in `manifest.json` includes everything that is produced during the build process. That's not an optimal solution because the build for non-ISO formats is multi-stage and a lot of the time intermediate objects have no value for the flavor.

For example, Hyper-V images are built using the following sequence: `iso → raw → vhdx`. The raw image from that sequence is useless because Hyper-V doesn't natively support raw images, the ISO is useless because the generic ISO already includes a guest agent for Hyper-V. Thus when a Hyper-V image is build by a release pipeline, the pipeline should only pick up the `.vhdx` image.

This PR introduces two changes:

* First, it adds a new option `artifact_format`. For example, `artifact_format = "ova"` or `artifact_format = ["iso", "xva"]`.
* Second, if that option is not specified, it assumes that extensions from `image_format` are artifacts, so build with `image_format = "raw"` do not include the ISO in the manifest.

Thus it's easy to automate artifact upload — the script only needs to read the `artifacts` field, no need to guess which files to pick.  

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
