### PR TITLE
frr: T6756: Added patches for nhrp cisco authentication

### DIFF
--- a/scripts/package-build/frr/patches/0001-nhrp-add-cisco-authentication-password-support.patch
+++ b/scripts/package-build/frr/patches/0001-nhrp-add-cisco-authentication-password-support.patch
@@ -1,0 +1,547 @@
+From bed0bfdf2509c19b97488126f53cefcfedb72485 Mon Sep 17 00:00:00 2001
+From: Volodymyr Huti <v.huti@vyos.io>
+Date: Mon, 13 Nov 2023 22:47:31 +0200
+Subject: [PATCH 1/6] nhrp: add `cisco-authentication` password support
+
+Implemented:
+- handling 8 char long password, aka Cisco style.
+- minimal error inidication routine
+- test case, password change affects conection
+
+Signed-off-by: Volodymyr Huti <v.huti@vyos.io>
+---
+ doc/user/nhrpd.rst                          |  6 ++
+ nhrpd/nhrp_nhs.c                            |  4 +-
+ nhrpd/nhrp_packet.c                         | 27 ++++--
+ nhrpd/nhrp_peer.c                           | 98 ++++++++++++++++++---
+ nhrpd/nhrp_shortcut.c                       |  4 +-
+ nhrpd/nhrp_vty.c                            | 63 +++++++++++++
+ nhrpd/nhrpd.h                               | 10 ++-
+ nhrpd/subdir.am                             |  4 +
+ tests/topotests/nhrp_topo/r1/nhrpd.conf     |  1 +
+ tests/topotests/nhrp_topo/r2/nhrpd.conf     |  1 +
+ tests/topotests/nhrp_topo/test_nhrp_topo.py | 55 ++++++++++--
+ 11 files changed, 242 insertions(+), 31 deletions(-)
+
+diff --git a/doc/user/nhrpd.rst b/doc/user/nhrpd.rst
+index 54527a0c9..e0ba90fcc 100644
+--- a/doc/user/nhrpd.rst
++++ b/doc/user/nhrpd.rst
+@@ -84,6 +84,12 @@ Configuring NHRP
+    registration requests are sent. By default registrations are sent every one
+    third of the holdtime.
+ 
++.. clicmd:: ip nhrp authentication PASSWORD
++
++   Enables Cisco style authentication on NHRP packets. This embeds the
++   plaintext password to the outgoing NHRP packets.
++   Maximum length of the is 8 characters.
++
+ .. clicmd:: ip nhrp map A.B.C.D|X:X::X:X A.B.C.D|local
+ 
+    Map an IP address of a station to the station's NBMA address.
+diff --git a/nhrpd/nhrp_nhs.c b/nhrpd/nhrp_nhs.c
+index f779f9348..b8958ba22 100644
+--- a/nhrpd/nhrp_nhs.c
++++ b/nhrpd/nhrp_nhs.c
+@@ -216,7 +216,7 @@ static void nhrp_reg_send_req(struct event *t)
+ 	cie->holding_time = htons(if_ad->holdtime);
+ 	cie->mtu = htons(if_ad->mtu);
+ 
+-	nhrp_ext_request(zb, hdr, ifp);
++	nhrp_ext_request(zb, hdr);
+ 
+ 	/* Cisco NAT detection extension */
+ 	if (sockunion_family(&r->proto_addr) != AF_UNSPEC) {
+@@ -240,7 +240,7 @@ static void nhrp_reg_send_req(struct event *t)
+ 	cie->mtu = htons(if_ad->mtu);
+ 	nhrp_ext_complete(zb, ext);
+ 
+-	nhrp_packet_complete(zb, hdr);
++	nhrp_packet_complete(zb, hdr, ifp);
+ 	nhrp_peer_send(r->peer, zb);
+ 	zbuf_free(zb);
+ }
+diff --git a/nhrpd/nhrp_packet.c b/nhrpd/nhrp_packet.c
+index c6bd3bbbd..71f5c2f00 100644
+--- a/nhrpd/nhrp_packet.c
++++ b/nhrpd/nhrp_packet.c
+@@ -115,14 +115,32 @@ uint16_t nhrp_packet_calculate_checksum(const uint8_t *pdu, uint16_t len)
+ 	return (~csum) & 0xffff;
+ }
+ 
+-void nhrp_packet_complete(struct zbuf *zb, struct nhrp_packet_header *hdr)
++void nhrp_packet_complete(struct zbuf *zb, struct nhrp_packet_header *hdr,
++			  struct interface *ifp)
+ {
++	nhrp_packet_complete_auth(zb, hdr, ifp, true);
++}
++
++void nhrp_packet_complete_auth(struct zbuf *zb, struct nhrp_packet_header *hdr,
++			       struct interface *ifp, bool auth)
++{
++	struct nhrp_interface *nifp = ifp->info;
++	struct zbuf *auth_token = nifp->auth_token;
++	struct nhrp_extension_header *dst;
+ 	unsigned short size;
+ 
++	if (auth && auth_token) {
++		dst = nhrp_ext_push(zb, hdr,
++				    NHRP_EXTENSION_AUTHENTICATION |
++					    NHRP_EXTENSION_FLAG_COMPULSORY);
++		zbuf_copy_peek(zb, auth_token, zbuf_size(auth_token));
++		nhrp_ext_complete(zb, dst);
++	}
++
+ 	if (hdr->extension_offset)
+ 		nhrp_ext_push(zb, hdr,
+-			      NHRP_EXTENSION_END
+-				      | NHRP_EXTENSION_FLAG_COMPULSORY);
++			      NHRP_EXTENSION_END |
++				      NHRP_EXTENSION_FLAG_COMPULSORY);
+ 
+ 	size = zb->tail - (uint8_t *)hdr;
+ 	hdr->packet_size = htons(size);
+@@ -225,8 +243,7 @@ struct nhrp_extension_header *nhrp_ext_pull(struct zbuf *zb,
+ 	return ext;
+ }
+ 
+-void nhrp_ext_request(struct zbuf *zb, struct nhrp_packet_header *hdr,
+-		      struct interface *ifp)
++void nhrp_ext_request(struct zbuf *zb, struct nhrp_packet_header *hdr)
+ {
+ 	/* Place holders for standard extensions */
+ 	nhrp_ext_push(zb, hdr,
+diff --git a/nhrpd/nhrp_peer.c b/nhrpd/nhrp_peer.c
+index 1e149a167..b4ecd2614 100644
+--- a/nhrpd/nhrp_peer.c
++++ b/nhrpd/nhrp_peer.c
+@@ -609,7 +609,7 @@ static void nhrp_handle_resolution_req(struct nhrp_packet_parser *pp)
+ 			break;
+ 		}
+ 	}
+-	nhrp_packet_complete(zb, hdr);
++	nhrp_packet_complete(zb, hdr, ifp);
+ 	nhrp_peer_send(peer, zb);
+ err:
+ 	nhrp_peer_unref(peer);
+@@ -736,7 +736,8 @@ static void nhrp_handle_registration_request(struct nhrp_packet_parser *p)
+ 		}
+ 	}
+ 
+-	nhrp_packet_complete(zb, hdr);
++	// auth ext was validated and copied from the request
++	nhrp_packet_complete_auth(zb, hdr, ifp, false);
+ 	nhrp_peer_send(p->peer, zb);
+ err:
+ 	zbuf_free(zb);
+@@ -818,7 +819,7 @@ void nhrp_peer_send_indication(struct interface *ifp, uint16_t protocol_type,
+ 
+ 	/* Payload is the packet causing indication */
+ 	zbuf_copy(zb, pkt, zbuf_used(pkt));
+-	nhrp_packet_complete(zb, hdr);
++	nhrp_packet_complete(zb, hdr, ifp);
+ 	nhrp_peer_send(p, zb);
+ 	nhrp_peer_unref(p);
+ 	zbuf_free(zb);
+@@ -1069,7 +1070,8 @@ static void nhrp_peer_forward(struct nhrp_peer *p,
+ 		nhrp_ext_complete(zb, dst);
+ 	}
+ 
+-	nhrp_packet_complete(zb, hdr);
++	// XXX: auth already handled ???
++	nhrp_packet_complete_auth(zb, hdr, pp->ifp, false);
+ 	nhrp_peer_send(p, zb);
+ 	zbuf_free(zb);
+ 	zbuf_free(zb_copy);
+@@ -1095,8 +1097,7 @@ static void nhrp_packet_debug(struct zbuf *zb, const char *dir)
+ 
+ 	reply = packet_types[hdr->type].type == PACKET_REPLY;
+ 	debugf(NHRP_DEBUG_COMMON, "%s %s(%d) %pSU -> %pSU", dir,
+-	       (packet_types[hdr->type].name ? packet_types[hdr->type].name
+-					     : "Unknown"),
++	       (packet_types[hdr->type].name ? : "Unknown"),
+ 	       hdr->type, reply ? &dst_proto : &src_proto,
+ 	       reply ? &src_proto : &dst_proto);
+ }
+@@ -1112,11 +1113,70 @@ static int proto2afi(uint16_t proto)
+ 	return AF_UNSPEC;
+ }
+ 
+-struct nhrp_route_info {
+-	int local;
+-	struct interface *ifp;
+-	struct nhrp_vc *vc;
+-};
++static int nhrp_packet_send_error(struct nhrp_packet_parser *pp,
++				  uint16_t indication_code, uint16_t offset)
++{
++	union sockunion src_proto, dst_proto;
++	struct nhrp_packet_header *hdr;
++	struct zbuf *zb;
++
++	src_proto = pp->src_proto;
++	dst_proto = pp->dst_proto;
++	if (packet_types[pp->hdr->type].type != PACKET_REPLY) {
++		src_proto = pp->dst_proto;
++		dst_proto = pp->src_proto;
++	}
++	/* Create reply */
++	zb = zbuf_alloc(1500); // XXX: hardcode -> calculation routine
++	hdr = nhrp_packet_push(zb, NHRP_PACKET_ERROR_INDICATION, &pp->src_nbma,
++			       &src_proto, &dst_proto);
++
++	hdr->u.error.code = indication_code;
++	hdr->u.error.offset = htons(offset);
++	hdr->flags = pp->hdr->flags;
++	hdr->hop_count = 0; // XXX: cisco returns 255
++
++	/* Payload is the packet causing error */
++	/* Don`t add extension according to RFC */
++	/* wireshark gives bad checksum, without exts */
++	// pp->hdr->checksum = nhrp_packet_calculate_checksum(zbuf_used(&pp->payload))
++	zbuf_put(zb, pp->hdr, sizeof(*pp->hdr));
++	zbuf_copy(zb, &pp->payload, zbuf_used(&pp->payload));
++	nhrp_packet_complete_auth(zb, hdr, pp->ifp, false);
++
++	/* nhrp_packet_debug(zb, "SEND_ERROR"); */
++	nhrp_peer_send(pp->peer, zb);
++	zbuf_free(zb);
++	return 0;
++}
++
++static bool nhrp_connection_authorized(struct nhrp_packet_parser *pp)
++{
++	struct nhrp_cisco_authentication_extension *auth_ext;
++	struct nhrp_interface *nifp = pp->ifp->info;
++	struct zbuf *auth = nifp->auth_token;
++	struct nhrp_extension_header *ext;
++	struct zbuf *extensions, pl;
++	int cmp = 0;
++
++
++	extensions = zbuf_alloc(zbuf_used(&pp->extensions));
++	zbuf_copy_peek(extensions, &pp->extensions, zbuf_used(&pp->extensions));
++	while ((ext = nhrp_ext_pull(extensions, &pl)) != NULL) {
++		switch (htons(ext->type) & ~NHRP_EXTENSION_FLAG_COMPULSORY) {
++		case NHRP_EXTENSION_AUTHENTICATION:
++			cmp = memcmp(auth->buf, pl.buf, zbuf_size(auth));
++			auth_ext = (struct nhrp_cisco_authentication_extension *)
++					   auth->buf;
++			debugf(NHRP_DEBUG_COMMON,
++			       "Processing Authentication Extension for (%s:%s|%d)",
++			       auth_ext->secret, (const char *)pl.buf, cmp);
++			break;
++		}
++	}
++	zbuf_free(extensions);
++	return cmp == 0;
++}
+ 
+ void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb)
+ {
+@@ -1197,10 +1257,20 @@ void nhrp_peer_recv(struct nhrp_peer *p, struct zbuf *zb)
+ 		goto drop;
+ 	}
+ 
++	/* RFC2332 5.3.4 - Authentication is always done pairwise on an NHRP
++	 * hop-by-hop basis; i.e. regenerated at each hop. */
+ 	nhrp_packet_debug(zb, "Recv");
+-
+-	/* FIXME: Check authentication here. This extension needs to be
+-	 * pre-handled. */
++	if (nifp->auth_token &&
++	    (hdr->type != NHRP_PACKET_ERROR_INDICATION ||
++	     hdr->u.error.code != NHRP_ERROR_AUTHENTICATION_FAILURE)) {
++		if (!nhrp_connection_authorized(&pp)) {
++			nhrp_packet_send_error(&pp,
++					       NHRP_ERROR_AUTHENTICATION_FAILURE,
++					       0);
++			info = "authentication failure";
++			goto drop;
++		}
++	}
+ 
+ 	/* Figure out if this is local */
+ 	target_addr = (packet_types[hdr->type].type == PACKET_REPLY)
+diff --git a/nhrpd/nhrp_shortcut.c b/nhrpd/nhrp_shortcut.c
+index e83ce7f58..9b47d974c 100644
+--- a/nhrpd/nhrp_shortcut.c
++++ b/nhrpd/nhrp_shortcut.c
+@@ -425,7 +425,7 @@ static void nhrp_shortcut_send_resolution_req(struct nhrp_shortcut *s)
+ 	       "Shortcut res_req: set cie ht to %u and mtu to %u. shortcut ht is %u",
+ 	       ntohs(cie->holding_time), ntohs(cie->mtu), s->holding_time);
+ 
+-	nhrp_ext_request(zb, hdr, ifp);
++	nhrp_ext_request(zb, hdr);
+ 
+ 	/* Cisco NAT detection extension */
+ 	hdr->flags |= htons(NHRP_FLAG_RESOLUTION_NAT);
+@@ -438,7 +438,7 @@ static void nhrp_shortcut_send_resolution_req(struct nhrp_shortcut *s)
+ 		nhrp_ext_complete(zb, ext);
+ 	}
+ 
+-	nhrp_packet_complete(zb, hdr);
++	nhrp_packet_complete(zb, hdr, ifp);
+ 
+ 	nhrp_peer_send(peer, zb);
+ 	nhrp_peer_unref(peer);
+diff --git a/nhrpd/nhrp_vty.c b/nhrpd/nhrp_vty.c
+index f91fcb532..7c53e5a4f 100644
+--- a/nhrpd/nhrp_vty.c
++++ b/nhrpd/nhrp_vty.c
+@@ -12,6 +12,9 @@
+ 
+ #include "nhrpd.h"
+ #include "netlink.h"
++#include "nhrp_protocol.h"
++
++#include "nhrpd/nhrp_vty_clippy.c"
+ 
+ static int nhrp_config_write(struct vty *vty);
+ static struct cmd_node zebra_node = {
+@@ -459,6 +462,56 @@ DEFUN(if_no_nhrp_holdtime, if_no_nhrp_holdtime_cmd,
+ 	return CMD_SUCCESS;
+ }
+ 
++#define NHRP_CISCO_PASS_LEN 8
++DEFPY(if_nhrp_authentication, if_nhrp_authentication_cmd,
++      AFI_CMD "nhrp authentication PASSWORD$password",
++      AFI_STR
++      NHRP_STR
++      "Specify plaint text password used for authenticantion\n"
++      "Password, plain text, limited to 8 characters\n")
++{
++	VTY_DECLVAR_CONTEXT(interface, ifp);
++	struct nhrp_cisco_authentication_extension *auth;
++	struct nhrp_interface *nifp = ifp->info;
++	int pass_len = strlen(password);
++
++	if (pass_len > NHRP_CISCO_PASS_LEN) {
++		vty_out(vty, "Password size limit exceeded (%d>%d)\n",
++			pass_len, NHRP_CISCO_PASS_LEN);
++		return CMD_WARNING_CONFIG_FAILED;
++	}
++
++	if (nifp->auth_token)
++		zbuf_free(nifp->auth_token);
++
++	nifp->auth_token = zbuf_alloc(pass_len + sizeof(uint32_t));
++	auth = (struct nhrp_cisco_authentication_extension *)
++		       nifp->auth_token->buf;
++	auth->type = htonl(NHRP_AUTHENTICATION_PLAINTEXT);
++	memcpy(auth->secret, password, pass_len);
++
++	// XXX RFC: reset active (non-authorized) connections?
++	/* vty_out(vty, "NHRP passwd (%s:%s)", nifp->ifp->name, auth->secret); */
++	return CMD_SUCCESS;
++}
++
++
++DEFPY(if_no_nhrp_authentication, if_no_nhrp_authentication_cmd,
++      "no " AFI_CMD "nhrp authentication PASSWORD$password",
++      NO_STR
++      AFI_STR
++      NHRP_STR
++      "Reset password used for authentication\n"
++      "Password, plain text\n")
++{
++	VTY_DECLVAR_CONTEXT(interface, ifp);
++	struct nhrp_interface *nifp = ifp->info;
++	if (nifp->auth_token)
++		zbuf_free(nifp->auth_token);
++	return CMD_SUCCESS;
++}
++
++
+ DEFUN(if_nhrp_mtu, if_nhrp_mtu_cmd,
+ 	"ip nhrp mtu <(576-1500)|opennhrp>",
+ 	IP_STR
+@@ -1053,6 +1106,7 @@ DEFUN(show_dmvpn, show_dmvpn_cmd,
+ static void clear_nhrp_cache(struct nhrp_cache *c, void *data)
+ {
+ 	struct info_ctx *ctx = data;
++
+ 	if (c->cur.type <= NHRP_CACHE_DYNAMIC) {
+ 		nhrp_cache_update_binding(c, c->cur.type, -1, NULL, 0, NULL,
+ 					  NULL);
+@@ -1129,6 +1183,7 @@ static void interface_config_write_nhrp_map(struct nhrp_cache_config *c,
+ static int interface_config_write(struct vty *vty)
+ {
+ 	struct vrf *vrf = vrf_lookup_by_id(VRF_DEFAULT);
++	struct nhrp_cisco_authentication_extension *auth;
+ 	struct write_map_ctx mapctx;
+ 	struct interface *ifp;
+ 	struct nhrp_interface *nifp;
+@@ -1155,6 +1210,12 @@ static int interface_config_write(struct vty *vty)
+ 		if (nifp->source)
+ 			vty_out(vty, " tunnel source %s\n", nifp->source);
+ 
++		if (nifp->auth_token) {
++			auth = (struct nhrp_cisco_authentication_extension *)
++				       nifp->auth_token->buf;
++			vty_out(vty, " ip nhrp authentication %s\n", auth->secret);
++		}
++
+ 		for (afi = 0; afi < AFI_MAX; afi++) {
+ 			struct nhrp_afi_data *ad = &nifp->afi[afi];
+ 
+@@ -1256,6 +1317,8 @@ void nhrp_config_init(void)
+ 	install_element(INTERFACE_NODE, &if_no_nhrp_network_id_cmd);
+ 	install_element(INTERFACE_NODE, &if_nhrp_holdtime_cmd);
+ 	install_element(INTERFACE_NODE, &if_no_nhrp_holdtime_cmd);
++	install_element(INTERFACE_NODE, &if_nhrp_authentication_cmd);
++	install_element(INTERFACE_NODE, &if_no_nhrp_authentication_cmd);
+ 	install_element(INTERFACE_NODE, &if_nhrp_mtu_cmd);
+ 	install_element(INTERFACE_NODE, &if_no_nhrp_mtu_cmd);
+ 	install_element(INTERFACE_NODE, &if_nhrp_flags_cmd);
+diff --git a/nhrpd/nhrpd.h b/nhrpd/nhrpd.h
+index e389b7489..344e1d517 100644
+--- a/nhrpd/nhrpd.h
++++ b/nhrpd/nhrpd.h
+@@ -311,6 +311,7 @@ DECLARE_DLIST(nhrp_reglist, struct nhrp_registration, reglist_entry);
+ struct nhrp_interface {
+ 	struct interface *ifp;
+ 
++	struct zbuf *auth_token;
+ 	unsigned enabled : 1;
+ 
+ 	char *ipsec_profile, *ipsec_fallback_profile, *source;
+@@ -480,9 +481,13 @@ struct nhrp_packet_header *nhrp_packet_push(struct zbuf *zb, uint8_t type,
+ 					    const union sockunion *src_nbma,
+ 					    const union sockunion *src_proto,
+ 					    const union sockunion *dst_proto);
+-void nhrp_packet_complete(struct zbuf *zb, struct nhrp_packet_header *hdr);
+ uint16_t nhrp_packet_calculate_checksum(const uint8_t *pdu, uint16_t len);
+ 
++void nhrp_packet_complete(struct zbuf *zb, struct nhrp_packet_header *hdr,
++			  struct interface *ifp);
++void nhrp_packet_complete_auth(struct zbuf *zb, struct nhrp_packet_header *hdr,
++			       struct interface *ifp, bool auth);
++
+ struct nhrp_packet_header *nhrp_packet_pull(struct zbuf *zb,
+ 					    union sockunion *src_nbma,
+ 					    union sockunion *src_proto,
+@@ -501,8 +506,7 @@ nhrp_ext_push(struct zbuf *zb, struct nhrp_packet_header *hdr, uint16_t type);
+ void nhrp_ext_complete(struct zbuf *zb, struct nhrp_extension_header *ext);
+ struct nhrp_extension_header *nhrp_ext_pull(struct zbuf *zb,
+ 					    struct zbuf *payload);
+-void nhrp_ext_request(struct zbuf *zb, struct nhrp_packet_header *hdr,
+-		      struct interface *);
++void nhrp_ext_request(struct zbuf *zb, struct nhrp_packet_header *hdr);
+ int nhrp_ext_reply(struct zbuf *zb, struct nhrp_packet_header *hdr,
+ 		   struct interface *ifp, struct nhrp_extension_header *ext,
+ 		   struct zbuf *extpayload);
+diff --git a/nhrpd/subdir.am b/nhrpd/subdir.am
+index 227ff6c67..94fb3bb5b 100644
+--- a/nhrpd/subdir.am
++++ b/nhrpd/subdir.am
+@@ -42,3 +42,7 @@ noinst_HEADERS += \
+ 	nhrpd/zbuf.h \
+ 	nhrpd/znl.h \
+ 	# end
++
++clippy_scan += \
++	nhrpd/nhrp_vty.c \
++	# end
+diff --git a/tests/topotests/nhrp_topo/r1/nhrpd.conf b/tests/topotests/nhrp_topo/r1/nhrpd.conf
+index e5224e4aa..027312dcd 100644
+--- a/tests/topotests/nhrp_topo/r1/nhrpd.conf
++++ b/tests/topotests/nhrp_topo/r1/nhrpd.conf
+@@ -1,6 +1,7 @@
+ log stdout debugging
+ ! debug nhrp all
+ interface r1-gre0
++ ip nhrp authentication secret
+  ip nhrp holdtime 500
+  ip nhrp shortcut
+  ip nhrp network-id 42
+diff --git a/tests/topotests/nhrp_topo/r2/nhrpd.conf b/tests/topotests/nhrp_topo/r2/nhrpd.conf
+index f9185f9a6..621db6abc 100644
+--- a/tests/topotests/nhrp_topo/r2/nhrpd.conf
++++ b/tests/topotests/nhrp_topo/r2/nhrpd.conf
+@@ -2,6 +2,7 @@
+ log stdout debugging
+ nhrp nflog-group 1
+ interface r2-gre0
++ ip nhrp authentication secret
+  ip nhrp holdtime 500
+  ip nhrp redirect
+  ip nhrp network-id 42
+diff --git a/tests/topotests/nhrp_topo/test_nhrp_topo.py b/tests/topotests/nhrp_topo/test_nhrp_topo.py
+index 284c58a8e..c57d28b70 100644
+--- a/tests/topotests/nhrp_topo/test_nhrp_topo.py
++++ b/tests/topotests/nhrp_topo/test_nhrp_topo.py
+@@ -214,19 +214,64 @@ def test_protocols_convergence():
+ def test_nhrp_connection():
+     "Assert that the NHRP peers can find themselves."
+     tgen = get_topogen()
++    pingrouter = tgen.gears["r1"]
++    hubrouter = tgen.gears["r2"]
+     if tgen.routers_have_failure():
+         pytest.skip(tgen.errors)
+ 
+-    pingrouter = tgen.gears["r1"]
+-    logger.info("Check Ping IPv4 from  R1 to R2 = 10.255.255.2)")
+-    output = pingrouter.run("ping 10.255.255.2 -f -c 1000")
+-    logger.info(output)
+-    if "1000 packets transmitted, 1000 received" not in output:
++    def ping_helper():
++        output = pingrouter.run("ping 10.255.255.2 -f -c 100")
++        logger.info(output)
++        return output
++
++    # force session to reinitialize
++    def relink_session():
++        for r in ["r1", "r2"]:
++            tgen.gears[r].vtysh_cmd("clear ip nhrp cache")
++            tgen.net[r].cmd("ip l del {}-gre0".format(r));
++        _populate_iface();
++
++    ### Passwords are the same
++    logger.info("Check Ping IPv4 from  R1 to R2 = 10.255.255.2")
++    output = ping_helper()
++    if "100 packets transmitted, 100 received" not in output:
+         assertmsg = "expected ping IPv4 from R1 to R2 should be ok"
+         assert 0, assertmsg
+     else:
+         logger.info("Check Ping IPv4 from R1 to R2 OK")
+ 
++    ### Passwords are different
++    logger.info("Modify password and send ping again, should drop")
++    hubrouter.vtysh_cmd("""
++        configure
++            interface r2-gre0
++                ip nhrp authentication secret12
++    """)
++    relink_session()
++    topotest.sleep(10, "Waiting for session to initialize")
++    output = ping_helper()
++    if "Network is unreachable" not in output:
++        assertmsg = "expected ping IPv4 from R1 to R2 - should be down"
++        assert 0, assertmsg
++    else:
++        logger.info("Check Ping IPv4 from R1 to R2 missing - OK")
++
++    ### Passwords are the same - again
++    logger.info("Recover password and verify conectivity is back")
++    hubrouter.vtysh_cmd("""
++        configure
++            interface r2-gre0
++                ip nhrp authentication secret
++    """)
++    relink_session()
++    topotest.sleep(10, "Waiting for session to initialize")
++    output = pingrouter.run("ping 10.255.255.2 -f -c 100")
++    logger.info(output)
++    if "100 packets transmitted, 100 received" not in output:
++        assertmsg = "expected ping IPv4 from R1 to R2 should be ok"
++        assert 0, assertmsg
++    else:
++        logger.info("Check Ping IPv4 from R1 to R2 OK")
+ 
+ def test_route_install():
+     "Test use of NHRP routes by other protocols (sharpd here)."
+-- 
+2.30.2
+

--- a/scripts/package-build/frr/patches/0002-nhrpd-add-cisco-authentication-password-support.patch
+++ b/scripts/package-build/frr/patches/0002-nhrpd-add-cisco-authentication-password-support.patch
@@ -1,0 +1,279 @@
+From 904f9b7e85db9d8fd88f8a40ba6efb31fdab8031 Mon Sep 17 00:00:00 2001
+From: Dave LeRoy <dleroy@labn.net>
+Date: Wed, 5 Jun 2024 12:10:11 -0700
+Subject: [PATCH 2/6] nhrpd: add cisco-authentication password support
+
+Taking over this development from https://github.com/FRRouting/frr/pull/14788
+
+This commit addresses 4 issues found in the previous PR
+
+1) FRR would accept messages from a spoke without authentication when FRR NHRP had auth configured.
+2) The error indication was not being sent in network byte order
+3) The debug print in nhrp_connection_authorized was not correctly printing the received password
+4) The addresses portion of the mandatory part of the error indication was invalid on the wire (confirmed in wireshark)
+
+Signed-off-by: Dave LeRoy <dleroy@labn.net>
+Co-authored-by: Volodymyr Huti <volodymyr.huti@gmail.com>
+---
+ doc/user/nhrpd.rst                          |  2 +-
+ nhrpd/nhrp_interface.c                      |  2 +
+ nhrpd/nhrp_peer.c                           | 31 ++++++++------
+ nhrpd/nhrp_vty.c                            |  9 ++--
+ tests/topotests/nhrp_topo/r1/nhrpd.conf     |  2 +-
+ tests/topotests/nhrp_topo/r2/nhrpd.conf     |  2 +-
+ tests/topotests/nhrp_topo/test_nhrp_topo.py | 46 ++++++++++-----------
+ 7 files changed, 51 insertions(+), 43 deletions(-)
+
+diff --git a/doc/user/nhrpd.rst b/doc/user/nhrpd.rst
+index e0ba90fcc..648d56d9c 100644
+--- a/doc/user/nhrpd.rst
++++ b/doc/user/nhrpd.rst
+@@ -88,7 +88,7 @@ Configuring NHRP
+ 
+    Enables Cisco style authentication on NHRP packets. This embeds the
+    plaintext password to the outgoing NHRP packets.
+-   Maximum length of the is 8 characters.
++   Maximum length of the password is 8 characters.
+ 
+ .. clicmd:: ip nhrp map A.B.C.D|X:X::X:X A.B.C.D|local
+ 
+diff --git a/nhrpd/nhrp_interface.c b/nhrpd/nhrp_interface.c
+index 7d0ab9762..e81a2efbb 100644
+--- a/nhrpd/nhrp_interface.c
++++ b/nhrpd/nhrp_interface.c
+@@ -99,6 +99,8 @@ static int nhrp_if_delete_hook(struct interface *ifp)
+ 		free(nifp->ipsec_fallback_profile);
+ 	if (nifp->source)
+ 		free(nifp->source);
++	if (nifp->auth_token)
++		zbuf_free(nifp->auth_token);
+ 
+ 	XFREE(MTYPE_NHRP_IF, ifp->info);
+ 	return 0;
+diff --git a/nhrpd/nhrp_peer.c b/nhrpd/nhrp_peer.c
+index b4ecd2614..602db36d2 100644
+--- a/nhrpd/nhrp_peer.c
++++ b/nhrpd/nhrp_peer.c
+@@ -736,7 +736,7 @@ static void nhrp_handle_registration_request(struct nhrp_packet_parser *p)
+ 		}
+ 	}
+ 
+-	// auth ext was validated and copied from the request
++	/* auth ext was validated and copied from the request */
+ 	nhrp_packet_complete_auth(zb, hdr, ifp, false);
+ 	nhrp_peer_send(p->peer, zb);
+ err:
+@@ -1070,7 +1070,6 @@ static void nhrp_peer_forward(struct nhrp_peer *p,
+ 		nhrp_ext_complete(zb, dst);
+ 	}
+ 
+-	// XXX: auth already handled ???
+ 	nhrp_packet_complete_auth(zb, hdr, pp->ifp, false);
+ 	nhrp_peer_send(p, zb);
+ 	zbuf_free(zb);
+@@ -1127,24 +1126,26 @@ static int nhrp_packet_send_error(struct nhrp_packet_parser *pp,
+ 		dst_proto = pp->src_proto;
+ 	}
+ 	/* Create reply */
+-	zb = zbuf_alloc(1500); // XXX: hardcode -> calculation routine
++	zb = zbuf_alloc(1500);
+ 	hdr = nhrp_packet_push(zb, NHRP_PACKET_ERROR_INDICATION, &pp->src_nbma,
+ 			       &src_proto, &dst_proto);
+ 
+-	hdr->u.error.code = indication_code;
++	hdr->u.error.code = htons(indication_code);
+ 	hdr->u.error.offset = htons(offset);
+ 	hdr->flags = pp->hdr->flags;
+-	hdr->hop_count = 0; // XXX: cisco returns 255
++	hdr->hop_count = 0; /* XXX: cisco returns 255 */
+ 
+ 	/* Payload is the packet causing error */
+ 	/* Don`t add extension according to RFC */
+-	/* wireshark gives bad checksum, without exts */
+-	// pp->hdr->checksum = nhrp_packet_calculate_checksum(zbuf_used(&pp->payload))
+ 	zbuf_put(zb, pp->hdr, sizeof(*pp->hdr));
+-	zbuf_copy(zb, &pp->payload, zbuf_used(&pp->payload));
++	zbuf_put(zb, sockunion_get_addr(&pp->src_nbma),
++		 hdr->src_nbma_address_len);
++	zbuf_put(zb, sockunion_get_addr(&pp->src_proto),
++		 hdr->src_protocol_address_len);
++	zbuf_put(zb, sockunion_get_addr(&pp->dst_proto),
++		 hdr->dst_protocol_address_len);
+ 	nhrp_packet_complete_auth(zb, hdr, pp->ifp, false);
+ 
+-	/* nhrp_packet_debug(zb, "SEND_ERROR"); */
+ 	nhrp_peer_send(pp->peer, zb);
+ 	zbuf_free(zb);
+ 	return 0;
+@@ -1157,8 +1158,7 @@ static bool nhrp_connection_authorized(struct nhrp_packet_parser *pp)
+ 	struct zbuf *auth = nifp->auth_token;
+ 	struct nhrp_extension_header *ext;
+ 	struct zbuf *extensions, pl;
+-	int cmp = 0;
+-
++	int cmp = 1;
+ 
+ 	extensions = zbuf_alloc(zbuf_used(&pp->extensions));
+ 	zbuf_copy_peek(extensions, &pp->extensions, zbuf_used(&pp->extensions));
+@@ -1170,7 +1170,14 @@ static bool nhrp_connection_authorized(struct nhrp_packet_parser *pp)
+ 					   auth->buf;
+ 			debugf(NHRP_DEBUG_COMMON,
+ 			       "Processing Authentication Extension for (%s:%s|%d)",
+-			       auth_ext->secret, (const char *)pl.buf, cmp);
++			       auth_ext->secret,
++			       ((struct nhrp_cisco_authentication_extension *)
++					pl.buf)
++				       ->secret,
++			       cmp);
++			break;
++		default:
++			/* Ignoring all received extensions except Authentication*/
+ 			break;
+ 		}
+ 	}
+diff --git a/nhrpd/nhrp_vty.c b/nhrpd/nhrp_vty.c
+index 7c53e5a4f..8d0d0cc54 100644
+--- a/nhrpd/nhrp_vty.c
++++ b/nhrpd/nhrp_vty.c
+@@ -467,7 +467,7 @@ DEFPY(if_nhrp_authentication, if_nhrp_authentication_cmd,
+       AFI_CMD "nhrp authentication PASSWORD$password",
+       AFI_STR
+       NHRP_STR
+-      "Specify plaint text password used for authenticantion\n"
++      "Specify plain text password used for authenticantion\n"
+       "Password, plain text, limited to 8 characters\n")
+ {
+ 	VTY_DECLVAR_CONTEXT(interface, ifp);
+@@ -490,8 +490,6 @@ DEFPY(if_nhrp_authentication, if_nhrp_authentication_cmd,
+ 	auth->type = htonl(NHRP_AUTHENTICATION_PLAINTEXT);
+ 	memcpy(auth->secret, password, pass_len);
+ 
+-	// XXX RFC: reset active (non-authorized) connections?
+-	/* vty_out(vty, "NHRP passwd (%s:%s)", nifp->ifp->name, auth->secret); */
+ 	return CMD_SUCCESS;
+ }
+ 
+@@ -501,11 +499,12 @@ DEFPY(if_no_nhrp_authentication, if_no_nhrp_authentication_cmd,
+       NO_STR
+       AFI_STR
+       NHRP_STR
+-      "Reset password used for authentication\n"
+-      "Password, plain text\n")
++      "Specify plain text password used for authenticantion\n"
++	  "Password, plain text, limited to 8 characters\n")
+ {
+ 	VTY_DECLVAR_CONTEXT(interface, ifp);
+ 	struct nhrp_interface *nifp = ifp->info;
++
+ 	if (nifp->auth_token)
+ 		zbuf_free(nifp->auth_token);
+ 	return CMD_SUCCESS;
+diff --git a/tests/topotests/nhrp_topo/r1/nhrpd.conf b/tests/topotests/nhrp_topo/r1/nhrpd.conf
+index 027312dcd..8ade77d07 100644
+--- a/tests/topotests/nhrp_topo/r1/nhrpd.conf
++++ b/tests/topotests/nhrp_topo/r1/nhrpd.conf
+@@ -2,7 +2,7 @@ log stdout debugging
+ ! debug nhrp all
+ interface r1-gre0
+  ip nhrp authentication secret
+- ip nhrp holdtime 500
++ ip nhrp holdtime 10
+  ip nhrp shortcut
+  ip nhrp network-id 42
+  ip nhrp nhs dynamic nbma 10.2.1.2
+diff --git a/tests/topotests/nhrp_topo/r2/nhrpd.conf b/tests/topotests/nhrp_topo/r2/nhrpd.conf
+index 621db6abc..d8e59936c 100644
+--- a/tests/topotests/nhrp_topo/r2/nhrpd.conf
++++ b/tests/topotests/nhrp_topo/r2/nhrpd.conf
+@@ -3,7 +3,7 @@ log stdout debugging
+ nhrp nflog-group 1
+ interface r2-gre0
+  ip nhrp authentication secret
+- ip nhrp holdtime 500
++ ip nhrp holdtime 10
+  ip nhrp redirect
+  ip nhrp network-id 42
+  ip nhrp registration no-unique
+diff --git a/tests/topotests/nhrp_topo/test_nhrp_topo.py b/tests/topotests/nhrp_topo/test_nhrp_topo.py
+index c57d28b70..883300310 100644
+--- a/tests/topotests/nhrp_topo/test_nhrp_topo.py
++++ b/tests/topotests/nhrp_topo/test_nhrp_topo.py
+@@ -28,7 +28,7 @@ sys.path.append(os.path.join(CWD, "../"))
+ from lib import topotest
+ from lib.topogen import Topogen, TopoRouter, get_topogen
+ from lib.topolog import logger
+-from lib.common_config import required_linux_kernel_version
++from lib.common_config import required_linux_kernel_version, retry
+ 
+ # Required to instantiate the topology builder class.
+ 
+@@ -231,14 +231,27 @@ def test_nhrp_connection():
+             tgen.net[r].cmd("ip l del {}-gre0".format(r));
+         _populate_iface();
+ 
++    @retry(retry_timeout=40, initial_wait=5)
++    def verify_same_password():
++        output = ping_helper()
++        if "100 packets transmitted, 100 received" not in output:
++            assertmsg = "expected ping IPv4 from R1 to R2 should be ok"
++            assert 0, assertmsg
++        else:
++            logger.info("Check Ping IPv4 from R1 to R2 OK")
++
++    @retry(retry_timeout=40, initial_wait=5)
++    def verify_mismatched_password():
++        output = ping_helper()
++        if "Network is unreachable" not in output:
++            assertmsg = "expected ping IPv4 from R1 to R2 - should be down"
++            assert 0, assertmsg
++        else:
++            logger.info("Check Ping IPv4 from R1 to R2 missing - OK")
++
+     ### Passwords are the same
+     logger.info("Check Ping IPv4 from  R1 to R2 = 10.255.255.2")
+-    output = ping_helper()
+-    if "100 packets transmitted, 100 received" not in output:
+-        assertmsg = "expected ping IPv4 from R1 to R2 should be ok"
+-        assert 0, assertmsg
+-    else:
+-        logger.info("Check Ping IPv4 from R1 to R2 OK")
++    verify_same_password()
+ 
+     ### Passwords are different
+     logger.info("Modify password and send ping again, should drop")
+@@ -248,14 +261,8 @@ def test_nhrp_connection():
+                 ip nhrp authentication secret12
+     """)
+     relink_session()
+-    topotest.sleep(10, "Waiting for session to initialize")
+-    output = ping_helper()
+-    if "Network is unreachable" not in output:
+-        assertmsg = "expected ping IPv4 from R1 to R2 - should be down"
+-        assert 0, assertmsg
+-    else:
+-        logger.info("Check Ping IPv4 from R1 to R2 missing - OK")
+-
++    verify_mismatched_password()
++    
+     ### Passwords are the same - again
+     logger.info("Recover password and verify conectivity is back")
+     hubrouter.vtysh_cmd("""
+@@ -264,14 +271,7 @@ def test_nhrp_connection():
+                 ip nhrp authentication secret
+     """)
+     relink_session()
+-    topotest.sleep(10, "Waiting for session to initialize")
+-    output = pingrouter.run("ping 10.255.255.2 -f -c 100")
+-    logger.info(output)
+-    if "100 packets transmitted, 100 received" not in output:
+-        assertmsg = "expected ping IPv4 from R1 to R2 should be ok"
+-        assert 0, assertmsg
+-    else:
+-        logger.info("Check Ping IPv4 from R1 to R2 OK")
++    verify_same_password()
+ 
+ def test_route_install():
+     "Test use of NHRP routes by other protocols (sharpd here)."
+-- 
+2.30.2
+

--- a/scripts/package-build/frr/patches/0003-nhrpd-Fixes-auth-config-change-bug.patch
+++ b/scripts/package-build/frr/patches/0003-nhrpd-Fixes-auth-config-change-bug.patch
@@ -1,0 +1,47 @@
+From 889df80cd104bae5e3ce4a11a7af68723a4de082 Mon Sep 17 00:00:00 2001
+From: Dave LeRoy <dleroy@labn.net>
+Date: Wed, 17 Jul 2024 10:37:44 -0700
+Subject: [PATCH 3/6] nhrpd: Fixes auth config change bug
+
+Freeing auth-token does not set nifp->auth_token to NULL.
+Explicitly set auth_token to NULL when deleting auth config in order
+for write config logic to succeed.
+
+Fix bug #16359
+
+Signed-off-by: Dave LeRoy <dleroy@labn.net>
+---
+ nhrpd/nhrp_vty.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/nhrpd/nhrp_vty.c b/nhrpd/nhrp_vty.c
+index 8d0d0cc54..96ba4728b 100644
+--- a/nhrpd/nhrp_vty.c
++++ b/nhrpd/nhrp_vty.c
+@@ -481,8 +481,10 @@ DEFPY(if_nhrp_authentication, if_nhrp_authentication_cmd,
+ 		return CMD_WARNING_CONFIG_FAILED;
+ 	}
+ 
+-	if (nifp->auth_token)
++	if (nifp->auth_token) {
+ 		zbuf_free(nifp->auth_token);
++		nifp->auth_token = NULL;
++	}
+ 
+ 	nifp->auth_token = zbuf_alloc(pass_len + sizeof(uint32_t));
+ 	auth = (struct nhrp_cisco_authentication_extension *)
+@@ -505,8 +507,10 @@ DEFPY(if_no_nhrp_authentication, if_no_nhrp_authentication_cmd,
+ 	VTY_DECLVAR_CONTEXT(interface, ifp);
+ 	struct nhrp_interface *nifp = ifp->info;
+ 
+-	if (nifp->auth_token)
++	if (nifp->auth_token) {
+ 		zbuf_free(nifp->auth_token);
++		nifp->auth_token = NULL;
++	}
+ 	return CMD_SUCCESS;
+ }
+ 
+-- 
+2.30.2
+

--- a/scripts/package-build/frr/patches/0004-nhrpd-Fixes-auth-no-redirect-bug.patch
+++ b/scripts/package-build/frr/patches/0004-nhrpd-Fixes-auth-no-redirect-bug.patch
@@ -1,0 +1,48 @@
+From 89fced5c4e96f891926acecdac1cf35bde34925d Mon Sep 17 00:00:00 2001
+From: Dave LeRoy <dleroy@labn.net>
+Date: Thu, 18 Jul 2024 10:19:30 -0700
+Subject: [PATCH 4/6] nhrpd: Fixes auth no redirect bug
+
+The nhrp_peer_forward() routine was not explicitly handling the
+Authentication Extension in the switch statement and instead fell
+through to the default case which checked whether this was an
+unhandled Compulsory extension and errored out, never forwarding
+the Resolution Request.
+
+Fix bug #16371
+
+Signed-off-by: Dave LeRoy <dleroy@labn.net>
+---
+ nhrpd/nhrp_peer.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/nhrpd/nhrp_peer.c b/nhrpd/nhrp_peer.c
+index 602db36d2..1fd089a34 100644
+--- a/nhrpd/nhrp_peer.c
++++ b/nhrpd/nhrp_peer.c
+@@ -1052,6 +1052,13 @@ static void nhrp_peer_forward(struct nhrp_peer *p,
+ 				zbuf_put(zb, extpl.head, len);
+ 			}
+ 			break;
++		case NHRP_EXTENSION_AUTHENTICATION:
++			/* At this point, received packet has been authenticated.
++			 *  Just need to regenerate auth extension before forwarding.
++			 *  This will be done below in nhrp_packet_complete_auth().
++			 */
++			break;
++
+ 		default:
+ 			if (htons(ext->type) & NHRP_EXTENSION_FLAG_COMPULSORY)
+ 				/* FIXME: RFC says to just copy, but not
+@@ -1070,7 +1077,7 @@ static void nhrp_peer_forward(struct nhrp_peer *p,
+ 		nhrp_ext_complete(zb, dst);
+ 	}
+ 
+-	nhrp_packet_complete_auth(zb, hdr, pp->ifp, false);
++	nhrp_packet_complete_auth(zb, hdr, pp->ifp, true);
+ 	nhrp_peer_send(p, zb);
+ 	zbuf_free(zb);
+ 	zbuf_free(zb_copy);
+-- 
+2.30.2
+

--- a/scripts/package-build/frr/patches/0005-nhrpd-fixes-duplicate-auth-extension.patch
+++ b/scripts/package-build/frr/patches/0005-nhrpd-fixes-duplicate-auth-extension.patch
@@ -1,0 +1,68 @@
+From fb5b155778bb380d7aa9003f1649f78d3ed40bc2 Mon Sep 17 00:00:00 2001
+From: Dave LeRoy <dleroy@labn.net>
+Date: Thu, 25 Jul 2024 11:58:22 -0700
+Subject: [PATCH 5/6] nhrpd: fixes duplicate auth extension
+
+When an NHRP server was forwarding a message, it was copying all
+extensions from the originally received packet. The authentication
+extension must be regenerated hop by hop per RFC2332. The copied
+auth extension had an incorrect length. This fix checks for the
+auth extension when copying extensions and omits the original
+packet auth and instead regenerates a new auth extension.
+
+Fix bug #16466
+
+Signed-off-by: Dave LeRoy <dleroy@labn.net>
+---
+ nhrpd/nhrp_peer.c | 19 +++++++++++--------
+ 1 file changed, 11 insertions(+), 8 deletions(-)
+
+diff --git a/nhrpd/nhrp_peer.c b/nhrpd/nhrp_peer.c
+index 1fd089a34..d2c1a8c40 100644
+--- a/nhrpd/nhrp_peer.c
++++ b/nhrpd/nhrp_peer.c
+@@ -965,9 +965,12 @@ static void nhrp_peer_forward(struct nhrp_peer *p,
+ 		if (type == NHRP_EXTENSION_END)
+ 			break;
+ 
+-		dst = nhrp_ext_push(zb, hdr, htons(ext->type));
+-		if (!dst)
+-			goto err;
++		dst = NULL;
++		if (type != NHRP_EXTENSION_AUTHENTICATION) {
++			dst = nhrp_ext_push(zb, hdr, htons(ext->type));
++			if (!dst)
++				goto err;
++		}
+ 
+ 		switch (type) {
+ 		case NHRP_EXTENSION_FORWARD_TRANSIT_NHS:
+@@ -1053,12 +1056,11 @@ static void nhrp_peer_forward(struct nhrp_peer *p,
+ 			}
+ 			break;
+ 		case NHRP_EXTENSION_AUTHENTICATION:
+-			/* At this point, received packet has been authenticated.
+-			 *  Just need to regenerate auth extension before forwarding.
+-			 *  This will be done below in nhrp_packet_complete_auth().
++			/* Extensions can be copied from original packet except
++			 * authentication extension which must be regenerated
++			 * hop by hop.
+ 			 */
+ 			break;
+-
+ 		default:
+ 			if (htons(ext->type) & NHRP_EXTENSION_FLAG_COMPULSORY)
+ 				/* FIXME: RFC says to just copy, but not
+@@ -1074,7 +1076,8 @@ static void nhrp_peer_forward(struct nhrp_peer *p,
+ 			zbuf_copy(zb, &extpl, len);
+ 			break;
+ 		}
+-		nhrp_ext_complete(zb, dst);
++		if (dst)
++			nhrp_ext_complete(zb, dst);
+ 	}
+ 
+ 	nhrp_packet_complete_auth(zb, hdr, pp->ifp, true);
+-- 
+2.30.2
+

--- a/scripts/package-build/frr/patches/0006-nhrpd-Added-a-command-no-tunnel-protection-vici-prof.patch
+++ b/scripts/package-build/frr/patches/0006-nhrpd-Added-a-command-no-tunnel-protection-vici-prof.patch
@@ -1,0 +1,40 @@
+From 548f6dc1c8d02e5a5913c8cbc7c17c2148a41186 Mon Sep 17 00:00:00 2001
+From: aapostoliuk <a.apostoliuk@vyos.io>
+Date: Thu, 5 Sep 2024 18:37:27 +0300
+Subject: [PATCH 6/6] nhrpd: Added a command "no tunnel protection vici profile
+ PROFILE"
+
+For compatibility with frr-reload, a command
+"no tunnel protection [vici profile PROFILE [fallback-profile FALLBACK]]"
+was added.
+
+Signed-off-by: aapostoliuk <a.apostoliuk@vyos.io>
+---
+ nhrpd/nhrp_vty.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/nhrpd/nhrp_vty.c b/nhrpd/nhrp_vty.c
+index 96ba4728b..f20257696 100644
+--- a/nhrpd/nhrp_vty.c
++++ b/nhrpd/nhrp_vty.c
+@@ -295,10 +295,15 @@ DEFUN(tunnel_protection, tunnel_protection_cmd,
+ }
+ 
+ DEFUN(no_tunnel_protection, no_tunnel_protection_cmd,
+-	"no tunnel protection",
++	"no tunnel protection [vici profile PROFILE [fallback-profile FALLBACK]]",
+ 	NO_STR
+ 	"NHRP/GRE integration\n"
+-	"IPsec protection\n")
++	"IPsec protection\n"
++	"VICI (StrongSwan)\n"
++	"IPsec profile\n"
++	"IPsec profile name\n"
++	"Fallback IPsec profile\n"
++	"Fallback IPsec profile name\n")
+ {
+ 	VTY_DECLVAR_CONTEXT(interface, ifp);
+ 
+-- 
+2.30.2
+


### PR DESCRIPTION
Added patches to FRR 10.1 which implements nhrp cisco authentication.
This feature is implemented in FRR 10.2
Commits from FRR:
b5540d326b82ca92ed88f9082fe0ed2433b09c27
51f070028692260ea19b5ef0f489c56de5683bbc
55de91d8535d15c6cc08f8a36be5363b021e65ce
c531584a37bb34e7d8cf62887fd27c701270cd4b
7c20ffaaba228fe5a6893d49caf50ec1df1ec142
be218183134b984c5e087de327a4c6a08756d9d0

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6756

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
frr

## Proposed changes
<!--- Describe your changes in detail -->
Added patches to FRR 10.1 which implements nhrp cisco authentication. 
This feature is implemented in FRR 10.2
Commits from FRR:
b5540d326b82ca92ed88f9082fe0ed2433b09c27
51f070028692260ea19b5ef0f489c56de5683bbc
55de91d8535d15c6cc08f8a36be5363b021e65ce
c531584a37bb34e7d8cf62887fd27c701270cd4b
7c20ffaaba228fe5a6893d49caf50ec1df1ec142
be218183134b984c5e087de327a4c6a08756d9d0

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
