### PR TITLE
T6840: Build OpenVPN-otp use commit id instead of master

### DIFF
--- a/scripts/package-build/openvpn-otp/.gitignore
+++ b/scripts/package-build/openvpn-otp/.gitignore
@@ -4,3 +4,4 @@ openvpn-otp/
 *.changes
 *.deb
 *.dsc
+*.tar.gz

--- a/scripts/package-build/openvpn-otp/package.toml
+++ b/scripts/package-build/openvpn-otp/package.toml
@@ -1,6 +1,6 @@
 [[packages]]
 name = "openvpn-otp"
-commit_id = "master"
+commit_id = "9781ff1"
 scm_url = "https://github.com/evgeny-gridasov/openvpn-otp"
 
 # build_cmd = "cd ..; ./build-openvpn-otp.sh"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Build OpenVPN-otp use commit id instead of master
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Use commit-id instead of master

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6840

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
openvpn-otp
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
