### PR TITLE
T7278: Fix python3-cracklib database creation on update

### DIFF
--- a/data/live-build-config/hooks/live/40-init-cracklib-db.chroot
+++ b/data/live-build-config/hooks/live/40-init-cracklib-db.chroot
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+CRACKLIB_DIR=/var/cache/cracklib
+CRACKLIB_DB=cracklib_dict
+
+if [ ! -f "${CRACKLIB_DIR}/${CRACKLIB_DB}.pwd" ]; then
+  echo "I: Creating the cracklib database ${CRACKLIB_DIR}/${CRACKLIB_DB}"
+  mkdir -p $CRACKLIB_DIR
+
+  /usr/sbin/create-cracklib-dict -o $CRACKLIB_DIR/$CRACKLIB_DB \
+    /usr/share/dict/cracklib-small
+fi
+

--- a/data/live-build-config/rootfs/excludes
+++ b/data/live-build-config/rootfs/excludes
@@ -44,7 +44,8 @@ usr/games/*
 usr/local/games/*
 
 # T5511: We do not need any caches on the system (will be recreated when needed).
-var/cache/*
+# T7278: We need directory created by python3-cracklib for password checks
+var/cache/!(cracklib)
 
 # T5511: We do not need any log-files on the system (will be recreated when needed).
 var/log/*.log


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Explicitly omit directory in /var/cache created by cracklib in the exclusion list for `mksquashfs` and add a script that creates this directory and required files in the `chroot` environment during build.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7278
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
Blocks: https://github.com/vyos/vyos-1x/pull/4413
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
