### PR TITLE
T75: ipt-netflow fix aggregation mode

### DIFF
--- a/scripts/package-build/linux-kernel/patches/ipt-netflow/0004-Change-aggregation-parameter-mode-400-444.patch
+++ b/scripts/package-build/linux-kernel/patches/ipt-netflow/0004-Change-aggregation-parameter-mode-400-444.patch
@@ -1,0 +1,25 @@
+From 3f45658e9a2b8642e1c43f4adc22e107ea6eb235 Mon Sep 17 00:00:00 2001
+From: Kyrylo Yatsenko <hedrok@gmail.com>
+Date: Tue, 2 Sep 2025 10:29:04 +0300
+Subject: [PATCH] Change 'aggregation' parameter mode 400->444
+
+---
+ ipt_NETFLOW.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ipt_NETFLOW.c b/ipt_NETFLOW.c
+index eee8074..721353d 100644
+--- a/ipt_NETFLOW.c
++++ b/ipt_NETFLOW.c
+@@ -229,7 +229,7 @@ MODULE_PARM_DESC(engine_id, "Observation Domain ID");
+ #define AGGR_SIZE 1024
+ static char aggregation_buf[AGGR_SIZE] = "";
+ static char *aggregation = aggregation_buf;
+-module_param(aggregation, charp, 0400);
++module_param(aggregation, charp, 0444);
+ MODULE_PARM_DESC(aggregation, "aggregation ruleset");
+ static LIST_HEAD(aggr_n_list);
+ static LIST_HEAD(aggr_p_list);
+-- 
+2.50.1
+


### PR DESCRIPTION
## ipt_NETFLOW: fix aggregation mode
<!--- Provide a general summary of your changes in the Title above -->

Add patch 0004-Change-aggregation-parameter-mode-400-444.patch: Tests need to read 'aggregation' parameter. All other parameters have modes 444 or 644. Change mode of 'aggregation' 400 -> 444

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T75
* https://vyos.dev/T7761

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
