### PR TITLE
T7352: add arg to test script for running smoketests under vyconfd/commitd

### DIFF
--- a/data/live-build-config/hooks/live/18-enable-disable_services.chroot
+++ b/data/live-build-config/hooks/live/18-enable-disable_services.chroot
@@ -71,9 +71,7 @@ systemctl disable zabbix-agent2.service
 systemctl disable suricata.service
 systemctl disable vyconfd.service
 systemctl disable vpp.service
-systemctl disable vyos-commitd.service
 systemctl disable netplug.service
-
 
 echo I: Enabling services
 systemctl enable vyos-hostsd.service
@@ -81,6 +79,7 @@ systemctl enable acpid.service
 systemctl enable vyos-router.service
 systemctl enable vyos-configd.service
 systemctl enable vyos-grub-update.service
+systemctl enable vyos-commitd.service
 
 echo I: Masking services
 systemctl mask systemd-journald-audit.socket

--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -97,6 +97,8 @@ parser.add_argument('--qemu-cmd', help='Only generate QEMU launch command',
                 action='store_true', default=False)
 parser.add_argument('--cpu', help='Set QEMU CPU', type=int, default=2)
 parser.add_argument('--memory', help='Set QEMU memory', type=int, default=4)
+parser.add_argument('--vyconf', help='Execute testsuite with vyconfd', action='store_true',
+                    default=False)
 
 args = parser.parse_args()
 
@@ -804,6 +806,11 @@ try:
             # remove interface tests as they consume a lot of time
             c.sendline('sudo rm -f /usr/libexec/vyos/tests/smoke/cli/test_interfaces_*')
             c.expect(op_mode_prompt)
+
+        if args.vyconf:
+            c.sendline('sudo /usr/libexec/vyos/set_vyconf_backend.py --no-prompt &> /dev/null')
+            c.expect(op_mode_prompt)
+            log.info('Smoketests will be run using vyconfd/vyos-commitd')
 
         log.info('Executing VyOS smoketests')
         c.sendline('/usr/bin/vyos-smoketest')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

NOTE: this requires PR https://github.com/vyos/vyos-1x/pull/4505 and related.

Add arg to scripts/check-qemu-install for testing under vyconf.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyconf/pull/21
https://github.com/vyos/libvyosconfig/pull/36
https://github.com/vyos/vyos-1x/pull/4505

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
