### PR TITLE
T6958: Clear Babel config on babeld stop

### DIFF
--- a/scripts/package-build/frr/patches/0003-Clear-Babel-Config-On-Stop.patch
+++ b/scripts/package-build/frr/patches/0003-Clear-Babel-Config-On-Stop.patch
@@ -1,0 +1,29 @@
+From c3c70e87b040233263b9594d14582dfedfecc92e Mon Sep 17 00:00:00 2001
+From: Yaroslav Kholod <y.kholod@vyos.io>
+Date: Wed, 18 Dec 2024 11:48:29 +0200
+Subject: [PATCH] #17413: Clean babeld config on stop
+
+---
+ babeld/babeld.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/babeld/babeld.c b/babeld/babeld.c
+index b562f0b70..6f1a9a3d7 100644
+--- a/babeld/babeld.c
++++ b/babeld/babeld.c
+@@ -304,6 +304,12 @@ void babel_clean_routing_process(void)
+     flush_all_routes();
+     babel_interface_close_all();
+ 
++    /* Clean babel config */
++    diversity_kind = DIVERSITY_NONE;
++    diversity_factor = BABEL_DEFAULT_DIVERSITY_FACTOR;
++    resend_delay = BABEL_DEFAULT_RESEND_DELAY;
++    smoothing_half_life = BABEL_DEFAULT_SMOOTHING_HALF_LIFE;
++
+     /* cancel events */
+     event_cancel(&babel_routing_process->t_read);
+     event_cancel(&babel_routing_process->t_update);
+-- 
+2.43.0
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
