### PR TITLE
T7697: Remove vyos-vpp build requirements to build vyos-1x

### DIFF
--- a/scripts/package-build/vyos-1x/.gitignore
+++ b/scripts/package-build/vyos-1x/.gitignore
@@ -1,2 +1,1 @@
 /vyos-1x/
-/vyos-vpp/

--- a/scripts/package-build/vyos-1x/package.toml
+++ b/scripts/package-build/vyos-1x/package.toml
@@ -1,11 +1,4 @@
 [[packages]]
-name = "vyos-vpp"
-commit_id = "current"
-scm_url = "https://github.com/vyos/vyos-vpp.git"
-build_cmd = "/bin/true"
-
-[[packages]]
 name = "vyos-1x"
 commit_id = "current"
 scm_url = "https://github.com/vyos/vyos-1x.git"
-build_cmd = "rsync -av --exclude='.git' --exclude='.github' --exclude='README*' --exclude='LICENSE' --exclude='*.md' ../vyos-vpp/ ./; dpkg-buildpackage -us -uc -F"


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
The `vyos-vpp` repo was merged to the `vyos-1x` in the https://github.com/vyos/vyos-1x/pull/4650
We do not need a copy from the `vyos-vpp` repo anymore.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7697

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
