### PR TITLE
T6765: Fix build python3-vici package

### DIFF
--- a/scripts/package-build/strongswan/build-vici.sh
+++ b/scripts/package-build/strongswan/build-vici.sh
@@ -4,7 +4,7 @@ set -e
 
 SRC="strongswan/src/libcharon/plugins/vici/python"
 if [ ! -d ${SRC} ]; then
-    echo "Source directory does not exists, please 'git clone'"
+    echo "Source directory does not exist, please 'git clone'"
     exit 1
 fi
 
@@ -28,30 +28,31 @@ Depends: \${misc:Depends}, \${python3:Depends}
 Description: Native Python interface for strongSwan's VICI protocol
 EOF
 
-
 # Create rules file
-echo "I: create $SRC/rules"
+echo "I: create $SRC/debian/rules"
 cat <<EOF > debian/rules
 #!/usr/bin/make -f
 
 %:
 	dh \$@ --with python3
 EOF
-# Make the rules file executable
 chmod +x debian/rules
 
 echo '10' > debian/compat
 
+# Add the 'install' file to copy the vici package to the correct directory
+echo "I: create $SRC/debian/install"
+cat <<EOF > debian/install
+vici /usr/lib/python3/dist-packages/
+EOF
+
 # Copy changelog
 cp ../../../../../debian/changelog debian/
 
-
-ls -la
-pwd
-
-
+# Build the package
 echo "I: Build Debian Package"
 dpkg-buildpackage -uc -us -tc -b -d
 
+# Copy the resulting .deb packages
 echo "I: copy packages"
-cp ../*.deb  ../../../../../../
+cp ../*.deb ../../../../../../


### PR DESCRIPTION
Fix build python3-vici. It did not include the directory /usr/lib/python3/dist-packages/vici

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix build python3-vici. It did not include the directory /usr/lib/python3/dist-packages/vici
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6765

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
python3-vici, strongswas, vpn
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Build package and check files:
```
./build.py

vyos_bld@b8190803dc1d:/vyos/work/tmp/vyos-build/scripts/package-build/strongswan$ dpkg -c python3-vici_5.9.11-2+vyos0_all.deb 
drwxr-xr-x root/root         0 2024-10-08 07:48 ./
drwxr-xr-x root/root         0 2024-10-08 07:48 ./usr/
drwxr-xr-x root/root         0 2024-10-08 07:48 ./usr/lib/
drwxr-xr-x root/root         0 2024-10-08 07:48 ./usr/lib/python3/
drwxr-xr-x root/root         0 2024-10-08 07:48 ./usr/lib/python3/dist-packages/
drwxr-xr-x root/root         0 2024-10-08 07:45 ./usr/lib/python3/dist-packages/vici/
-rw-r--r-- root/root        29 2024-10-08 07:45 ./usr/lib/python3/dist-packages/vici/__init__.py
-rw-r--r-- root/root     10549 2024-10-08 07:45 ./usr/lib/python3/dist-packages/vici/command_wrappers.py
-rw-r--r-- root/root       402 2024-10-08 07:45 ./usr/lib/python3/dist-packages/vici/exception.py
-rw-r--r-- root/root      7419 2024-10-08 07:45 ./usr/lib/python3/dist-packages/vici/protocol.py
-rw-r--r-- root/root      7700 2024-10-08 07:45 ./usr/lib/python3/dist-packages/vici/session.py
drwxr-xr-x root/root         0 2024-10-08 07:48 ./usr/share/
drwxr-xr-x root/root         0 2024-10-08 07:48 ./usr/share/doc/
drwxr-xr-x root/root         0 2024-10-08 07:48 ./usr/share/doc/python3-vici/
-rw-r--r-- root/root      2657 2024-10-08 07:48 ./usr/share/doc/python3-vici/changelog.Debian.gz

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
