### PR TITLE
build: T6855: make the custom APT entry and key syntax more flexible

### DIFF
--- a/data/architectures/amd64.toml
+++ b/data/architectures/amd64.toml
@@ -1,8 +1,3 @@
-additional_repositories = [
-  "deb [arch=amd64] https://packages.vyos.net/saltproject/debian/11/amd64/3005 bullseye main",
-  "deb https://repo.zabbix.com/zabbix/6.0/debian bookworm main"
-]
-
 # Packages added to images for x86 by default
 packages = [
   "grub2",
@@ -13,3 +8,11 @@ packages = [
   "vyos-intel-ixgbe",
   "vyos-intel-ixgbevf",
 ]
+
+[additional_repositories.salt]
+  architecture = "amd64"
+  url = "https://packages.vyos.net/saltproject/debian/11/amd64/3005"
+  distribution = "bullseye"
+
+[additional_repositories.zabbix]
+  url = "https://repo.zabbix.com/zabbix/6.0/debian"

--- a/data/architectures/arm64.toml
+++ b/data/architectures/arm64.toml
@@ -1,10 +1,13 @@
-additional_repositories = [
-  "deb [arch=arm64] https://packages.vyos.net/saltproject/debian/11/arm64/3005 bullseye main",
-  "deb https://repo.zabbix.com/zabbix/6.0/debian-arm64 bookworm main"
-]
-
 # Packages included in ARM64 images by default
 packages = [
   "grub-efi-arm64",
 ]
 bootloaders = "grub-efi"
+
+[additional_repositories.salt]
+  architecture = "arm64"
+  url =	"https://packages.vyos.net/saltproject/debian/11/amd64/3005"
+  distribution = "bullseye"
+
+[additional_repositories.zabbix]
+  url = "https://repo.zabbix.com/zabbix/6.0/debian-arm64"

--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -25,6 +25,7 @@ import copy
 import uuid
 import glob
 import json
+import base64
 import shutil
 import argparse
 import datetime
@@ -503,8 +504,9 @@ DOCUMENTATION_URL="{build_config['documentation_url']}"
         ## Create live-build configuration files
 
         # Add the additional repositories to package lists
-        print("I: Setting up additional APT entries")
+        print("I: Setting up VyOS repository APT entries")
         vyos_repo_entry = "deb {vyos_mirror} {vyos_branch} main\n".format(**build_config)
+        vyos_repo_entry += "deb-src {vyos_mirror} {vyos_branch} main\n".format(**build_config)
 
         apt_file = defaults.VYOS_REPO_FILE
 
@@ -516,10 +518,36 @@ DOCUMENTATION_URL="{build_config['documentation_url']}"
             f.write(vyos_repo_entry)
 
         # Add custom APT entries
+        print("I: Setting up additional APT entries")
         if build_config.get('additional_repositories', False):
-            build_config['custom_apt_entry'] += build_config['additional_repositories']
+            for r in build_config['additional_repositories']:
+                repo_data = build_config['additional_repositories'][r]
 
-        if build_config.get('custom_apt_entry', False):
+                url = repo_data.get('url', None)
+                arch = repo_data.get('architecture', None)
+                distro = repo_data.get('distribution', build_config['debian_distribution'])
+                components = repo_data.get('components', 'main')
+
+                if not url:
+                    print(f'E: repository {r} does not specify URL')
+                    sys.exit(1)
+
+                if arch:
+                    arch_string = f'[arch={arch}]'
+                else:
+                    arch_string = ''
+
+                entry = f'deb {arch_string} {url} {distro} {components}'
+                build_config['custom_apt_entry'].append(entry)
+
+                if not repo_data.get('no_source', False):
+                    src_entry = f'deb-src {url} {distro} {components}'
+                    build_config['custom_apt_entry'].append(src_entry)
+
+                if repo_data.get('key', None):
+                    build_config['custom_apt_keys'].append({'name': r, 'key': repo_data['key']})
+
+        if build_config.get('custom_apt_entry', []):
             custom_apt_file = defaults.CUSTOM_REPO_FILE
             entries = "\n".join(build_config['custom_apt_entry'])
             if debug:
@@ -530,11 +558,13 @@ DOCUMENTATION_URL="{build_config['documentation_url']}"
                 f.write("\n")
 
         # Add custom APT keys
-        if has_nonempty_key(build_config, 'custom_apt_key'):
+        if has_nonempty_key(build_config, 'custom_apt_keys'):
             key_dir = defaults.ARCHIVES_DIR
-            for k in build_config['custom_apt_key']:
-                dst_name = '{0}.key.chroot'.format(os.path.basename(k))
-                shutil.copy(k, os.path.join(key_dir, dst_name))
+            for k in build_config['custom_apt_keys']:
+                dst_name = '{0}.key.chroot'.format(k['name'])
+                with open(os.path.join(key_dir, dst_name), 'bw') as f:
+                    key_data = base64.b64decode(k['key'])
+                    f.write(key_data)
 
         # Add custom packages
         if has_nonempty_key(build_config, 'packages'):

--- a/scripts/image-build/defaults.py
+++ b/scripts/image-build/defaults.py
@@ -35,7 +35,7 @@ boot_settings: dict[str, str] = {
 # Hardcoded default values
 HARDCODED_BUILD = {
     'custom_apt_entry': [],
-    'custom_apt_key': [],
+    'custom_apt_keys': [],
     'custom_package': [],
     'reuse_iso': None,
     'disk_size': 10,


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Right now, our custom repository and APT key options have a few shortcomings:

* APT entries are monolithic, so Debian distribution has to be updates in all entries when we switch to a new base distro.
* A lot of custom repos only have `main` component, but we force the config author to specify it.
* Configs may only include APT key file paths, so there's no way to distribute a self-contained flavor that uses custom repos with custom keys.
* Renames the oddly-sinfular `custom_apt_key` config option to `custom_apt_keys`. 

This PR:

* Makes custom APT entry syntax in build configs more flexible and allow specifying individual components instead of monolithic `sources.list` strings.
* Allows embedding APT keys in configs.
* Generates Debian source repository entries for all repositories.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

Build scripts and configs.

## Proposed changes
<!--- Describe your changes in detail -->

```toml
[additional_repositories.some-repo]
  # Optional, no default
  architecture = "amd64"

  # Optional, defaults to "main"
  components = "main contrib"

  # Optional, defaults to false
  no_source = true

  # Optional, defaults to build_config['debian_distribution'
  distribution = 'bo'

  # Mandatory
  url = 'https://example.com/some-repo/debian'

  # Optional
  key = ''' <Base64 encoded APT key data> '''
```

The new APT key mechanism can also be used at the config level rather than at the repository level:

```
[[custom_apt_keys]]
  name = 'foo'
  key = '<Base64 data>'
```

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
