### PR TITLE
T7197: Decrease config smoketest to 2 CPUs and 7G RAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-vpp: checkiso
 .PHONY: testc
 .ONESHELL:
 testc: checkiso
-	scripts/check-qemu-install --debug --configd --cpu 4 --memory 8 --configtest build/live-image-amd64.hybrid.iso $(filter-out $@,$(MAKECMDGOALS))
+	scripts/check-qemu-install --debug --configd --cpu 2 --memory 7 --configtest build/live-image-amd64.hybrid.iso $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: testraid
 .ONESHELL:


### PR DESCRIPTION
Decrease system resources for configload tests

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Decrease config smoketest to 2 CPUs and 7G RAM
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Decrease CPU and RAM

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7197

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Tests
```
vyos@vyos:~$ systemd-detect-virt
DEBUG - systemd-detect-virt
DEBUG - kvm
DEBUG - vyos@vyos:~$ show system cpu
DEBUG - show system cpu
CPU socket: 0
DEBUG - CPU Vendor:       AuthenticAMD
DEBUG - Model:            AMD Ryzen 5 3600 6-Core Processor
DEBUG - Cores:            2
DEBUG - Current MHz:      3593.248
vyos@vyos:~$ show system memory
DEBUG - show system memory
Total: 6.79 GB
DEBUG - Free:  6.25 GB
DEBUG - Used:  554.95 MB
vyos@vyos:~$ show version all | grep -e "vpp" -e "vyos-1x"
DEBUG - show version all | grep -e "vpp" -e "vyos-1x"
DEBUG - ii  libvppinfra                          24.10.0-13~gc95035f0f            amd64        Vector Packet Processing--runtime libraries
DEBUG - ii  libvppinfra-dev                      24.10.0-13~gc95035f0f            amd64        Vector Packet Processing--runtime libraries
DEBUG - ii  python3-vpp-api                      24.10.0-13~gc95035f0f            amd64        VPP Python3 API bindings
DEBUG - ii  vpp                                  24.10.0-13~gc95035f0f            amd64        Vector Packet Processing--executables
DEBUG - ii  vpp-dev                              24.10.0-13~gc95035f0f            amd64        Vector Packet Processing--development support
DEBUG - ii  vpp-plugin-core                      24.10.0-13~gc95035f0f            amd64        Vector Packet Processing--runtime core plugins
DEBUG - ii  vpp-plugin-dpdk                      24.10.0-13~gc95035f0f            amd64        Vector Packet Processing--runtime dpdk plugin
DEBUG - ii  vyos-1x                              1.5dev0-2689-gfe08f7f3a          amd64        VyOS configuration scripts and data
DEBUG - ii  vyos-1x-smoketest                    1.5dev0-2689-gfe08f7f3a          all          VyOS build sanity checking toolkit
DEBUG - vyos@vyos:~$ lsb_release --short --id 2>/dev/null
DEBUG - lsb_release --short --id 2>/dev/null
DEBUG - VyOSlsb_release --short --release 2>/dev/null
DEBUG - 
DEBUG - vyos@vyos:~$ lsb_release --short --release 2>/dev/null
DEBUG - 1.5-rolling-202502250918lsb_release --short --codename 2>/dev/null
DEBUG - 
DEBUG - vyos@vyos:~$ lsb_release --short --codename 2>/dev/null
DEBUG - current
DEBUG - show log kernel | match "VyOS build time autogenerated kernel key"
DEBUG - vyos@vyos:~$ show log kernel | match "VyOS build time autogenerated kernel key"
DEBUG - Feb 25 11:57:52 kernel: Loaded X.509 cert 'VyOS build time autogenerated kernel key: 940b62e7bcb8679748f82b4a9c22d942ca6472cf'
DEBUG - vyos@vyos:~$ touch /tmp/vyos.smoketests.hint
DEBUG - touch /tmp/vyos.smoketests.hint
 INFO - Adding a legacy WireGuard default keypair for migrations
DEBUG - vyos@vyos:~$ sudo mkdir -p /config/auth/wireguard/default
DEBUG - sudo mkdir -p /config/auth/wireguard/default
DEBUG - vyos@vyos:~$ echo "aGx+fvW916Ej7QRnBbW3QMoldhNv1u95/WHz45zDmF0=" | sudo tee /config/auth/wireguard/default/private.key
fig/auth/wireguard/default/private.keydhNv1u95/WHz45zDmF0=" | sudo tee /con 
DEBUG - aGx+fvW916Ej7QRnBbW3QMoldhNv1u95/WHz45zDmF0=
DEBUG - vyos@vyos:~$echo "x39C77eavJNpvYbNzPSG3n1D68rHYei6q3AEBEyL1z8=" | sudo tee /config/auth/wireguard/default/public.key
fig/auth/wireguard/default/public.key1D68rHYei6q3AEBEyL1z8=" | sudo tee /con 
DEBUG - x39C77eavJNpvYbNzPSG3n1D68rHYei6q3AEBEyL1z8=
 INFO - Generating PKI objects
DEBUG - vyos@vyos:~$ /usr/bin/vyos-configtest-pki
DEBUG - /usr/bin/vyos-configtest-pki
DEBUG - vyos@vyos:~$ echo "#!/bin/sh" > /config/scripts/vyos-foo-update.script; chmod 775 /config/scripts/vyos-foo-update.script
5 /config/scripts/vyos-foo-update.scriptts/vyos-foo-update.script; chmod 77 
 INFO - Executing load config tests
DEBUG - vyos@vyos:~$ /usr/bin/vyos-configtest
DEBUG - /usr/bin/vyos-configtest
DEBUG - Generating tests
DEBUG - Loaded migration result test for config "basic-api-service"
DEBUG - Loaded migration result test for config "basic-syslog"
DEBUG - Loaded migration result test for config "basic-vyos"
DEBUG - Loaded migration result test for config "basic-vyos-no-ntp"
DEBUG - Loaded migration result test for config "bgp-azure-ipsec-gateway"
DEBUG - Loaded migration result test for config "bgp-bfd-communities"
DEBUG - Loaded migration result test for config "bgp-big-as-cloud"
DEBUG - Loaded migration result test for config "bgp-dmvpn-hub"
DEBUG - Loaded migration result test for config "bgp-dmvpn-spoke"
DEBUG - Loaded migration result test for config "bgp-evpn-l2vpn-leaf"
DEBUG - Loaded migration result test for config "bgp-evpn-l2vpn-spine"
DEBUG - Loaded migration result test for config "bgp-evpn-l3vpn-pe-router"
DEBUG - Loaded migration result test for config "bgp-medium-confederation"
DEBUG - Loaded migration result test for config "bgp-rpki"
DEBUG - Loaded migration result test for config "bgp-small-internet-exchange"
DEBUG - Loaded migration result test for config "bgp-small-ipv4-unicast"
DEBUG - Loaded migration result test for config "cluster-basic"
DEBUG - Loaded migration result test for config "container-simple"
DEBUG - Loaded migration result test for config "dialup-router-complex"
DEBUG - Loaded migration result test for config "dialup-router-medium-vpn"
DEBUG - Loaded migration result test for config "dialup-router-wireguard-ipv6"
DEBUG - Loaded migration result test for config "egp-igp-route-maps"
DEBUG - Loaded migration result test for config "igmp-pim-small"
DEBUG - Loaded migration result test for config "ipoe-server"
DEBUG - Loaded migration result test for config "ipv6-disable"
DEBUG - Loaded migration result test for config "isis-small"
DEBUG - Loaded migration result test for config "nat-basic"
DEBUG - Loaded migration result test for config "ospf-simple"
DEBUG - Loaded migration result test for config "ospf-small"
DEBUG - Loaded migration result test for config "pppoe-server"
DEBUG - Loaded migration result test for config "qos-basic"
DEBUG - Loaded migration result test for config "rip-router"
DEBUG - Loaded migration result test for config "rpki-only"
DEBUG - Loaded migration result test for config "static-route-basic"
DEBUG - Loaded migration result test for config "tunnel-broker"
DEBUG - Loaded migration result test for config "vpn-openconnect-sstp"
DEBUG - Loaded migration result test for config "vpp"
DEBUG - Loaded migration result test for config "vrf-basic"
DEBUG - Loaded migration result test for config "vrf-bgp-pppoe-underlay"
DEBUG - Loaded migration result test for config "vrf-ospf"
DEBUG - Loaded migration result test for config "wireless-basic"
DEBUG - ... completed: 0.029061
DEBUG - test_basic_api_service (__main__.TestConfigBasicApiService.test_basic_api_service) ...  time: 24.249
DEBUG - ok
DEBUG - test_basic_syslog (__main__.TestConfigBasicSyslog.test_basic_syslog) ...  time: 8.045
DEBUG - ok
DEBUG - test_basic_vyos (__main__.TestConfigBasicVyos.test_basic_vyos) ...  time: 29.091
DEBUG - ok
DEBUG - test_basic_vyos_no_ntp (__main__.TestConfigBasicVyosNoNtp.test_basic_vyos_no_ntp) ...  time: 27.385
DEBUG - ok
DEBUG - test_bgp_azure_ipsec_gateway (__main__.TestConfigBgpAzureIpsecGateway.test_bgp_azure_ipsec_gateway) ...  time: 37.863
DEBUG - ok
DEBUG - test_bgp_bfd_communities (__main__.TestConfigBgpBfdCommunities.test_bgp_bfd_communities) ...  time: 26.957
DEBUG - ok
DEBUG - test_bgp_big_as_cloud (__main__.TestConfigBgpBigAsCloud.test_bgp_big_as_cloud) ...  time: 65.017
DEBUG - ok
DEBUG - test_bgp_dmvpn_hub (__main__.TestConfigBgpDmvpnHub.test_bgp_dmvpn_hub) ...  time: 25.863
DEBUG - ok
DEBUG - test_bgp_dmvpn_spoke (__main__.TestConfigBgpDmvpnSpoke.test_bgp_dmvpn_spoke) ...  time: 26.261
DEBUG - ok
DEBUG - test_bgp_evpn_l2vpn_leaf (__main__.TestConfigBgpEvpnL2vpnLeaf.test_bgp_evpn_l2vpn_leaf) ...  time: 24.691
DEBUG - ok
DEBUG - test_bgp_evpn_l2vpn_spine (__main__.TestConfigBgpEvpnL2vpnSpine.test_bgp_evpn_l2vpn_spine) ...  time: 23.520
DEBUG - ok
DEBUG - test_bgp_evpn_l3vpn_pe_router (__main__.TestConfigBgpEvpnL3vpnPeRouter.test_bgp_evpn_l3vpn_pe_router) ...  time: 29.454
DEBUG - ok
DEBUG - test_bgp_medium_confederation (__main__.TestConfigBgpMediumConfederation.test_bgp_medium_confederation) ...  time: 11.138
DEBUG - ok
DEBUG - test_bgp_rpki (__main__.TestConfigBgpRpki.test_bgp_rpki) ...  time: 23.002
DEBUG - ok
DEBUG - test_bgp_small_internet_exchange (__main__.TestConfigBgpSmallInternetExchange.test_bgp_small_internet_exchange) ...  time: 26.334
DEBUG - ok
DEBUG - test_bgp_small_ipv4_unicast (__main__.TestConfigBgpSmallIpv4Unicast.test_bgp_small_ipv4_unicast) ...  time: 24.344
DEBUG - ok
DEBUG - test_cluster_basic (__main__.TestConfigClusterBasic.test_cluster_basic) ...  time: 9.425
DEBUG - ok
DEBUG - test_container_simple (__main__.TestConfigContainerSimple.test_container_simple) ...  time: 8.647
DEBUG - ok
DEBUG - test_dialup_router_complex (__main__.TestConfigDialupRouterComplex.test_dialup_router_complex) ...  time: 47.895
DEBUG - ok
DEBUG - test_dialup_router_medium_vpn (__main__.TestConfigDialupRouterMediumVpn.test_dialup_router_medium_vpn) ...  time: 42.193
DEBUG - ok
DEBUG - test_dialup_router_wireguard_ipv6 (__main__.TestConfigDialupRouterWireguardIpv6.test_dialup_router_wireguard_ipv6) ...  time: 49.598
DEBUG - ok
DEBUG - test_egp_igp_route_maps (__main__.TestConfigEgpIgpRouteMaps.test_egp_igp_route_maps) ...  time: 9.677
DEBUG - ok
DEBUG - test_igmp_pim_small (__main__.TestConfigIgmpPimSmall.test_igmp_pim_small) ...  time: 23.375
DEBUG - ok
DEBUG - test_ipoe_server (__main__.TestConfigIpoeServer.test_ipoe_server) ...  time: 25.385
DEBUG - ok
DEBUG - test_ipv6_disable (__main__.TestConfigIpv6Disable.test_ipv6_disable) ...  time: 24.181
DEBUG - ok
DEBUG - test_isis_small (__main__.TestConfigIsisSmall.test_isis_small) ...  time: 24.465
DEBUG - ok
DEBUG - test_nat_basic (__main__.TestConfigNatBasic.test_nat_basic) ...  time: 27.132
DEBUG - ok
DEBUG - test_ospf_simple (__main__.TestConfigOspfSimple.test_ospf_simple) ...  time: 9.569
DEBUG - ok
DEBUG - test_ospf_small (__main__.TestConfigOspfSmall.test_ospf_small) ...  time: 26.576
DEBUG - ok
DEBUG - test_pppoe_server (__main__.TestConfigPppoeServer.test_pppoe_server) ...  time: 25.229
DEBUG - ok
DEBUG - test_qos_basic (__main__.TestConfigQosBasic.test_qos_basic) ...  time: 23.339
DEBUG - ok
DEBUG - test_rip_router (__main__.TestConfigRipRouter.test_rip_router) ...  time: 24.743
DEBUG - ok
DEBUG - test_rpki_only (__main__.TestConfigRpkiOnly.test_rpki_only) ...  time: 25.892
DEBUG - ok
DEBUG - test_static_route_basic (__main__.TestConfigStaticRouteBasic.test_static_route_basic) ...  time: 8.491
DEBUG - ok
DEBUG - test_tunnel_broker (__main__.TestConfigTunnelBroker.test_tunnel_broker) ...  time: 25.596
DEBUG - ok
DEBUG - test_vpn_openconnect_sstp (__main__.TestConfigVpnOpenconnectSstp.test_vpn_openconnect_sstp) ...  time: 29.098
DEBUG - ok
DEBUG - test_vpp (__main__.TestConfigVpp.test_vpp) ...  time: 23.466
DEBUG - ok
DEBUG - test_vrf_basic (__main__.TestConfigVrfBasic.test_vrf_basic) ...  time: 27.801
DEBUG - ok
DEBUG - test_vrf_bgp_pppoe_underlay (__main__.TestConfigVrfBgpPppoeUnderlay.test_vrf_bgp_pppoe_underlay) ...  time: 38.863
DEBUG - ok
DEBUG - test_vrf_ospf (__main__.TestConfigVrfOspf.test_vrf_ospf) ...  time: 24.523
DEBUG - ok
DEBUG - test_wireless_basic (__main__.TestConfigWirelessBasic.test_wireless_basic) ...  time: 9.374
DEBUG - ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 41 tests in 1048.214s
DEBUG - 
DEBUG - OK
DEBUG - vyos@vyos:~$ echo EXITCODE:$?
DEBUG - echo EXITCODE:$?
DEBUG - EXITCODE:0

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
