### PR TITLE
T861: T6713: Sign Realtek drivers

### DIFF
--- a/scripts/package-build/linux-kernel/build-driver-realtek-r8152.py
+++ b/scripts/package-build/linux-kernel/build-driver-realtek-r8152.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
+import os
 from tomllib import loads as toml_loads
 from requests import get
 from pathlib import Path
 from subprocess import run
+
+CWD = os.getcwd()
 
 # dependency modifier
 def add_depends(package_dir: str, package_name: str,
@@ -86,3 +89,7 @@ build_rules_path.write_text(build_rules_text, encoding='utf-8')
 # build a package
 debuild_cmd: list[str] = ['debuild']
 run(debuild_cmd, cwd=PACKAGE_DIR, check=True)
+
+# Sign generated Kernel modules
+sign_modules_script = os.path.join(CWD, 'sign-modules.sh')
+run([sign_modules_script, PACKAGE_DIR], check=True)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
T861: T6713: Sign Realtek drivers
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->

 * https://vyos.dev/T861
 * https://vyos.dev/T6713

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
realtek, kernel
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
build kernel
build realtek
```
./build-driver-realtek-r8152.py

dpkg-deb: building package 'vyos-drivers-realtek-r8152' in '../vyos-drivers-realtek-r8152_2.18.1-1_amd64.deb'.
 dpkg-genbuildinfo -O../vyos-drivers-realtek-r8152_2.18.1-1_amd64.buildinfo
 dpkg-genchanges -O../vyos-drivers-realtek-r8152_2.18.1-1_amd64.changes
dpkg-genchanges: info: including full source code in upload
 dpkg-source --after-build .
dpkg-buildpackage: info: full upload (original source is included)
I: Signing vyos-drivers-realtek-r8152-2.18.1/r8152.ko ...
I: Signing vyos-drivers-realtek-r8152-2.18.1/debian/vyos-drivers-realtek-r8152/lib/modules/6.6.54-vyos/updates/drivers/net/usb/r8152.ko ...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
