### PR TITLE
Docker: T7568: add apt-get update as last command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -334,6 +334,9 @@ RUN rm -rf /tmp/*
 # Remove cleanup script so that in-container apt-get install uses cache
 RUN rm /etc/apt/apt.conf.d/clean
 
+# Add cache once as it is needed by some builds in GitHub Actions
+RUN apt-get update
+
 # Disable mouse in vim
 RUN printf "set mouse=\nset ttymouse=\n" > /etc/vim/vimrc.local
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Add apt-get update as last command to fix GitHub Actions
<!--- Provide a general summary of your changes in the Title above -->

Some of GitHub actions were relying on cache from apt-get update being available.

My previous changes broke those GitHub actions.

Add `apt-get update` as one of last commands, which adds ~20Mb, but still 2.04Gb -> 2.01Gb for vyos-build comparing with Dockerfile without cache cleaning.

No changes for vyos image as I hope it is not used in any automatic scripts that use `apt-get install` without prior `apt-get update`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T7568

## Related PR(s)

My previous PR that broke GitHub Actions:

https://github.com/vyos/vyos-build/pull/979

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
