### PR TITLE
build: T6923: Fix and assume `/debian-security` for security URL path

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -272,7 +272,7 @@ if __name__ == "__main__":
         pre_build_config['pbuilder_debian_mirror'] = pre_build_config['debian_mirror']
 
     if pre_build_config['debian_security_mirror'] is None:
-        pre_build_config['debian_security_mirror'] = pre_build_config['debian_mirror']
+        pre_build_config['debian_security_mirror'] = pre_build_config['debian_mirror'].replace('/debian', '/debian-security')
 
     # Validate characters in version name
     if args.get('version'):
@@ -306,8 +306,8 @@ if __name__ == "__main__":
 
     # If Debian mirror is specified explicitly but Debian security mirror is not,
     # assume that the user wants to use that mirror for security updates as well.
-    if (args['debian_mirror'] is not None) and (args['debian_security_mirror'] is None):
-        build_config['debian_security_mirror'] = args['debian_mirror']
+    if (build_config['debian_mirror'] is not None) and (build_config['debian_security_mirror'] is None):
+        build_config['debian_security_mirror'] = build_config['debian_mirror'].replace('/debian', '/debian-security')
 
     ## Rename and merge some fields for simplicity
     ## E.g. --custom-packages is for the user, but internally


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In all official mirrors, the URL path `/debian-security` is required for security packages.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Before:
```
... --mirror-binary http://deb.debian.org/debian/ --mirror-binary-security http://deb.debian.org/debian/ --mirror-bootstrap http://deb.debian.org/debian/ --mirror-chroot http://deb.debian.org/debian/ --mirror-chroot-security http://deb.debian.org/debian/ ...
```

Fixed: 
```
... --mirror-binary http://deb.debian.org/debian --mirror-binary-security http://deb.debian.org/debian-security --mirror-bootstrap http://deb.debian.org/debian --mirror-chroot http://deb.debian.org/debian --mirror-chroot-security http://deb.debian.org/debian-security ...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
