### PR TITLE
Testsuite: T861: use proper base MAC address from RFC7042

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -155,7 +155,8 @@ def get_qemu_cmd(name, enable_uefi, disk_img, raid=None, iso_img=None, tpm=False
                 f' -device ahci,id=achi0' \
                 f' -device ide-cd,bus=achi0.0,drive=drive-cd1,id=cd1,bootindex=10'
 
-    macbase = '02:00:00:00:00'
+    # RFC7042 section 2.1.2 MAC addresses used for documentation
+    macbase = '00:00:5E:00:53'
     cmd = f'qemu-system-x86_64 \
         -name "{name}" \
         -smp 2,sockets=1,cores=2,threads=1 \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 085df7615a (`Testsuite: T861: always use 2 VCPUs`) also altered the base MAC address used by QEMU to a locally administered one. Something that looked "right" in the beginning turned out to break the smoketest platform.

The reason is the locally administered bit is evaluated in [1] and if set and not on the exclusion list (as it was a Realtek base MAC address before), the interface in question is not considered persistent and thus not added to the configuration file upon system startup.

1: https://github.com/vyos/vyos-1x/blob/825743b6bcdf8fa2c263dabaa3fee40ba7a98525/src/helpers/vyos-interface-rescan.py#L73-L74

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T861

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
