### PR TITLE
T7714: Exclude auxiliary directories from linux-kernel tarballs

### DIFF
--- a/scripts/package-build/linux-kernel/build.py
+++ b/scripts/package-build/linux-kernel/build.py
@@ -95,11 +95,21 @@ def create_tarball(package_name, source_dir=None):
     if not os.path.isdir(source_dir):
         raise FileNotFoundError(f"Directory '{source_dir}' does not exist.")
 
+    base_dir = os.path.dirname(source_dir) or '.'
+    dir_name = os.path.basename(source_dir)
+
     # Create the tarball
     try:
-        shutil.make_archive(base_name=output_tarball.replace('.tar.gz', ''), format='gztar', root_dir=source_dir)
+        subprocess.run([
+            'tar',
+            f'--exclude={dir_name}/.git',
+            f'--exclude={dir_name}/.github',
+            '-czf', output_tarball,
+            '-C', base_dir,
+            dir_name
+        ], check=True)
         print(f"I: Tarball created: {output_tarball}")
-    except Exception as e:
+    except subprocess.CalledProcessError as e:
         print(f"I: Failed to create tarball for {package_name}: {e}")
 
 


### PR DESCRIPTION
Exclude auxiliary directories from linux-kernel and related to linux-kernel tarballs

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Exclude auxiliary directories from linux-kernel tarballs
Replace `shutil` to `tar`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Replace shutil

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7714

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
