### PR TITLE
T7140: check-qemu-install: fix unparsable command

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -554,7 +554,7 @@ try:
     c.expect(op_mode_prompt)
     c.sendline('show system memory')
     c.expect(op_mode_prompt)
-    c.sendline('show version all | match "vpp|vyos-1x"')
+    c.sendline('show version all | grep -e "vpp" -e "vyos-1x"')
     c.expect(op_mode_prompt)
 
     #################################################


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
this seems to be whats causing the recent build failures I've been seeing in the flows of nightly builds. it later tries to parse commands by splitting on `|` around 800 and fails on a (W) (T) (F). the output remains the same but with grep theres no need to rely on including a `|`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T7140

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
