### PR TITLE
T7749: Dehardcode x86_64 ARCH to build VPP libraries for accel-pp-ng

### DIFF
--- a/scripts/package-build/linux-kernel/build-accel-ppp-ng.sh
+++ b/scripts/package-build/linux-kernel/build-accel-ppp-ng.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
+ARCH_TRIPLET=$(dpkg-architecture -qDEB_HOST_MULTIARCH)
 CWD=$(pwd)
 KERNEL_VAR_FILE=${CWD}/kernel-vars
 VPP_INCLUDE_PATH="${CWD}/../vpp/vpp/src/vpp-api:${CWD}/../vpp/vpp/src:${CWD}/../vpp/vpp/build-root/build-vpp-native/vpp/CMakeFiles/vpp-api"
-VPP_LIBRARY_PATH="${CWD}/../vpp/vpp/build-root/build-vpp-native/vpp/CMakeFiles/debian/libvppinfra/usr/lib/x86_64-linux-gnu/:${CWD}/../vpp/vpp/build-root/install-vpp-native/vpp/lib/x86_64-linux-gnu/"
-VPP_LIB_CHECK_PATH="${CWD}/../vpp/vpp/build-root/build-vpp-native/vpp/CMakeFiles/debian/libvppinfra/usr/lib/x86_64-linux-gnu/"
+VPP_LIBRARY_PATH="${CWD}/../vpp/vpp/build-root/build-vpp-native/vpp/CMakeFiles/debian/libvppinfra/usr/lib/${ARCH_TRIPLET}:${CWD}/../vpp/vpp/build-root/install-vpp-native/vpp/lib/${ARCH_TRIPLET}"
+VPP_LIB_CHECK_PATH="${CWD}/../vpp/vpp/build-root/build-vpp-native/vpp/CMakeFiles/debian/libvppinfra/usr/lib/${ARCH_TRIPLET}"
 
 ACCEL_SRC=${CWD}/accel-ppp-ng
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Dehardcode x86_64 ARCH to build VPP libraries used for accel-ppp-ng
Allows building `accel-ppp-ng`  dependencies for ARM
Backport only after merging `accel-ppp-ng` for circinus to avoid conflicts

```
vyos_bld@76f809ee20c4:/vyos/work/T7749/vyos-build/scripts/package-build/linux-kernel$ dpkg-architecture -qDEB_HOST_MULTIARCH
x86_64-linux-gnu

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7749

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Check
```
./build.py --packages linux-kernel accel-ppp-ng

vyos_bld@76f809ee20c4:/vyos/work/T7749/vyos-build/scripts/package-build/linux-kernel$ ls -l *.deb
-rw-r--r-- 1 vyos_bld vyos_bld    583424 Aug 23 12:34 accel-ppp-ng_f5764ea_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld    190140 Aug 23 12:34 libvppinfra_25.06.0-21~ga5eeb187f-dirty_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld    161084 Aug 23 12:34 libvppinfra-dev_25.06.0-21~ga5eeb187f-dirty_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   8995728 Aug 23 12:17 linux-headers-6.6.100-vyos_6.6.100-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld  29582808 Aug 23 12:17 linux-image-6.6.100-vyos_6.6.100-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   1319320 Aug 23 12:17 linux-libc-dev_6.6.100-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   2481688 Aug 23 12:17 linux-perf-6.6.100-vyos_6.6.100-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld     30172 Aug 23 12:34 python3-vpp-api_25.06.0-21~ga5eeb187f-dirty_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   5319504 Aug 23 12:34 vpp_25.06.0-21~ga5eeb187f-dirty_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   1192772 Aug 23 12:34 vpp-crypto-engines_25.06.0-21~ga5eeb187f-dirty_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld 104306476 Aug 23 12:34 vpp-dbg_25.06.0-21~ga5eeb187f-dirty_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   1446608 Aug 23 12:34 vpp-dev_25.06.0-21~ga5eeb187f-dirty_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   4673668 Aug 23 12:34 vpp-plugin-core_25.06.0-21~ga5eeb187f-dirty_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld    376612 Aug 23 12:34 vpp-plugin-devtools_25.06.0-21~ga5eeb187f-dirty_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld   4797216 Aug 23 12:34 vpp-plugin-dpdk_25.06.0-21~ga5eeb187f-dirty_amd64.deb
vyos_bld@76f809ee20c4:/vyos/work/T7749/vyos-build/scripts/package-build/linux-kernel$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
