### PR TITLE
build: T7453: Make raw image building logic more robust

### DIFF
--- a/scripts/image-build/raw_image.py
+++ b/scripts/image-build/raw_image.py
@@ -63,22 +63,38 @@ class BuildContext:
 
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_tb):
+    def __exit__(self, exc_type, exc_value, traceback):
         print(f"I: Tearing down the raw image build environment in {self.work_dir}")
-        cmd(f"""umount {self.squash_dir}/dev/""")
-        cmd(f"""umount {self.squash_dir}/proc/""")
-        cmd(f"""umount {self.squash_dir}/sys/""")
 
-        cmd(f"umount {self.squash_dir}/boot/efi")
-        cmd(f"umount {self.squash_dir}/boot")
+        for mount in [
+            f"{self.squash_dir}/dev/",
+            f"{self.squash_dir}/proc/",
+            f"{self.squash_dir}/sys/",
+            f"{self.squash_dir}/boot/efi",
+            f"{self.squash_dir}/boot",
+            f"{self.squash_dir}",
+            f"{self.iso_dir}",
+            f"{self.raw_dir}",
+            f"{self.efi_dir}"
+        ]:
+            if os.path.ismount(mount):
+                try:
+                    cmd(f"umount {mount}")
+                except Exception as e:
+                    print(f"W: Failed to umount {mount}: {e}")
 
-        cmd(f"""umount {self.squash_dir}""")
-        cmd(f"""umount {self.iso_dir}""")
-        cmd(f"""umount {self.raw_dir}""")
-        cmd(f"""umount {self.efi_dir}""")
-
+        # Remove kpartx mappings
         if self.loop_device:
-            cmd(f"""losetup -d {self.loop_device}""")
+            mapper_base = os.path.basename(self.loop_device)
+            try:
+                cmd(f"kpartx -d {self.loop_device}")
+            except Exception as e:
+                print(f"W: Failed to remove kpartx mappings for {mapper_base}: {e}")
+
+            try:
+                cmd(f"losetup -d {self.loop_device}")
+            except Exception as e:
+                print(f"W: Failed to detach loop device {self.loop_device}: {e}")
 
 def create_disk(path, size):
     cmd(f"""qemu-img create -f raw "{path}" {size}G""")
@@ -106,14 +122,23 @@ def setup_loop_device(con, raw_file):
 def mount_image(con):
     import vyos.system.disk
 
-    from subprocess import Popen, PIPE, STDOUT
-    from re import match
+    try:
+        root = con.disk_details.partition['root']
+        efi = con.disk_details.partition['efi']
+    except (AttributeError, KeyError):
+        raise RuntimeError("E: No valid root or EFI partition found in disk details")
 
-    vyos.system.disk.filesystem_create(con.disk_details.partition['efi'], 'efi')
-    vyos.system.disk.filesystem_create(con.disk_details.partition['root'], 'ext4')
+    vyos.system.disk.filesystem_create(efi, 'efi')
+    vyos.system.disk.filesystem_create(root, 'ext4')
 
-    cmd(f"mount -t ext4 {con.disk_details.partition['root']} {con.raw_dir}")
-    cmd(f"mount -t vfat {con.disk_details.partition['efi']} {con.efi_dir}")
+    print(f"I: Mounting root: {root} to {con.raw_dir}")
+    cmd(f"mount -t ext4 {root} {con.raw_dir}")
+    cmd(f"mount -t vfat {efi} {con.efi_dir}")
+
+    if not os.path.ismount(con.efi_dir):
+        cmd(f"mount -t vfat {con.disk_details.partition['efi']} {con.efi_dir}")
+    else:
+        print(f"I: {con.disk_details.partition['efi']} already mounted on {con.efi_dir}")
 
 def install_image(con, version):
     from glob import glob
@@ -205,6 +230,22 @@ def create_raw_image(build_config, iso_file, work_dir):
         create_disk(raw_file, build_config["disk_size"])
         setup_loop_device(con, raw_file)
         disk_details = parttable_create(con.loop_device, (int(build_config["disk_size"]) - 1) * 1024 * 1024)
+
+        # Map partitions using kpartx
+        cmd(f"kpartx -av {con.loop_device}")
+        cmd("udevadm settle")
+
+        # Resolve mapper names (example: /dev/mapper/loop0p2)
+        from glob import glob
+        mapper_base = os.path.basename(con.loop_device).replace("/dev/", "")
+        mapped_parts = sorted(glob(f"/dev/mapper/{mapper_base}p*"))
+
+        if len(mapped_parts) < 3:
+            raise RuntimeError("E: Expected at least 3 partitions created by kpartx")
+
+        disk_details.partition['efi'] = mapped_parts[1]
+        disk_details.partition['root'] = mapped_parts[2]
+
         con.disk_details = disk_details
         mount_image(con)
         install_image(con, version)

--- a/scripts/image-build/raw_image.py
+++ b/scripts/image-build/raw_image.py
@@ -236,7 +236,6 @@ def create_raw_image(build_config, iso_file, work_dir):
         cmd(f"kpartx -av {con.loop_device}")
         cmd("udevadm settle")
 
-        cmd("ls -l /dev/mapper")  # debug output
 
         # Detect mapped partitions
         from glob import glob


### PR DESCRIPTION
## Change summary
This pull request improves the reliability and robustness of the raw image generation process in raw_image.py, specifically addressing partition mapping and environment cleanup.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Description
Added support for kpartx to explicitly map partitions (EFI, root) from loop devices instead of relying on /dev/loopXp*, which can be unreliable.
Introduced disk_details as an attribute of BuildContext to persist partition info throughout the image creation process.
Enhanced BuildContext.__exit__() to unmount all mount points, remove kpartx mappings, and detach the loop device even in failure scenarios.
Fixed a potential crash when con.disk_details was missing in mount_image().
Added debug output for better observability (e.g., loop device in use, partitions mapped).
These changes improve compatibility across a variety of environments (containers, hosts with strict udev policies) and ensure a cleaner teardown process during builds.

## How Has This Been Tested?
Flavor file: cloud-init.toml
packages = [
  "cloud-init",
  "qemu-guest-agent"
]
image_format = ["qcow2"]
disk_size = 10
[boot_settings]
console_type = "ttyS0"

Command:
sudo ./build-vyos-image --architecture amd64 --build-by "you@example.com" --reuse-iso vyos-1.5-rolling-*.iso cloud-init

Result:
 - Image builds successfully without errors.
 - QCOW2 image boots correctly in KVM/Proxmox.
 - Partition mapping via /dev/mapper/loopXp* is successful.
 - Loop devices and mount points are cleaned up after build.

## Related Task(s)
T7453

## Related PR(s)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
