### PR TITLE
T6322: Include microcode in amd64 architecture builds

### DIFF
--- a/data/architectures/amd64.toml
+++ b/data/architectures/amd64.toml
@@ -8,6 +8,8 @@ packages = [
   "vyos-intel-ixgbe",
   "vyos-intel-ixgbevf",
   "vyos-ipt-netflow",
+  "intel-microcode",
+  "amd64-microcode"
 ]
 
 [additional_repositories.salt]

--- a/data/defaults.toml
+++ b/data/defaults.toml
@@ -7,7 +7,7 @@ debian_distribution = "bookworm"
 debian_mirror = "http://deb.debian.org/debian"
 debian_security_mirror = "http://deb.debian.org/debian-security"
 
-debian_archive_areas = "main contrib non-free non-free-firmware"
+debian_archive_areas = "main,contrib,non-free,non-free-firmware"
 
 vyos_mirror = "https://packages.vyos.net/repositories/current"
 


### PR DESCRIPTION
## Change summary
Include Intel & AMD microcode packages in amd64 architecture builds.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T6322

## Related PR(s)
- https://github.com/vyos/vyos-community-flavors/pull/2

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
