### PR TITLE
live: T5568: Fix live grub menu entries

### DIFF
--- a/data/live-build-config/hooks/live/01-live-serial.binary
+++ b/data/live-build-config/hooks/live/01-live-serial.binary
@@ -10,22 +10,22 @@ SERIAL_CONSOLE="console=tty0 console=ttyS0,115200"
 GRUB_MENUENTRY=$(sed -e '/menuentry.*hotkey.*/,/^}/!d' -e 's/--hotkey=l//g' $GRUB_PATH)
 
 # Update KVM menuentry name
-sed -i 's/"Live system \((.*-vyos)\)"/"Live system \1 - KVM console"/' $GRUB_PATH
+sed -i 's/"Live system \((.*vyos)\)"/"Live system \1 - KVM console"/' $GRUB_PATH
 
 # Insert serial menuentry
 echo "$GRUB_MENUENTRY" | sed \
-    -e 's/"Live system \((.*-vyos)\)"/"Live system \1 - Serial console"/' \
+    -e 's/"Live system \((.*vyos)\)"/"Live system \1 - Serial console"/' \
     -e "s/$KVM_CONSOLE/$SERIAL_CONSOLE/g" >> $GRUB_PATH
 
 # Live.cfg Update
 ISOLINUX_MENUENTRY=$(sed -e '/label live-\(.*\)-vyos$/,/^\tappend.*/!d' $ISOLINUX_PATH)
 
 # Update KVM menuentry name
-sed -i 's/Live system \((.*-vyos)\)/Live system \1 - KVM console/' $ISOLINUX_PATH
+sed -i 's/Live system \((.*vyos)\)/Live system \1 - KVM console/' $ISOLINUX_PATH
 
 # Insert serial menuentry
 echo "\n$ISOLINUX_MENUENTRY" | sed \
     -e 's/live-\(.*\)-vyos/live-\1-vyos-serial/' \
     -e '/^\tmenu default/d' \
-    -e 's/Live system \((.*-vyos)\)/Live system \1 - Serial console/' \
+    -e 's/Live system \((.*vyos)\)/Live system \1 - Serial console/' \
     -e "s/$KVM_CONSOLE/$SERIAL_CONSOLE/g" >> $ISOLINUX_PATH


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Update `sed` regex strings to fix live boot grub menu

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
grub, live boot

## Proposed changes
<!--- Describe your changes in detail -->
Fixes grub menu text to show KVM/Serial console

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
From:
```
 |*Live system (vyos)                                                         |
 | Live system (vyos fail-safe mode)                                          |
 | Live system (vyos)                                                         |
```
to:
```
 |*Live system (vyos) - KVM console                                           |
 | Live system (vyos fail-safe mode)                                          |
 | Live system (vyos) - Serial console                                        |
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
