### PR TITLE
T6961: package-build: Fix kea build race condition

### DIFF
--- a/scripts/package-build/build.py
+++ b/scripts/package-build/build.py
@@ -32,30 +32,32 @@ def ensure_dependencies(dependencies: list) -> None:
         return
 
     print("I: Ensure Debian build dependencies are met")
-    run(['sudo', 'apt-get', 'update'], check=True)
-    run(['sudo', 'apt-get', 'install', '-y'] + dependencies, check=True)
+    run(["sudo", "apt-get", "update"], check=True)
+    run(["sudo", "apt-get", "install", "-y"] + dependencies, check=True)
 
 
 def apply_patches(repo_dir: Path, patch_dir: Path) -> None:
     """Apply patches from the patch directory to the repository"""
     if not patch_dir.exists() or not patch_dir.is_dir():
-        print(f"I: Patch directory {patch_dir} does not exist, skipping patch application")
+        print(
+            f"I: Patch directory {patch_dir} does not exist, skipping patch application"
+        )
         return
 
-    patches = sorted(patch_dir.glob('*'))
+    patches = sorted(patch_dir.glob("*"))
     if not patches:
         print(f"I: No patches found in {patch_dir}")
         return
 
-    debian_patches_dir = repo_dir / 'debian/patches'
+    debian_patches_dir = repo_dir / "debian/patches"
     debian_patches_dir.mkdir(parents=True, exist_ok=True)
 
-    series_file = debian_patches_dir / 'series'
-    with series_file.open('a') as series:
+    series_file = debian_patches_dir / "series"
+    with series_file.open("a") as series:
         for patch in patches:
             patch_dest = debian_patches_dir / patch.name
             shutil.copy(patch, patch_dest)
-            series.write(patch.name + '\n')
+            series.write(patch.name + "\n")
             print(f"I: Applied patch: {patch.name}")
 
 
@@ -66,7 +68,7 @@ def prepare_package(repo_dir: Path, install_data: str) -> None:
         return
 
     try:
-        install_file = repo_dir / 'debian/install'
+        install_file = repo_dir / "debian/install"
         install_file.parent.mkdir(parents=True, exist_ok=True)
         install_file.write_text(install_data)
         print("I: Prepared package")
