### PR TITLE
CI: T7579: fix of the run trigger for CLA

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -7,7 +7,7 @@ permissions:
   statuses: write
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, closed]
   issue_comment:
     types: [created]
@@ -15,5 +15,4 @@ on:
 jobs:
   call-cla-assistant:
     uses: vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current
-    secrets:
-      CLA_PAT: ${{ secrets.CLA_PAT }}
+    secrets: inherit


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
The current implementation of the CLA has an issue when the CLA check workflow fails due to insufficient access to the necessary GA secret. This problem arises from an incorrect run trigger `pull_request`, which needs to be replaced with the appropriate trigger `pull_request_target`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T7579

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
