### PR TITLE
build: T6949: add missing build trigger for blackbox exporter

### DIFF
--- a/.github/workflows/trigger_rebuild_packages.yml
+++ b/.github/workflows/trigger_rebuild_packages.yml
@@ -129,6 +129,10 @@ jobs:
             trigger_build "bash-completion"
           fi
 
+          if [ "${{ steps.changes.outputs.blackbox_exporter }}" == "true" ]; then
+            trigger_build "blackbox_exporter"
+          fi
+
           if [ "${{ steps.changes.outputs.ddclient }}" == "true" ]; then
             trigger_build "ddclient"
           fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit d6fab6c8c036 ("T6949: Adds build for blackbox exporter deb package") added the general requirements for a package build - but it missed the trigger for changes within the build ocnfiguration dir.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6949

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
