### PR TITLE
T6813: Add tarballs for the netfilter

### DIFF
--- a/scripts/package-build/netfilter/.gitignore
+++ b/scripts/package-build/netfilter/.gitignore
@@ -5,4 +5,4 @@
 *.changes
 *.deb
 *.dsc
-
+*.tar.gz

--- a/scripts/package-build/netfilter/build.py
+++ b/scripts/package-build/netfilter/build.py
@@ -112,6 +112,12 @@ def build_package(package: dict, dependencies: list, patch_dir: Path) -> None:
         # Apply patches if any
         apply_patches(repo_dir, patch_dir, repo_name)
 
+        # Sanitize the commit ID and build a tarball for the package
+        commit_id_sanitized = package['commit_id'].replace('/', '_')
+        tarball_name = f"{repo_name}_{commit_id_sanitized}.tar.gz"
+        run(['tar', '-czf', tarball_name, '-C', str(repo_dir.parent), repo_name], check=True)
+        print(f"I: Tarball created: {tarball_name}")
+
         # Prepare the package if required
         if package.get('prepare_package', False):
             prepare_package(repo_dir, package.get('install_data', ''))


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add tarballs for the netfilter
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Add tarball for the netfilter

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T6813

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
netfilter, build
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
