### PR TITLE
Kernel: T5887: update Linux Kernel to v6.6.102

### DIFF
--- a/data/defaults.toml
+++ b/data/defaults.toml
@@ -14,7 +14,7 @@ vyos_mirror = "https://packages.vyos.net/repositories/current"
 vyos_branch = "current"
 release_train = "current"
 
-kernel_version = "6.6.100"
+kernel_version = "6.6.102"
 kernel_flavor = "vyos"
 bootloaders = "syslinux,grub-efi"
 

--- a/scripts/package-build/linux-kernel/build.py
+++ b/scripts/package-build/linux-kernel/build.py
@@ -177,17 +177,6 @@ def build_package(package: dict, dependencies: list) -> None:
         pass
 
 
-def cleanup_build_deps(repo_dir: Path) -> None:
-    """Clean up build dependency packages"""
-    try:
-        if repo_dir.exists():
-            for file in glob.glob(str(repo_dir / '*build-deps*.deb')):
-                os.remove(file)
-            print("Cleaned up build dependency packages")
-    except Exception as e:
-        print(f"Error cleaning up build dependencies: {e}")
-
-
 def copy_packages(repo_dir: Path) -> None:
     """Copy generated .deb packages to the parent directory"""
     try:
@@ -320,9 +309,6 @@ if __name__ == '__main__':
 
         # Build the package
         build_package(package, dependencies)
-
-        # Clean up build dependency packages after build
-        cleanup_build_deps(Path(package['name']))
 
         # Copy generated .deb packages to parent directory
         copy_packages(Path(package['name']))


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Update Linux Kernel to version 6.6.102.

Remove unused code path cleaning up DEB build dependencies which is unused as there are no dependencies installed via debian/control file mechanism.

All Smoketests passed

<img width="1128" height="239" alt="image" src="https://github.com/user-attachments/assets/bec93cec-50bc-468d-8cd6-74ee32c95451" />


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5887

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
