### PR TITLE
T6957: Ignore no ISIS command after no ipX router

### DIFF
--- a/scripts/package-build/frr/patches/0002-CLI-No-ISIS.patch
+++ b/scripts/package-build/frr/patches/0002-CLI-No-ISIS.patch
@@ -1,0 +1,80 @@
+From 777498a9df170a457cf63b03527bcf2fafdfd5e3 Mon Sep 17 00:00:00 2001
+From: Yaroslav Kholod <y.kholod@vyos.io>
+Date: Wed, 18 Dec 2024 11:44:18 +0200
+Subject: [PATCH] 10133 and #17472: Ignore no ISIS command after no ipX router
+ ISIS
+
+---
+ tools/frr-reload.py | 42 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 42 insertions(+)
+
+diff --git a/tools/frr-reload.py b/tools/frr-reload.py
+index 08a1f1e07..32ec44fea 100755
+--- a/tools/frr-reload.py
++++ b/tools/frr-reload.py
+@@ -38,6 +38,11 @@ class VtyshException(Exception):
+     pass
+ 
+ 
++class StaticVariables:
++    no_ip_router_isis = False
++    no_ipv6_router_isis = False
++
++
+ class Vtysh(object):
+     def __init__(self, bindir=None, confdir=None, sockdir=None, pathspace=None):
+         self.bindir = bindir
+@@ -1966,6 +1971,38 @@ def compare_context_objects(newconf, running):
+     return (lines_to_add, lines_to_del)
+ 
+ 
++def vyos_no_isis_processing(cmd):
++    """
++    Makes frr-reload.py to ignore all no ISIS commands after both ip router isis
++    and ipv6 router isis are deleted from the interface.
++    """
++    new_cmd = cmd
++
++    if ("interface" in cmd):
++        StaticVariables.no_ip_router_isis = False
++        StaticVariables.no_ipv6_router_isis = False
++
++    if ("ip router isis" in cmd):
++        StaticVariables.no_ip_router_isis = False
++    if ("ipv6 router isis" in cmd):
++        StaticVariables.no_ipv6_router_isis = False
++
++    if ("no ip router isis" in cmd):
++        StaticVariables.no_ip_router_isis = True
++        return new_cmd
++    if ("no ipv6 router isis" in cmd):
++        StaticVariables.no_ipv6_router_isis = True
++        return new_cmd
++
++    # Ignore all commands that have "no" and "isis" in them
++    if (StaticVariables.no_ip_router_isis and StaticVariables.no_ipv6_router_isis):
++        if ("no" in cmd) and ("isis" in cmd):
++            log.info("VYoS makes config to ignore %s instruction", cmd)
++            new_cmd = ""
++
++    return new_cmd
++
++
+ if __name__ == "__main__":
+     # Command line options
+     parser = argparse.ArgumentParser(
+@@ -2305,6 +2342,11 @@ if __name__ == "__main__":
+                     # vtysh -f that file. See the next comment for an explanation
+                     # of their quirks
+                     cmd = lines_to_config(ctx_keys, line, True)
++
++                    if len(cmd) > 1:
++                        vyos_cmd = vyos_no_isis_processing(cmd[1])
++                        cmd[1] = vyos_cmd
++
+                     original_cmd = cmd
+ 
+                     # Some commands in frr are picky about taking a "no" of the entire line.
+-- 
+2.43.0
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6957

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
