### PR TITLE
T3303: fix location of os-release file

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -452,19 +452,18 @@ if __name__ == "__main__":
 
         # Multi line strings needs to be un-indented to not have leading
         # whitespaces in the resulting file
-        os_release = f"""
-    PRETTY_NAME="VyOS {version} ({build_config['release_train']})"
-    NAME="VyOS"
-    VERSION_ID="{version}"
-    VERSION="{version} ({build_config['release_train']})"
-    VERSION_CODENAME={build_defaults['debian_distribution']}
-    ID=vyos
-    BUILD_ID="{build_git}"
-    HOME_URL="{build_defaults['website_url']}"
-    SUPPORT_URL="{build_defaults['support_url']}"
-    BUG_REPORT_URL="{build_defaults['bugtracker_url']}"
-    DOCUMENTATION_URL="{build_config['documentation_url']}"
-        """
+        os_release = f"""PRETTY_NAME="VyOS {version} ({build_config['release_train']})"
+NAME="VyOS"
+VERSION_ID="{version}"
+VERSION="{version} ({build_config['release_train']})"
+VERSION_CODENAME={build_defaults['debian_distribution']}
+ID=vyos
+BUILD_ID="{build_git}"
+HOME_URL="{build_defaults['website_url']}"
+SUPPORT_URL="{build_defaults['support_url']}"
+BUG_REPORT_URL="{build_defaults['bugtracker_url']}"
+DOCUMENTATION_URL="{build_config['documentation_url']}"
+"""
 
         # Reminder: all paths relative to the build dir, not to the repository root
         chroot_includes_dir = defaults.CHROOT_INCLUDES_DIR
@@ -484,8 +483,8 @@ if __name__ == "__main__":
             print("Version: {0}".format(version), file=f)
 
         # Define variables that influence to welcome message on boot
-        os.makedirs(os.path.join(chroot_includes_dir, 'usr/lib/'), exist_ok=True)
-        with open(os.path.join(chroot_includes_dir, 'usr/lib/os-release'), 'w') as f:
+        os.makedirs(os.path.join(chroot_includes_dir, 'etc/'), exist_ok=True)
+        with open(os.path.join(chroot_includes_dir, 'etc/os-release'), 'w') as f:
             print(os_release, file=f)
 
         ## Clean up earlier build state and artifacts


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This restores the boot line: `Welcome to VyOS 1.5-foo-202410071336 (current)!`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T3303


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
