### PR TITLE
intel: T6847: update IXGBE Out-Of-Tree driver to v6.0.5

### DIFF
--- a/scripts/package-build/linux-kernel/.gitignore
+++ b/scripts/package-build/linux-kernel/.gitignore
@@ -24,7 +24,7 @@ vyos-intel-*/
 vyos-linux-firmware*/
 kernel-vars
 r8152-*.tar.bz2
-
+ephemeral.*
 *.buildinfo
 *.build
 *.changes

--- a/scripts/package-build/linux-kernel/.gitignore
+++ b/scripts/package-build/linux-kernel/.gitignore
@@ -18,7 +18,7 @@
 # Intel Driver source
 i40e-*/
 igb-*/
-ixgbe-*/
+ethernet-linux-ixgbe/
 ixgbevf-*/
 vyos-intel-*/
 vyos-linux-firmware*/

--- a/scripts/package-build/linux-kernel/build-intel-ixgbe.sh
+++ b/scripts/package-build/linux-kernel/build-intel-ixgbe.sh
@@ -14,15 +14,14 @@ fi
 
 . ${KERNEL_VAR_FILE}
 
-url="https://sourceforge.net/projects/e1000/files/ixgbe%20stable/5.20.3/ixgbe-5.20.3.tar.gz"
+cd ${CWD}/ethernet-linux-ixgbe
+if [ -d .git ]; then
+    git clean --force -d -x
+    git reset --hard origin/main
+fi
 
-cd ${CWD}
-
-DRIVER_FILE=$(basename ${url} | sed -e s/tar_0/tar/)
-DRIVER_DIR="${DRIVER_FILE%.tar.gz}"
 DRIVER_NAME="ixgbe"
-DRIVER_VERSION=$(echo ${DRIVER_DIR} | awk -F${DRIVER_NAME} '{print $2}' | sed 's/^-//')
-DRIVER_VERSION_EXTRA=""
+DRIVER_VERSION=$(git describe | sed s/^v//)
 
 # Build up Debian related variables required for packaging
 DEBIAN_ARCH=$(dpkg --print-architecture)
@@ -30,23 +29,6 @@ DEBIAN_DIR="${CWD}/vyos-intel-${DRIVER_NAME}_${DRIVER_VERSION}_${DEBIAN_ARCH}"
 DEBIAN_CONTROL="${DEBIAN_DIR}/DEBIAN/control"
 DEBIAN_POSTINST="${CWD}/vyos-intel-ixgbe.postinst"
 
-# Fetch Intel driver source from SourceForge
-if [ -e ${DRIVER_FILE} ]; then
-    rm -f ${DRIVER_FILE}
-fi
-curl -L -o ${DRIVER_FILE} ${url}
-if [ "$?" -ne "0" ]; then
-    exit 1
-fi
-
-# Unpack archive
-if [ -d ${DRIVER_DIR} ]; then
-    rm -rf ${DRIVER_DIR}
-fi
-mkdir -p ${DRIVER_DIR}
-tar -C ${DRIVER_DIR} --strip-components=1 -xf ${DRIVER_FILE}
-
-cd ${DRIVER_DIR}/src
 if [ -z $KERNEL_DIR ]; then
     echo "KERNEL_DIR not defined"
     exit 1
@@ -54,19 +36,19 @@ fi
 
 # See https://lore.kernel.org/lkml/f90837d0-810e-5772-7841-28d47c44d260@intel.com/
 echo "I: remove pci_enable_pcie_error_reporting() code no longer present in Kernel"
-sed -i '/.*pci_disable_pcie_error_reporting(pdev);/d' ixgbe_main.c
-sed -i '/.*pci_enable_pcie_error_reporting(pdev);/d' ixgbe_main.c
+sed -i '/.*pci_disable_pcie_error_reporting(pdev);/d' src/ixgbe_main.c
+sed -i '/.*pci_enable_pcie_error_reporting(pdev);/d' src/ixgbe_main.c
 
 # See https://vyos.dev/T6155
 echo "I: always enable allow_unsupported_sfp for all NICs by default"
-patch -l -p1 < ../../patches/ixgbe/allow_unsupported_sfp.patch
+patch -l -p1 < ../patches/ixgbe/allow_unsupported_sfp.patch
 
 # See https://vyos.dev/T6162
 echo "I: add 1000BASE-BX support"
-patch -l -p1 < ../../patches/ixgbe/add_1000base-bx_support.patch
+patch -l -p1 < ../patches/ixgbe/add_1000base-bx_support.patch
 
 echo "I: Compile Kernel module for Intel ${DRIVER_NAME} driver"
-make KSRC=${KERNEL_DIR} INSTALL_MOD_PATH=${DEBIAN_DIR} INSTALL_FW_PATH=${DEBIAN_DIR} -j $(getconf _NPROCESSORS_ONLN) install
+make KSRC=${KERNEL_DIR} INSTALL_MOD_PATH=${DEBIAN_DIR} INSTALL_FW_PATH=${DEBIAN_DIR} -j $(getconf _NPROCESSORS_ONLN) -C src install
 
 if [ "x$?" != "x0" ]; then
     exit 1
@@ -96,18 +78,3 @@ fpm --input-type dir --output-type deb --name vyos-intel-${DRIVER_NAME} \
     --description "Vendor based driver for Intel ${DRIVER_NAME}" \
     --depends linux-image-${KERNEL_VERSION}${KERNEL_SUFFIX} \
     --license "GPL2" -C ${DEBIAN_DIR} --after-install ${DEBIAN_POSTINST}
-
-# echo "I: Cleanup ${DRIVER_NAME} source"
-# cd ${CWD}
-# if [ -e ${DRIVER_FILE} ]; then
-#     rm -f ${DRIVER_FILE}
-# fi
-# if [ -d ${DRIVER_DIR} ]; then
-#     rm -rf ${DRIVER_DIR}
-# fi
-# if [ -d ${DEBIAN_DIR} ]; then
-#     rm -rf ${DEBIAN_DIR}
-# fi
-# if [ -f ${DEBIAN_POSTINST} ]; then
-#     rm -f ${DEBIAN_POSTINST}
-# fi

--- a/scripts/package-build/linux-kernel/package.toml
+++ b/scripts/package-build/linux-kernel/package.toml
@@ -44,8 +44,8 @@ build_cmd = "build_intel_qat"
 
 [[packages]]
 name = "ixgbe"
-commit_id = ""
-scm_url = ""
+commit_id = "v6.0.5"
+scm_url = "https://github.com/intel/ethernet-linux-ixgbe"
 build_cmd = "build_intel_ixgbe"
 
 [[packages]]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Intel moved the driver sources to GitHub. After some issues with a binary build the IXGBE driver now
finally can be build for VyOS using the public GitHub sources.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Version Upgrade

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6847

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
