### PR TITLE
Kernel: T5887: update Linux Kernel to v6.6.79

### DIFF
--- a/data/defaults.toml
+++ b/data/defaults.toml
@@ -14,7 +14,7 @@ vyos_mirror = "https://packages.vyos.net/repositories/current"
 vyos_branch = "current"
 release_train = "current"
 
-kernel_version = "6.6.77"
+kernel_version = "6.6.79"
 kernel_flavor = "vyos"
 bootloaders = "syslinux,grub-efi"
 

--- a/scripts/package-build/linux-kernel/patches/kernel/0001-linkstate-ip-device-attribute.patch
+++ b/scripts/package-build/linux-kernel/patches/kernel/0001-linkstate-ip-device-attribute.patch
@@ -88,10 +88,10 @@ index cf592d7b630f..e8915701aa73 100644
  };
  
 diff --git a/net/ipv4/devinet.c b/net/ipv4/devinet.c
-index 4822f68edbf0..ba4304144d37 100644
+index c33b1ecc591e..7576d51cd16d 100644
 --- a/net/ipv4/devinet.c
 +++ b/net/ipv4/devinet.c
-@@ -2608,6 +2608,7 @@ static struct devinet_sysctl_table {
+@@ -2609,6 +2609,7 @@ static struct devinet_sysctl_table {
  					      "route_localnet"),
  		DEVINET_SYSCTL_FLUSHING_ENTRY(DROP_UNICAST_IN_L2_MULTICAST,
  					      "drop_unicast_in_l2_multicast"),
@@ -126,7 +126,7 @@ index 8360939acf85..b13832a08d28 100644
  		.procname	= "ioam6_id",
  		.data		= &ipv6_devconf.ioam6_id,
 diff --git a/net/ipv6/route.c b/net/ipv6/route.c
-index fc5c53462025..9c9c9d51a12d 100644
+index 5715d54f3d0b..e88971b512ba 100644
 --- a/net/ipv6/route.c
 +++ b/net/ipv6/route.c
 @@ -682,6 +682,14 @@ static inline void rt6_probe(struct fib6_nh *fib6_nh)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Latest Linux Kernel bugfix version

`make testc` passed locally

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5887

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
