### PR TITLE
T1771: enable "reboot-on-upgrade-failure" for new VyOS installations

### DIFF
--- a/tools/cloud-init/AWS/config.boot.default
+++ b/tools/cloud-init/AWS/config.boot.default
@@ -9,6 +9,9 @@ system {
             level admin
         }
     }
+    option {
+        reboot-on-upgrade-failure 5
+    }
     syslog {
         local {
             facility all {


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

If any part of the system boot fails, we now set overall_status=1 in the vyos-router startup script. When an error during the image upgrade is detected, the system will automatically revert the default boot image to the previously used version.

The user is informed via console messages:
```
Booting failed, reverting to previous image
Automatic reboot in 5 minutes
Use "reboot cancel" to cancel
```

The user has 5 minutes to log in and run reboot cancel to remain in the faulty image for troubleshooting.

Once the system boots into the previous image, the MOTD will display a persistent warning message - cleared during next reboot.
```
WARNING: Image update to "VyOS 1.5.xxxx" failed
Please check the logs:
/usr/lib/live/mount/persistence/boot/NAME/rw/var/log
Message is cleared on next reboot!
```

Upgrade failure can be synthetically injected by booting with Kernel command line option: `vyos-fail-migration`


![image](https://github.com/user-attachments/assets/8c9b5b00-f62e-4b96-8223-f2b99711df8d)



## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T1771

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4501
* https://github.com/vyos/vyos-documentation/pull/1635

## How to test / Smoketest result

You can boot the new image using: `vyos-fail-migration` Kernel cmdline parameter to trigger this.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
