### PR TITLE
T861: Fix kernel suffix for package build by actions

### DIFF
--- a/scripts/package-build/linux-kernel/build-kernel.sh
+++ b/scripts/package-build/linux-kernel/build-kernel.sh
@@ -21,7 +21,7 @@ echo "I: Copy Kernel config (x86_64_vyos_defconfig) to Kernel Source"
 cp -rv ${CWD}/arch/ .
 
 KERNEL_VERSION=$(make kernelversion)
-KERNEL_SUFFIX=-$(awk -F "= " '/kernel_flavor/ {print $2}' ../../../data/defaults.toml | tr -d \")
+KERNEL_SUFFIX=-$(awk -F "= " '/kernel_flavor/ {print $2}' ../../../../data/defaults.toml | tr -d \")
 KERNEL_CONFIG=arch/x86/configs/vyos_defconfig
 
 # VyOS requires some small Kernel Patches - apply them here


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix kernel suffix for package build by actions (without Jenkins)
The bug was introduced in https://github.com/vyos/vyos-build/pull/772/commits/d235b31a095f9b8fdb2d5c231935c8b4b4c3da6c
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
linux-kernel
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
![package](https://github.com/user-attachments/assets/1eba0b62-8739-4bf7-9f77-8b18c234daef)


Before the fix `-6.6.52-_6.6.52-1`:
```
vyos_bld@41a0a31c2db3:/vyos/work/tmp/vyos-build/scripts/package-build/linux-kernel$ 
ls -la | grep deb
-rw-r--r--  1 vyos_bld vyos_bld   8975124 Oct  1 12:22 linux-headers-6.6.52-_6.6.52-1_amd64.deb
-rw-r--r--  1 vyos_bld vyos_bld  29464376 Oct  1 12:22 linux-image-6.6.52-_6.6.52-1_amd64.deb
-rw-r--r--  1 vyos_bld vyos_bld   1318772 Oct  1 12:22 linux-libc-dev_6.6.52-1_amd64.deb
```
After the fix we have correct name `-6.6.52-vyos_6.6.52-1`:
```
vyos_bld@41a0a31c2db3:/vyos/work/tmp/vyos-build/scripts/package-build/linux-kernel$ ls -la | grep .deb
-rw-r--r--  1 vyos_bld vyos_bld   8975048 Oct  1 12:42 linux-headers-6.6.52-vyos_6.6.52-1_amd64.deb
-rw-r--r--  1 vyos_bld vyos_bld  29455308 Oct  1 12:42 linux-image-6.6.52-vyos_6.6.52-1_amd64.deb
-rw-r--r--  1 vyos_bld vyos_bld   1318844 Oct  1 12:42 linux-libc-dev_6.6.52-1_amd64.deb
vyos_bld@41a0a31c2db3:/vyos/work/tmp/vyos-build/scripts/package-build/linux-kernel$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
