### PR TITLE
T6804: Add ipmitool to generic image

### DIFF
--- a/data/build-flavors/generic.toml
+++ b/data/build-flavors/generic.toml
@@ -7,6 +7,7 @@ packages = [
   # QEMU and Xen guest tools exist for multiple architectures
   "qemu-guest-agent",
   "vyos-xe-guest-utilities",
+  "ipmitool"
 ]
 
 [architectures.amd64]


### PR DESCRIPTION
## Change Summary
The ipmitool can be immensely helpful if there is an issue or access to the bmc is lost.
Then basic settings can be accessed and set through the still accessible host OS.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6804

## Component(s) name


## Proposed changes
Adding ipmitool for system management

## How to test
Build and boot image, then run ipmitool (will fail on systems without an BMC).

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
