### PR TITLE
iso: T7610: include a file with ISO9660 string to prevent upgrade failures from 1.3.x

### DIFF
--- a/data/live-build-config/includes.binary/compat
+++ b/data/live-build-config/includes.binary/compat
@@ -1,0 +1,10 @@
+# VyOS 1.3.x image upgrade scipt checked if an image file was a valid ISO file
+# by grepping it for "ISO9660".
+# (The correct way to do that would be to use file/libmagic,
+#  but we cannot change the past).
+# At some point something has changed in xorriso or some other tool
+# and images no longer include that string.
+# so the image validity check fails.
+# To allow direct upgrades from older versions,
+# we artificially include that string to make the old check pass.
+ISO9660


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Artificially include a file with `ISO9660` string to the ISO to make it satisfy the old, misguided check from the 1.3.x era (https://github.com/vyos/vyatta-cfg-system/blob/equuleus/scripts/install/install-image#L179-L181).

Without that, direct upgrades from 1.3.x are impossible because something has changed in upstream tools that no longer includes `ISO9660` anywhere in the image (it doesn't have to, since it's not a part of the ISO9660 format standard).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
