### PR TITLE
T7226: Added FRR patch with option that disables LDP hello

### DIFF
--- a/scripts/package-build/frr/patches/frr/0001-T7226-Option-for-disabled-LDP-hello-message-during-T.patch
+++ b/scripts/package-build/frr/patches/frr/0001-T7226-Option-for-disabled-LDP-hello-message-during-T.patch
@@ -1,0 +1,174 @@
+From 9f0dc1829119ea180c2ee2ebe7dcd847556c6fda Mon Sep 17 00:00:00 2001
+From: Andrii Melnychenko <a.melnychenko@vyos.io>
+Date: Mon, 17 Mar 2025 13:25:20 +0100
+Subject: [PATCH 1/1] T7226 Option for disabled LDP hello message during TCP
+
+Added option "disable-establish-hello" that disableds
+sending additional LDP hello multicast messages during
+TCP session establishment.
+This option enables per interface: "(config-ldp-af-if)".
+---
+ ldpd/interface.c    |  2 ++
+ ldpd/ldp_vty.h      |  1 +
+ ldpd/ldp_vty_cmds.c | 11 +++++++++++
+ ldpd/ldp_vty_conf.c | 32 ++++++++++++++++++++++++++++++++
+ ldpd/ldpd.c         |  1 +
+ ldpd/ldpd.h         |  1 +
+ ldpd/neighbor.c     |  5 +++--
+ 7 files changed, 51 insertions(+), 2 deletions(-)
+
+diff --git a/ldpd/interface.c b/ldpd/interface.c
+index f0e70cbac..6fccd4af5 100644
+--- a/ldpd/interface.c
++++ b/ldpd/interface.c
+@@ -63,11 +63,13 @@ if_new(const char *name)
+ 	iface->ipv4.af = AF_INET;
+ 	iface->ipv4.iface = iface;
+ 	iface->ipv4.enabled = 0;
++	iface->ipv4.disable_establish_hello = 0;
+ 
+ 	/* ipv6 */
+ 	iface->ipv6.af = AF_INET6;
+ 	iface->ipv6.iface = iface;
+ 	iface->ipv6.enabled = 0;
++	iface->ipv6.disable_establish_hello = 0;
+ 
+ 	return (iface);
+ }
+diff --git a/ldpd/ldp_vty.h b/ldpd/ldp_vty.h
+index 5c83d1c56..196d05c93 100644
+--- a/ldpd/ldp_vty.h
++++ b/ldpd/ldp_vty.h
+@@ -24,6 +24,7 @@ int	 ldp_vty_allow_broken_lsp(struct vty *, const char *);
+ int	 ldp_vty_address_family (struct vty *, const char *, const char *);
+ int	 ldp_vty_disc_holdtime(struct vty *, const char *, enum hello_type, long);
+ int	 ldp_vty_disc_interval(struct vty *, const char *, enum hello_type, long);
++int	 ldp_vty_disable_establish_hello(struct vty *, const char *);
+ int	 ldp_vty_targeted_hello_accept(struct vty *, const char *, const char *);
+ int	 ldp_vty_nbr_session_holdtime(struct vty *, const char *, struct in_addr, long);
+ int	 ldp_vty_af_session_holdtime(struct vty *, const char *, long);
+diff --git a/ldpd/ldp_vty_cmds.c b/ldpd/ldp_vty_cmds.c
+index e046ae996..d6c36c35b 100644
+--- a/ldpd/ldp_vty_cmds.c
++++ b/ldpd/ldp_vty_cmds.c
+@@ -122,6 +122,15 @@ DEFPY  (ldp_discovery_link_interval,
+ 	return (ldp_vty_disc_interval(vty, no, HELLO_LINK, interval));
+ }
+ 
++DEFPY  (ldp_disable_establish_hello,
++	ldp_disable_establish_hello_cmd,
++	"[no] disable-establish-hello",
++	NO_STR
++	"Disable sending additional LDP hello message on establishing LDP tcp connection\n")
++{
++	return ldp_vty_disable_establish_hello(vty, no);
++}
++
+ DEFPY  (ldp_discovery_targeted_interval,
+ 	ldp_discovery_targeted_interval_cmd,
+ 	"[no] discovery targeted-hello interval (1-65535)$interval",
+@@ -866,9 +875,11 @@ ldp_vty_init (void)
+ 
+ 	install_element(LDP_IPV4_IFACE_NODE, &ldp_discovery_link_holdtime_cmd);
+ 	install_element(LDP_IPV4_IFACE_NODE, &ldp_discovery_link_interval_cmd);
++	install_element(LDP_IPV4_IFACE_NODE, &ldp_disable_establish_hello_cmd);
+ 
+ 	install_element(LDP_IPV6_IFACE_NODE, &ldp_discovery_link_holdtime_cmd);
+ 	install_element(LDP_IPV6_IFACE_NODE, &ldp_discovery_link_interval_cmd);
++	install_element(LDP_IPV6_IFACE_NODE, &ldp_disable_establish_hello_cmd);
+ 
+ 	install_element(LDP_L2VPN_NODE, &ldp_bridge_cmd);
+ 	install_element(LDP_L2VPN_NODE, &ldp_mtu_cmd);
+diff --git a/ldpd/ldp_vty_conf.c b/ldpd/ldp_vty_conf.c
+index ffff67683..56ad071c8 100644
+--- a/ldpd/ldp_vty_conf.c
++++ b/ldpd/ldp_vty_conf.c
+@@ -119,6 +119,8 @@ ldp_af_iface_config_write(struct vty *vty, int af)
+ 		    ia->hello_interval != 0)
+ 			vty_out (vty, "   discovery hello interval %u\n",
+ 			    ia->hello_interval);
++		if (ia->disable_establish_hello)
++			vty_out (vty, "   disable-establish-hello\n");
+ 
+ 		vty_out (vty, "  exit\n");
+ 	}
+@@ -632,6 +634,36 @@ ldp_vty_disc_interval(struct vty *vty, const char *negate,
+ 	return (CMD_SUCCESS);
+ }
+ 
++int
++ldp_vty_disable_establish_hello(struct vty *vty,
++	const char *negate)
++{
++	struct iface		*iface;
++	struct iface_af		*ia;
++	int			 af;
++
++	switch (vty->node) {
++	case LDP_IPV4_IFACE_NODE:
++	case LDP_IPV6_IFACE_NODE:
++		af = ldp_vty_get_af(vty);
++		iface = VTY_GET_CONTEXT(iface);
++		VTY_CHECK_CONTEXT(iface);
++
++		ia = iface_af_get(iface, af);
++		if (negate)
++			ia->disable_establish_hello = 0;
++		else
++			ia->disable_establish_hello = 1;
++
++		ldp_config_apply(vty, vty_conf);
++		break;
++	default:
++		fatalx("ldp_vty_disable_establish_hello: unexpected node");
++	}
++
++	return (CMD_SUCCESS);
++}
++
+ int
+ ldp_vty_targeted_hello_accept(struct vty *vty, const char *negate,
+     const char *acl_from_str)
+diff --git a/ldpd/ldpd.c b/ldpd/ldpd.c
+index 4d38fdcd0..9a5667c26 100644
+--- a/ldpd/ldpd.c
++++ b/ldpd/ldpd.c
+@@ -1604,6 +1604,7 @@ merge_iface_af(struct iface_af *ia, struct iface_af *xi)
+ 	}
+ 	ia->hello_holdtime = xi->hello_holdtime;
+ 	ia->hello_interval = xi->hello_interval;
++	ia->disable_establish_hello = xi->disable_establish_hello;
+ }
+ 
+ static void
+diff --git a/ldpd/ldpd.h b/ldpd/ldpd.h
+index ad831a6ea..40a1e8c3c 100644
+--- a/ldpd/ldpd.h
++++ b/ldpd/ldpd.h
+@@ -332,6 +332,7 @@ struct iface_af {
+ 	struct event *hello_timer;
+ 	uint16_t		 hello_holdtime;
+ 	uint16_t		 hello_interval;
++	int disable_establish_hello;
+ };
+ 
+ struct iface_ldp_sync {
+diff --git a/ldpd/neighbor.c b/ldpd/neighbor.c
+index 2596c7948..b9199f0d9 100644
+--- a/ldpd/neighbor.c
++++ b/ldpd/neighbor.c
+@@ -630,8 +630,9 @@ nbr_establish_connection(struct nbr *nbr)
+ 	 * an adjacency as well.
+ 	 */
+ 	RB_FOREACH(adj, nbr_adj_head, &nbr->adj_tree)
+-		send_hello(adj->source.type, adj->source.link.ia,
+-		    adj->source.target);
++		if (!adj->source.link.ia->disable_establish_hello)
++			send_hello(adj->source.type, adj->source.link.ia,
++				adj->source.target);
+ 
+ 	if (connect(nbr->fd, &remote_su.sa, sockaddr_len(&remote_su.sa)) == -1) {
+ 		if (errno == EINPROGRESS) {
+-- 
+2.43.0
+


### PR DESCRIPTION
Added patch for FRR that adds option to disable "addition LDP hello message during TCP session establishing".

Added option "disable-establish-hello" that disables sending additional LDP hello multicast messages during TCP session establishment. This option enables per interface: "(config-ldp-af-if)"

Usage example:
```
VyOS# configure
VyOS(config)# mpls ldp
VyOS(config-ldp)# address-family ipv4
VyOS(config-ldp-af)# interface eth0
VyOS(config-ldp-af-if)# disable-establish-hello
VyOS(config-ldp-af-if)# end
VyOS# 
```

NOTE: Additional VyOS binding required.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T7226

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
