### PR TITLE
T6353: Add cracklib dependencies, fix local Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -264,7 +264,8 @@ RUN pip install --break-system-packages \
       python3-zmq \
       pylint \
       quilt \
-      whois
+      whois \
+      python3-cracklib
 
 # Go required for telegraf and prometheus exporters build
 RUN GO_VERSION_INSTALL="1.23.2" ; \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
- Add the following packages required by vyos/vyos-1x:
  - `libcrack2`
  - `cracklib-runtime`
  - `python3-cracklib`
  - `miscfiles` - Dictionaries
- Fix a bug in Dockerfile that caused local Docker builds always to fail
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):
  - Broken local build fix: when running `docker build -t vyos/vyos-build:current docker` in the source root directory locally the build was continuously failing on step 12 (line 138) when trying to download and install opam and OCaml, always displaying the same error message. A closer investigation revealed that the line causing the error was `sed -i 's/read -r BINDIR/BINDIR=\"\"/' /tmp/opam_install.sh` which was supposed to edit an installation script on the fly. However, since the installation script is always pulled from the source repository, this line was no longer valid since the current version of the script uses `read_tty` instead of `read -r` (line 1199 of the opam install script). After changing the line in question a local container was successfully built.

  - Add the system dependencies required by password strength check functionality in vyos/vyos-1x

### Local build error message (pre-change):

  ```
  => ERROR [12/45] RUN curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh       --output /tmp/opam_install.sh --retry 10 --retry-delay 5 &&     sed -i 's/read   2.1s 
  ------                                                                                                                                                                                      
   > [12/45] RUN curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh       --output /tmp/opam_install.sh --retry 10 --retry-delay 5 &&     sed -i 's/read -r BINDIR/BINDIR=""/' /tmp/opam_install.sh && sh /tmp/opam_install.sh &&     opam init --root=/opt/opam --comp=4.14.2 --disable-sandboxing --no-setup:                                                    
  0.173   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                                                                                       
  0.173                                  Dload  Upload   Total   Spent    Left  Speed                                                                                                         
  100 61474  100 61474    0     0   167k      0 --:--:-- --:--:-- --:--:--  167k                                                                                                              
  0.540 ## Downloading opam 2.3.0 for linux on x86_64...
  2.017 ## Downloaded.
  2.017 ## Where should it be installed ? [/usr/local/bin] 
  ------
  Dockerfile:138
  --------------------
   137 |     # Installing OCAML needed to compile libvyosconfig
   138 | >>> RUN curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh \
   139 | >>>       --output /tmp/opam_install.sh --retry 10 --retry-delay 5 && \
   140 | >>>     sed -i 's/read -r BINDIR/BINDIR=""/' /tmp/opam_install.sh && sh /tmp/opam_install.sh && \
   141 | >>>     opam init --root=/opt/opam --comp=${OCAML_VERSION} --disable-sandboxing --no-setup
   142 |     
  --------------------
  ERROR: failed to solve: process "/bin/sh -c curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh       --output /tmp/opam_install.sh --retry 10 --retry-delay 5 &&     sed -i 's/read -r BINDIR/BINDIR=\"\"/' /tmp/opam_install.sh && sh /tmp/opam_install.sh &&     opam init --root=/opt/opam --comp=${OCAML_VERSION} --disable-sandboxing --no-setup" did not complete successfully: exit code: 1
  ```

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6353

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/4338 - Is blocked by this PR

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
