### PR TITLE
T6813: Build tarballs for the packages

### DIFF
--- a/scripts/package-build/build.py
+++ b/scripts/package-build/build.py
@@ -101,6 +101,12 @@ def build_package(package: list, dependencies: list, patch_dir: Path) -> None:
         if (repo_dir / 'patches'):
             apply_patches(repo_dir, patch_dir)
 
+        # Sanitize the commit ID and build a tarball for the package
+        commit_id_sanitized = package['commit_id'].replace('/', '_')
+        tarball_name = f"{repo_name}_{commit_id_sanitized}.tar.gz"
+        run(['tar', '-czf', tarball_name, '-C', str(repo_dir.parent), repo_name], check=True)
+        print(f"I: Tarball created: {tarball_name}")
+
         # Prepare the package if required
         if package.get('prepare_package', False):
             prepare_package(repo_dir, package.get('install_data', ''))


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Build tarballs for the packages with our changes after patches
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Add tarballs

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6813

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Build a package and check tar.gz:
```
vyos_bld@a4322d60da1e:/vyos/work/T6813/vyos-build/scripts/package-build/ddclient$ ./build.py 
...
vyos_bld@a4322d60da1e:/vyos/work/T6813/vyos-build/scripts/package-build/ddclient$ ls -la
total 2812
drwxr-xr-x  3 vyos_bld vyos_bld    4096 Oct 24 13:00 .
drwxr-xr-x 31 vyos_bld vyos_bld    4096 Oct 24 12:45 ..
lrwxrwxrwx  1 vyos_bld vyos_bld      11 Oct 24 12:43 build.py -> ../build.py
drwxr-xr-x  9 vyos_bld vyos_bld    4096 Oct 24 13:00 ddclient
-rw-r--r--  1 vyos_bld vyos_bld  102072 Oct 24 13:00 ddclient_3.11.2-1_all.deb
-rw-r--r--  1 vyos_bld vyos_bld    7116 Oct 24 13:00 ddclient_3.11.2-1_amd64.buildinfo
-rw-r--r--  1 vyos_bld vyos_bld    1785 Oct 24 13:00 ddclient_3.11.2-1_amd64.changes
-rw-r--r--  1 vyos_bld vyos_bld 2742239 Oct 24 13:00 ddclient_debian_3.11.2-1.tar.gz
-rw-r--r--  1 vyos_bld vyos_bld      53 Oct 24 12:43 .gitignore
-rw-r--r--  1 vyos_bld vyos_bld     114 Oct 24 12:43 package.toml


vyos_bld@a4322d60da1e:/vyos/work/T6813/vyos-build/scripts/package-build/ethtool$ ./build.py
...
vyos_bld@a4322d60da1e:/vyos/work/T6813/vyos-build/scripts/package-build/ethtool$ ls -la
total 3124
drwxr-xr-x  3 vyos_bld vyos_bld    4096 Oct 24 13:07 .
drwxr-xr-x 31 vyos_bld vyos_bld    4096 Oct 24 12:45 ..
lrwxrwxrwx  1 vyos_bld vyos_bld      11 Oct 24 12:43 build.py -> ../build.py
drwxr-xr-x  9 vyos_bld vyos_bld   12288 Oct 24 13:07 ethtool
-rw-r--r--  1 vyos_bld vyos_bld    5271 Oct 24 13:07 ethtool_6.10-1_amd64.buildinfo
-rw-r--r--  1 vyos_bld vyos_bld    1279 Oct 24 13:07 ethtool_6.10-1_amd64.changes
-rw-r--r--  1 vyos_bld vyos_bld  214676 Oct 24 13:07 ethtool_6.10-1_amd64.deb
-rw-r--r--  1 vyos_bld vyos_bld  495152 Oct 24 13:07 ethtool-dbgsym_6.10-1_amd64.deb
-rw-r--r--  1 vyos_bld vyos_bld 2444699 Oct 24 13:07 ethtool_debian_1%6.10-1.tar.gz
-rw-r--r--  1 vyos_bld vyos_bld      52 Oct 24 12:43 .gitignore
-rw-r--r--  1 vyos_bld vyos_bld     117 Oct 24 12:43 package.toml
vyos_bld@a4322d60da1e:/vyos/work/T6813/vyos-build/scripts/package-build/ethtool$ 


vyos_bld@a4322d60da1e:/vyos/work/T6813/vyos-build/scripts/package-build/hsflowd$ ls -la
total 10556
drwxr-xr-x  3 vyos_bld vyos_bld     4096 Oct 24 13:08 .
drwxr-xr-x 31 vyos_bld vyos_bld     4096 Oct 24 12:45 ..
lrwxrwxrwx  1 vyos_bld vyos_bld       11 Oct 24 12:43 build.py -> ../build.py
-rw-r--r--  1 vyos_bld vyos_bld       54 Oct 24 12:43 .gitignore
drwxr-xr-x 11 vyos_bld vyos_bld     4096 Oct 24 13:08 host-sflow
-rw-r--r--  1 vyos_bld vyos_bld 10387574 Oct 24 13:08 host-sflow_v2.0.55-1.tar.gz
-rw-r--r--  1 vyos_bld vyos_bld   395900 Oct 24 13:08 hsflowd_2.0.55-1_amd64.deb
-rw-r--r--  1 vyos_bld vyos_bld      216 Oct 24 12:43 package.toml
vyos_bld@a4322d60da1e:/vyos/work/T6813/vyos-build/scripts/package-build/hsflowd$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
