### PR TITLE
T7576: Remove unnecessary code for checking dirty build status

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -409,9 +409,6 @@ if __name__ == "__main__":
             repo = git.Repo('.', search_parent_directories=True)
             # Retrieve the Git commit ID of the repository, 14 charaters will be sufficient
             build_git = repo.head.object.hexsha[:14]
-            # If somone played around with the source tree and the build is "dirty", mark it
-            if repo.is_dirty():
-                build_git += "-dirty"
 
             # Retrieve git branch name or current tag
             # Building a tagged release might leave us checking out a git tag that is not the tip of a named branch (detached HEAD)


### PR DESCRIPTION
## Change summary
Remove the "dirty" suffix from vyos-build commit IDs in image version info to avoid confusing users. 

Previously, the `-dirty` suffix indicated uncommitted changes in the build source, but this information is not meaningful for users and may cause unnecessary concern. Now, the commit ID will be shown without the "dirty" suffix, regardless of local modifications during the build process.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7576

## How to test
Build [ISO](https://docs.vyos.io/en/latest/contributing/build-vyos.html#build-iso) image:
```
cd vyos-build
make clean
./build-vyos-image --architecture amd64 --build-by "test-user001@vyos.io" generic
```

Run VM or docker container using already created ISO image:
```
vyos@92e63e967749:~$ show version | match dirty
vyos@92e63e967749:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
