### PR TITLE
T7772: Fix amazon-cloudwatch-agent build

### DIFF
--- a/scripts/package-build/amazon-cloudwatch-agent/package.toml
+++ b/scripts/package-build/amazon-cloudwatch-agent/package.toml
@@ -1,11 +1,11 @@
 [[packages]]
 name = "amazon-cloudwatch-agent"
-commit_id = "v1.300050.0"
+commit_id = "v1.300057.0"
 scm_url = "https://github.com/aws/amazon-cloudwatch-agent"
 
 build_cmd = """
 
-make clean test check_secrets amazon-cloudwatch-agent-linux package-deb
+make clean check_secrets amazon-cloudwatch-agent-linux package-deb
 ARCH=$(dpkg --print-architecture)
 TAG=$(git describe --tags --abbrev=0)
 COMMIT=$(git rev-parse --short HEAD)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This change was created to fix a problem with build process. That problem is related to tests, that we run before the actual build. It is not required to run these tests every build, that's why these tests will be disabled until the following issue is fixed : https://github.com/aws/amazon-cloudwatch-agent/pull/1843/files

The packages version is also changed to latest available: v1.300057.0

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): disable pre-build tests and bump version.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/TT7772 

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
