### PR TITLE
T7026: Use vpp patches during build as they not applied

### DIFF
--- a/scripts/package-build/build.py
+++ b/scripts/package-build/build.py
@@ -120,9 +120,17 @@ def build_package(package: list, patch_dir: Path) -> None:
                 print(f"I: pre_build_hook failed for the {repo_name}")
                 raise
 
-        # Apply patches if any
-        if (repo_dir / 'patches'):
-            apply_patches(repo_dir, patch_dir / repo_name)
+        # Apply patches if the 'apply_patches' key is set to True (default) in the package configuration
+        # This allows skipping patch application for specific packages when desired
+        #
+        # Usage:
+        #   apply_patches = false
+        #
+        # Default to True if the key is missing
+        if package.get('apply_patches', True):
+            # Check if the 'patches' directory exists in the repository
+            if (repo_dir / 'patches'):
+                apply_patches(repo_dir, patch_dir / repo_name)
 
         # Sanitize the commit ID and build a tarball for the package
         commit_id_sanitized = package['commit_id'].replace('/', '_')

--- a/scripts/package-build/vpp/package.toml
+++ b/scripts/package-build/vpp/package.toml
@@ -3,11 +3,14 @@ name = "vyos-vpp-patches"
 commit_id = "current"
 scm_url = "https://github.com/vyos/vyos-vpp-patches"
 build_cmd = "/bin/true"
+apply_patches = false
 
 [[packages]]
 name = "vpp"
 commit_id = "stable/2406"
 scm_url = "https://github.com/FDio/vpp"
+# Skip apply patches by build.py as we use them in build_cmd
+apply_patches = false
 
 pre_build_hook = """
 mkdir -p ../patches/vpp/
@@ -15,6 +18,12 @@ rsync -av ../vyos-vpp-patches/patches/vpp/ ../patches/vpp/
 """
 
 build_cmd = """
+# Patches for vpp should applied here
+for patch in ../patches/vpp/*.patch; do
+    echo "I: build_cmd applying patch $patch..."
+    git -c user.email=maintainers@vyos.net -c user.name=vyos am "$patch" || { echo "Failed to apply patch $patch"; exit 1; }
+done
+
 make UNATTENDED=yes install-dep
 make pkg-deb
 cp build-root/*.deb ../


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Patches for VPP are not applied due to specific to the app repo structure, so we cannot use the standard included in the `build.py` function `apply_patches` to patch the app sources. 
Use an explicit patch in the `build_cmd` as a workaround and the most straightforward fix.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Before the fix
```
vyos@r14# set vpp settings interface eth1 driver dpdk 
[edit]
vyos@r14# commit
[ vpp ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 139, in run_script
    script.apply(c)
  File "/usr/libexec/vyos//conf_mode/vpp.py", line 477, in apply
    vpp_control.cli_cmd('lcp param route-no-paths off')
  File "/usr/lib/python3/dist-packages/vyos/vpp/control_vpp.py", line 81, in check_retval_wrapper
    raise VPPValueError(f'VPP API call failed: {return_value.retval}')
vpp_papi.vpp_papi.VPPValueError: VPP API call failed: -1

[[vpp]] failed
Commit failed

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
