### PR TITLE
radvd: T7376: upgrade package to v2.20

### DIFF
--- a/scripts/package-build/radvd/package.toml
+++ b/scripts/package-build/radvd/package.toml
@@ -1,6 +1,6 @@
 [[packages]]
 name = "radvd"
-commit_id = "f2de4764559"
+commit_id = "v2.20"
 scm_url = "https://github.com/radvd-project/radvd"
 
 #build_cmd = "cd ..; ./build.sh"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

```
2024/12/31  Release v2.20
	build: annotated/signed tags need a tweak to verify correctly
	build: need awk for newer autoconf
	build: verify tag earlier
	build: drop sha1, insecure
	build: use BSD-style checksum tags
	build: make sign & verify tighter
	build: cleanup old tarballs first
	docs: document formal release process
	ci: Updated FreeBSD workflow to fix the boot loop issue.
	ci: Removed Ubuntu 18.04 build.
	docs: Expand on RELEASE-PROCESS.md
	ci: Updated the checkout action version.
	fix: Prevent null de-reference when using poll in main_loop
	ci: use improved buildroot images.
	fix(netlink): cleanup interfaces upon removal
	fix: Add the socket option IPV6_MULTICAST_LOOP to prevent the interface from autoconfiguring using RA messages sent by itself.
	ci: Added Ubuntu 24.04.
	ci: Also use ubuntu-latest for the FreeBSD build
	ci: Use latest v1 action in all cases
	feat: implement setup_allrouters_membership() et al for FreeBSD #145
	chore: remove unused 'total_seen_options' variable
	feat: Change the Prefix field of the Route Information Option to be variable-length.
	test: add more RDNSS testing for PR#193
	feat: Support more addresses in RDNSS section
	feat: improve warning about long RA options
	fix: do not die on long DNSSL option
	test: support older libcheck for ubuntu20.04
	chore: document more testcases
	chore: make RDNSS/DNSSL documentation and logic consistent
	doc: update AUTHORS in manpage
	doc: fix truncated sentence about VRRP
	feat: handle long options better
	fix: ensure send_ra_forall racount only increments for non-unicast
	ci: radvd-autogen updates for ubuntu20.04
	build: missing files from packages
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): bump radvd to official v2.20

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7376

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
