### PR TITLE
T861: Fix mellanox build by actions

### DIFF
--- a/scripts/package-build/linux-kernel/build.py
+++ b/scripts/package-build/linux-kernel/build.py
@@ -187,7 +187,7 @@ def build_intel_ixgbevf():
 
 def build_mellanox_ofed():
     """Build Mellanox OFED"""
-    run(['sudo ./build-mellanox-ofed.sh'], check=True)
+    run(['sudo', './build-mellanox-ofed.sh'], check=True)
 
 
 def build_jool():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix mellanox build by actions
Add `sudo` as element of the list
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Before the fix:
```
   File "/__w/vyos-reusable-workflows/vyos-reusable-workflows/vyos-build/scripts/package-build/linux-kernel/./build.py", line 240, in <module>
    build_package(package, dependencies)
  File "/__w/vyos-reusable-workflows/vyos-reusable-workflows/vyos-build/scripts/package-build/linux-kernel/./build.py", line 102, in build_package
    build_mellanox_ofed()
  File "/__w/vyos-reusable-workflows/vyos-reusable-workflows/vyos-build/scripts/package-build/linux-kernel/./build.py", line 190, in build_mellanox_ofed
    run(['sudo ./build-mellanox-ofed.sh'], check=True)
  File "/usr/lib/python3.11/subprocess.py", line 548, in run
Cleaned up build dependency packages
Copied generated .deb packages
    with Popen(*popenargs, **kwargs) as process:
Cleaned up build dependency packages
Copied generated .deb packages
Cleaned up build dependency packages
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1024, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1901, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'sudo ./build-mellanox-ofed.sh'
```

After the fix:
```
./build.py --packages mlnx

$ ls -la | grep .deb
-rw-r--r--  1 root     root     2292880 Oct  1 15:51 mlnx-ofed-kernel-modules_24.07.OFED.24.07.0.6.1.1-1.kver.6.6.52-vyos_amd64.deb
-rw-r--r--  1 root     root       27996 Oct  1 15:50 mlnx-ofed-kernel-utils_24.07.OFED.24.07.0.6.1.1-1.kver.6.6.52-vyos_amd64.deb
-rw-r--r--  1 root     root       69692 Oct  1 15:50 mlnx-tools_24.07.0-1.2407061_amd64.deb

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
