### PR TITLE
build: T6231: remove Mellanox OFED drivers and tools until their license status is confirmed

### DIFF
--- a/data/architectures/amd64.toml
+++ b/data/architectures/amd64.toml
@@ -11,6 +11,4 @@ packages = [
   "vyos-intel-qat",
   "vyos-intel-ixgbe",
   "vyos-intel-ixgbevf",
-  "mlnx-ofed-kernel-modules",
-  "mlnx-tools",
 ]


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Remove the out-of-tree Mellanox drivers and tools for the time being. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): package removal.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Image build deps.

## Proposed changes
<!--- Describe your changes in detail -->


PR #777 could not be merged because the package is under a license that doesn't allow redistribution unconditionally. However, the situation gets even trickier.

Individual packages we build from https://network.nvidia.com/products/infiniband-drivers/linux/mlnx_ofed/ are licensed under GPL (for the kernel modules) or dual GPL/BSD for mlnx-tools. That seemed fine to us when we decided to include them

However, the [EULA of the entire package](https://developer.nvidia.com/networking/mlnx-ofed-eula) includes the following terms (emphasis is mine):

>1. General
>MLNX_OFED is based on the OpenFabrics Enterprise Distribution (OFED™), an open-source software for RDMA and kernel bypass applications provided by Open Fabric Alliance (OFA: www.openfabrics.org) under a dual license of BSD or GPL 2.0.
>
>Mellanox chose to license OFED to end users under BSD license, together with proprietary components of Mellanox and several open source software components contained therein, **all of which comprise together Mellanox OFED (collectively: the "Software Product")**.
>
>
>2. Grant of License
>Subject to the terms and conditions of this Agreement, and subject to the licenses set forth in Exhibit A, Mellanox grants you a personal, non-exclusive, non-transferable license to use, view, copy, print, and distribute software and accompanying documentation subject to the following conditions:
>
>(i) The Software Product and any accompanying documentation may be used solely to support Mellanox Products; and
>
>(ii) You may distribute **the Software Product** and accompanying documentation **solely as integrated with or installed on your products that incorporate the Mellanox Products**.
>3. Other Rights and Limitations
>3.1 Reverse Engineering. You shall not reverse engineer, decompile, disassemble or otherwise attempt to derive the source code of the Software Product, and shall not adapt, translate, port or otherwise modify the Software Product.
>
>3.2 Separation of Components. **The Software Product is licensed as a single product. Its component parts may not be separated for use beyond the designated Hardware.**

This implies that the only unquestionably legal case for distributing that software is an OS preinstalled on a box that includes Mellanox cards. Distributing it in an OS that may run on any box or a VM that has no Mellanox hardware in it is prohibited by _2.ii_ and taking only components under FOSS licenses to avoid the implications of _2.ii_ is prohibited by _3.2_ ("The Software Product is licensed as a single product.").

We will request clarification from NVIDIA to check if the EULA really overrides the GPL as it implies, but until we have a confirmation that we are in the clear, we should follow the literal interpretation and comply with it. 

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

In-tree drivers should still work, the kernel config seems to include all that is needed (but correct me if not).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
