### PR TITLE
T7530: Build package binaries script should exit if repo is absent

### DIFF
--- a/scripts/package-build/build.py
+++ b/scripts/package-build/build.py
@@ -93,7 +93,7 @@ def build_package(package: list, patch_dir: Path) -> None:
         # Check out the specific commit
         run(['git', 'checkout', package['commit_id']], cwd=repo_dir, check=True)
     except CalledProcessError as e:
-        print(f"❌ Failed to clone or checkout for package '{repo_name}': {e}")
+        print(f"Failed to clone or checkout for package '{repo_name}': {e}")
         sys.exit(1)
 
     try:

--- a/scripts/package-build/build.py
+++ b/scripts/package-build/build.py
@@ -17,6 +17,7 @@
 
 import glob
 import shutil
+import sys
 import toml
 import os
 
@@ -91,7 +92,11 @@ def build_package(package: list, patch_dir: Path) -> None:
 
         # Check out the specific commit
         run(['git', 'checkout', package['commit_id']], cwd=repo_dir, check=True)
+    except CalledProcessError as e:
+        print(f"❌ Failed to clone or checkout for package '{repo_name}': {e}")
+        sys.exit(1)
 
+    try:
         # The `pre_build_hook` is an optional configuration defined in `package.toml`.
         # It executes after the repository is checked out and before the build process begins.
         # This hook allows you to perform preparatory tasks, such as creating directories,

--- a/scripts/package-build/linux-kernel/build.py
+++ b/scripts/package-build/linux-kernel/build.py
@@ -18,6 +18,7 @@
 import datetime
 import glob
 import shutil
+import sys
 import toml
 import os
 import subprocess
@@ -60,8 +61,12 @@ def clone_or_update_repo(repo_dir: Path, scm_url: str, commit_id: str) -> None:
         run(['git', 'checkout', commit_id], cwd=repo_dir, check=True)
         #run(['git', 'pull'], cwd=repo_dir, check=True)
     else:
-        run(['git', 'clone', scm_url, str(repo_dir)], check=True)
-        run(['git', 'checkout', commit_id], cwd=repo_dir, check=True)
+        try:
+            run(['git', 'clone', scm_url, str(repo_dir)], check=True)
+            run(['git', 'checkout', commit_id], cwd=repo_dir, check=True)
+        except CalledProcessError as e:
+            print(f"❌ Failed to clone or checkout: {e}")
+            sys.exit(1)
 
 
 def create_tarball(package_name, source_dir=None):

--- a/scripts/package-build/linux-kernel/build.py
+++ b/scripts/package-build/linux-kernel/build.py
@@ -65,7 +65,7 @@ def clone_or_update_repo(repo_dir: Path, scm_url: str, commit_id: str) -> None:
             run(['git', 'clone', scm_url, str(repo_dir)], check=True)
             run(['git', 'checkout', commit_id], cwd=repo_dir, check=True)
         except CalledProcessError as e:
-            print(f"❌ Failed to clone or checkout: {e}")
+            print(f"Failed to clone or checkout: {e}")
             sys.exit(1)
 
 


### PR DESCRIPTION
## Change summary
<!--- Provide a general summary of your changes in the Title above -->
The build package binaries script should exit if the repo is absent or cannot be cloned

If a build package `repo-a` depends on the `repo-b` and the `repo-b` cannot be cloned, then we shoud exit from the script to avoid partly build dependencies

For example:
```
[[packages]]
name = "fake-repo"
commit_id = "v0.0.1"
scm_url = "https://github.com/vyos/fake-repo"

[[packages]]
name = "ethtool"
commit_id = "debian/1%6.10-1"
scm_url = "https://salsa.debian.org/kernel-team/ethtool"
```

If ethtool depends on some fake-package and this package cannot be downloaded from the repo, then we shouldn't build the ethtool package at all.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Improve the binaries build script logic

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7530

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## check
successful build
```
vyos_bld@75a3760aea21:/vyos/work/T7530/vyos-build/scripts/package-build/linux-kernel$ ls -l *.deb
-rw-r--r-- 1 vyos_bld vyos_bld   489248 Jun  9 09:30 accel-ppp_1.13.0_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   180800 Jun  9 09:32 jool_4.1.9+bf4c7e3669-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   271116 Jun  9 09:32 jool-dbgsym_4.1.9+bf4c7e3669-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld  8991940 Jun  9 09:21 linux-headers-6.6.92-vyos_6.6.92-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld 29523488 Jun  9 09:21 linux-image-6.6.92-vyos_6.6.92-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld  1319184 Jun  9 09:21 linux-libc-dev_6.6.92-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld  2481528 Jun  9 09:21 linux-perf-6.6.92-vyos_6.6.92-1_amd64.deb
-rw-r--r-- 1 root     root      2297964 Jun  9 09:35 mlnx-ofed-kernel-modules_24.07.OFED.24.07.0.6.1.1-1.kver.6.6.92-vyos_amd64.deb
-rw-r--r-- 1 root     root        27988 Jun  9 09:35 mlnx-ofed-kernel-utils_24.07.OFED.24.07.0.6.1.1-1.kver.6.6.92-vyos_amd64.deb
-rw-r--r-- 1 root     root        69692 Jun  9 09:35 mlnx-tools_24.07.0-1.2407061_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld    16856 Jun  9 09:31 nat-rtsp_5.3-2-g475af0a_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld    45212 Jun  9 09:31 openvpn-dco_0.2.20231117_amd64.deb
-rw-r--r-- 1 root     root       106504 Jun  9 09:35 vyos-drivers-realtek-r8152_2.18.1-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   159678 Jun  9 09:31 vyos-intel-igb_5.19.2.1-1-g866cd64_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   346704 Jun  9 09:32 vyos-intel-ixgbe_6.1.4-1-g009aba9_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld    61288 Jun  9 09:32 vyos-intel-ixgbevf_5.1.3-1-g4423d04_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld  4150920 Jun  9 09:31 vyos-intel-qat_4.24.0-00005-0_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld    45782 Jun  9 09:36 vyos-ipt-netflow_2.6-17-g0eb2092_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld 51499680 Jun  9 09:29 vyos-linux-firmware_20240610_all.deb
vyos_bld@75a3760aea21:/vyos/work/T7530/vyos-build/scripts/package-build/linux-kernel$ 

```
unsuccessful build:
```
vyos_bld@75a3760aea21:/vyos/work/T7530/vyos-build/scripts/package-build/ethtool$ ./build.py 
Cloning into 'fake-repo'...
remote: Repository not found.
fatal: repository 'https://github.com/vyos/fake-repo/' not found
❌ Failed to clone or checkout for package 'fake-repo': Command '['git', 'clone', 'https://github.com/vyos/fake-repo', 'fake-repo']' returned non-zero exit status 128.
vyos_bld@75a3760aea21:/vyos/work/T7530/vyos-build/scripts/package-build/ethtool$ 

```

## Why
We had a bug when `accel-ppp` repo was not cloned:
```
Failed to build package accel-ppp: Command '['git', 'clone', 'https://github.com/accel-ppp/accel-ppp.git', 'accel-ppp']' returned non-zero exit status 128.
Copied generated .deb packages 
```
This way we used the old version of the `accel-pppd` with signed modules by another key and kernel modules signed by the current key.

![accel-ppp-modules](https://github.com/user-attachments/assets/f7049d7a-0445-4b9c-8faf-c12c04db7aec)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
