### PR TITLE
T7105: Disable by default vpp service until it is configured

### DIFF
--- a/data/live-build-config/hooks/live/18-enable-disable_services.chroot
+++ b/data/live-build-config/hooks/live/18-enable-disable_services.chroot
@@ -69,6 +69,7 @@ systemctl disable dpkg-db-backup.service
 systemctl disable zabbix-agent2.service
 systemctl disable suricata.service
 systemctl disable vyconfd.service
+systemctl disable vpp.service
 
 echo I: Enabling services
 systemctl enable vyos-hostsd.service


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Disable by default vpp service until it is configured
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Disable by default `vpp.service`

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7105

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
