### PR TITLE
image-tools: T6864: keep file necessary for compat add image

### DIFF
--- a/data/live-build-config/includes.chroot/opt/vyatta/etc/grub/default-union-grub-entry
+++ b/data/live-build-config/includes.chroot/opt/vyatta/etc/grub/default-union-grub-entry
@@ -1,0 +1,20 @@
+menuentry "VyOS  (KVM console)" {
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 udev.exec_delay=3 vyos-union=/boot/ console=ttyS0,115200 console=tty0
+        initrd /boot//initrd.img
+}
+
+menuentry "VyOS  (Serial console)" {
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 udev.exec_delay=3 vyos-union=/boot/ console=tty0 console=ttyS0,115200
+        initrd /boot//initrd.img
+}
+
+menuentry "Lost password change  (KVM console)" {
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 udev.exec_delay=3 vyos-union=/boot/ console=ttyS0,115200 console=tty0 init=/opt/vyatta/sbin/standalone_root_pw_reset
+        initrd /boot//initrd.img
+}
+
+menuentry "Lost password change  (Serial console)" {
+        linux /boot//vmlinuz boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 udev.exec_delay=3 vyos-union=/boot/ console=tty0 console=ttyS0,115200 init=/opt/vyatta/sbin/standalone_root_pw_reset
+        initrd /boot//initrd.img
+}
+


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This reverts commit d50707bb29 to keep the file `grub/default-union-grub-entry`, necessary for compatibility-mode upgrades of the system image: when upgrading from a system with legacy image-tools, this file is expected to exist in the mounted image of the target iso.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
