### PR TITLE
packages: T6230: include iptables modules in vyos-ipt-netflow

### DIFF
--- a/scripts/package-build/linux-kernel/build-ipt-netflow.sh
+++ b/scripts/package-build/linux-kernel/build-ipt-netflow.sh
@@ -25,7 +25,7 @@ DRIVER_VERSION=$(git describe | sed s/^v//)
 
 # Build up Debian related variables required for packaging
 DEBIAN_ARCH=$(dpkg --print-architecture)
-DEBIAN_DIR="tmp/lib/modules/${KERNEL_VERSION}${KERNEL_SUFFIX}/extra"
+DEBIAN_DIR="tmp/"
 DEBIAN_CONTROL="${DEBIAN_DIR}/DEBIAN/control"
 DEBIAN_POSTINST="${CWD}/vyos-ipt-netflow.postinst"
 
@@ -47,6 +47,8 @@ fi
 # build Debian package
 echo "I: Building Debian package vyos-ipt-netflow"
 cp ipt_NETFLOW.ko ${DEBIAN_DIR}
+cp libipt_NETFLOW.so ${DEBIAN_DIR}
+cp libip6t_NETFLOW.so ${DEBIAN_DIR}
 
 # Sign generated Kernel modules
 ${CWD}/sign-modules.sh ${DEBIAN_DIR}
@@ -61,5 +63,7 @@ fpm --input-type dir --output-type deb --name vyos-ipt-netflow \
     --maintainer "VyOS Package Maintainers <maintainers@vyos.net>" \
     --description "ipt_NETFLOW module" \
     --depends linux-image-${KERNEL_VERSION}${KERNEL_SUFFIX} \
-    --license "GPL2" -C ${IPT_NETFLOW_SRC}/tmp --after-install ${DEBIAN_POSTINST}
-
+    --license "GPL2" -C ${IPT_NETFLOW_SRC}/tmp --after-install ${DEBIAN_POSTINST} \
+    ipt_NETFLOW.ko=/lib/modules/${KERNEL_VERSION}${KERNEL_SUFFIX}/extra/ipt_NETFLOW.ko \
+    libipt_NETFLOW.so=/lib/$(uname -m)-linux-gnu/xtables/libipt_NETFLOW.so \
+    libip6t_NETFLOW.so=/lib/$(uname -m)-linux-gnu/xtables/libip6t_NETFLOW.so


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Without those libs, the kernel module can be loaded, but iptables targets to send packets to the module for accounting are not available.

## Testing

Both these commands should work:

```
modprobe ipt_NETFLOW destination=127.0.0.1:2055

iptables -I FORWARD -j NETFLOW
```

Package contents after the change:

```
vyos_bld@fa920bd24f5a:/vyos/scripts/package-build/linux-kernel$ dpkg-deb -c ./vyos-ipt-netflow_2.6-17-g0eb2092_amd64.deb 
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./usr/
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./usr/share/
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./usr/share/doc/
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./usr/share/doc/vyos-ipt-netflow/
-rw-r--r-- 0/0             162 2025-04-17 15:50 ./usr/share/doc/vyos-ipt-netflow/changelog.gz
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./lib/
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./lib/x86_64-linux-gnu/
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./lib/x86_64-linux-gnu/xtables/
-rwxr-xr-x 0/0           15936 2025-04-17 15:50 ./lib/x86_64-linux-gnu/xtables/libip6t_NETFLOW.so
-rwxr-xr-x 0/0           15936 2025-04-17 15:50 ./lib/x86_64-linux-gnu/xtables/libipt_NETFLOW.so
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./lib/modules/
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./lib/modules/6.6.79-vyos/
drwxr-xr-x 0/0               0 2025-04-17 15:50 ./lib/modules/6.6.79-vyos/extra/
-rw-r--r-- 0/0          152775 2025-04-17 15:50 ./lib/modules/6.6.79-vyos/extra/ipt_NETFLOW.ko
vyos_bld@fa920bd24f5a:/vyos/scripts/package-build/linux-kernel$ 
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