@@ -82,47 +84,70 @@ def build_package(package: list, patch_dir: Path) -> None:
         package (list): List of Packages from toml
         patch_dir (Path): Directory containing patches
     """
-    repo_name = package['name']
+    repo_name = package["name"]
     repo_dir = Path(repo_name)
 
     try:
         # Clone the repository if it does not exist
         if not repo_dir.exists():
-            run(['git', 'clone', package['scm_url'], str(repo_dir)], check=True)
+            run(["git", "clone", package["scm_url"], str(repo_dir)], check=True)
 
         # Check out the specific commit
-        run(['git', 'checkout', package['commit_id']], cwd=repo_dir, check=True)
+        run(["git", "checkout", package["commit_id"]], cwd=repo_dir, check=True)
 
         # Apply patches if any
-        if (repo_dir / 'patches'):
+        if repo_dir / "patches":
             apply_patches(repo_dir, patch_dir)
 
         # Sanitize the commit ID and build a tarball for the package
-        commit_id_sanitized = package['commit_id'].replace('/', '_')
+        commit_id_sanitized = package["commit_id"].replace("/", "_")
         tarball_name = f"{repo_name}_{commit_id_sanitized}.tar.gz"
-        run(['tar', '-czf', tarball_name, '-C', str(repo_dir.parent), repo_name], check=True)
+        run(
+            ["tar", "-czf", tarball_name, "-C", str(repo_dir.parent), repo_name],
+            check=True,
+        )
         print(f"I: Tarball created: {tarball_name}")
 
         # Prepare the package if required
-        if package.get('prepare_package', False):
-            prepare_package(repo_dir, package.get('install_data', ''))
+        if package.get("prepare_package", False):
+            prepare_package(repo_dir, package.get("install_data", ""))
 
         # Build dependency package and install it
-        if (repo_dir / 'debian/control').exists():
+        if (repo_dir / "debian/control").exists():
             try:
-                run('sudo mk-build-deps --install --tool "apt-get --yes --no-install-recommends"', cwd=repo_dir, check=True, shell=True)
-                run('sudo dpkg -i *build-deps*.deb', cwd=repo_dir, check=True, shell=True)
+                run(
+                    'sudo mk-build-deps --install --tool "apt-get --yes --no-install-recommends"',
+                    cwd=repo_dir,
+                    check=True,
+                    shell=True,
+                )
+                run(
+                    "sudo dpkg -i *build-deps*.deb",
+                    cwd=repo_dir,
+                    check=True,
+                    shell=True,
+                )
             except CalledProcessError as e:
                 print(f"Failed to build package {repo_name}: {e}")
 
-        # Build the package, check if we have build_cmd in the package.toml
+        # Build the package, check if we have build_env and/or build_cmd in the package.toml
         try:
-            build_cmd = package.get('build_cmd', 'dpkg-buildpackage -uc -us -tc -F')
+            if package.get("build_env"):
+                build_cmd = package.get(
+                    "build_env" + "build_cmd", "dpkg-buildpackage -uc -us -tc -F"
+                )
+            else:
+                build_cmd = package.get("build_cmd", "dpkg-buildpackage -uc -us -tc -F")
             run(build_cmd, cwd=repo_dir, check=True, shell=True)
         except CalledProcessError as e:
             print(e)
             print("I: Source packages build failed, ignoring - building binaries only")
-            build_cmd = package.get('build_cmd', 'dpkg-buildpackage -uc -us -tc -b')
+            if package.get("build_env"):
+                build_cmd = package.get(
+                    "build_env" + "build_cmd", "dpkg-buildpackage -uc -us -tc -b"
+                )
+            else:
+                build_cmd = package.get("build_cmd", "dpkg-buildpackage -uc -us -tc -b")
             run(build_cmd, cwd=repo_dir, check=True, shell=True)
 
     except CalledProcessError as e:
@@ -137,7 +162,7 @@ def cleanup_build_deps(repo_dir: Path) -> None:
     """Clean up build dependency packages"""
     try:
         if repo_dir.exists():
-            for file in glob.glob(str(repo_dir / '*build-deps*.deb')):
+            for file in glob.glob(str(repo_dir / "*build-deps*.deb")):
                 os.remove(file)
             print("I: Cleaned up build dependency packages")
     except Exception as e:
@@ -147,7 +172,7 @@ def cleanup_build_deps(repo_dir: Path) -> None:
 def copy_packages(repo_dir: Path) -> None:
     """Copy generated .deb packages to the parent directory"""
     try:
-        deb_files = glob.glob(str(repo_dir / '*.deb'))
+        deb_files = glob.glob(str(repo_dir / "*.deb"))
         for deb_file in deb_files:
             shutil.copy(deb_file, repo_dir.parent)
             print(f'I: copy generated "{deb_file}" package')
@@ -155,26 +180,30 @@ def copy_packages(repo_dir: Path) -> None:
         print(f"Error copying packages: {e}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Prepare argument parser
     arg_parser = ArgumentParser()
-    arg_parser.add_argument('--config',
-                            default='package.toml',
-                            help='Path to the package configuration file')
-    arg_parser.add_argument('--patch-dir',
-                            default='patches',
-                            help='Path to the directory containing patches')
+    arg_parser.add_argument(
+        "--config",
+        default="package.toml",
+        help="Path to the package configuration file",
+    )
+    arg_parser.add_argument(
+        "--patch-dir",
+        default="patches",
+        help="Path to the directory containing patches",
+    )
     args = arg_parser.parse_args()
 
     # Load package configuration
-    with open(args.config, 'r') as file:
+    with open(args.config, "r") as file:
         config = toml.load(file)
 
-    packages = config['packages']
+    packages = config["packages"]
     patch_dir = Path(args.patch_dir)
 
     # Load global dependencies
-    global_dependencies = config.get('dependencies', {}).get('packages', [])
+    global_dependencies = config.get("dependencies", {}).get("packages", [])
     if global_dependencies:
         ensure_dependencies(global_dependencies)
 
@@ -183,7 +212,7 @@ if __name__ == '__main__':
         build_package(package, patch_dir)
 
         # Clean up build dependency packages after build
-        cleanup_build_deps(Path(package['name']))
+        cleanup_build_deps(Path(package["name"]))
 
         # Copy generated .deb packages to parent directory
-        copy_packages(Path(package['name']))
+        copy_packages(Path(package["name"]))

--- a/scripts/package-build/kea/package.toml
+++ b/scripts/package-build/kea/package.toml
@@ -2,3 +2,20 @@
 name = "isc-kea"
 commit_id = "debian/2.4.1-3"
 scm_url = "https://salsa.debian.org/debian/isc-kea"
+build_env = "DEB_BUILD_OPTIONS='parallel=1'"
+
+[dependencies]
+packages = [
+  "default-libmysqlclient-dev",
+  "dh-apparmor",
+  "docbook",
+  "elinks",
+  "libboost-dev",
+  "libboost-system-dev",
+  "liblog4cplus-dev",
+  "libpq-dev",
+  "postgresql-server-dev-all",
+  "python3-dev",
+  "python3-sphinx",
+  "python3-sphinx-rtd-theme"
+]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix a race condition in the `kea` package build process.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6961

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
package-build (`kea`)

## Proposed changes
<!--- Describe your changes in detail -->
Because the `package.toml` file for the `kea` package doesn't specify a build command, it defaults to running `dpkg-buildpackage -uc -us -tc -F` against the cloned `git` repo. This is a problem because, by default, `dpkg-buildpackage` runs tasks in parallel (the limit is defined as `auto`, but seems to be based off the number of processors the system has), and there's a component being compiled in `kea` that other make tasks rely on, but ends up sometimes not being built in time for the dependent task to run successfully.

This PR adds a build command to kea's package.toml that specifies the additional argument `-j 1` to the original `dpkg-buildpackage` command, which reverts `dpkg-buildpackage`'s behaviour to serial execution of tasks.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
(using the modified `package.toml`)
git clone https://github.com/vyos/vyos-build
cd vyos-build/scripts/package-build/kea
./build.py
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-build/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
