### PR TITLE
T6516: frr: fix isisd advertise-passive-only 

### DIFF
--- a/scripts/package-build/frr/patches/frr/0008-isis-fix-advertise-passive-only-routes-install.patch
+++ b/scripts/package-build/frr/patches/frr/0008-isis-fix-advertise-passive-only-routes-install.patch
@@ -1,0 +1,133 @@
+From e2dbe69dd830d01af5bf0202b347524b3151e4e6 Mon Sep 17 00:00:00 2001
+From: Kyrylo Yatsenko <hedrok@gmail.com>
+Date: Fri, 19 Sep 2025 09:17:03 +0300
+Subject: [PATCH] isis: fix advertise-passive-only routes install
+
+When advertise-passive-only is set don't ignore active circuits
+completely - we still need to install routes from those interfaces.
+
+Update test to check this.
+
+Fixes #16325
+
+Signed-off-by: Kyrylo Yatsenko <hedrok@gmail.com>
+---
+ isisd/isis_lsp.c                              | 43 ++++++++-----------
+ tests/topotests/isis_topo1/test_isis_topo1.py | 30 ++++++++++---
+ 2 files changed, 42 insertions(+), 31 deletions(-)
+
+diff --git a/isisd/isis_lsp.c b/isisd/isis_lsp.c
+index d588af314c..0aefba95a2 100644
+--- a/isisd/isis_lsp.c
++++ b/isisd/isis_lsp.c
+@@ -1308,37 +1308,30 @@ static void lsp_build(struct isis_lsp *lsp, struct isis_area *area)
+ 			continue;
+ 		}
+ 
+-		if (area->advertise_passive_only && !circuit->is_passive) {
+-			lsp_debug(
+-				"ISIS (%s): Circuit is not passive, ignoring.",
+-				area->area_tag);
+-			continue;
+-		}
+-
+ 		uint32_t metric = area->oldmetric
+ 					  ? circuit->metric[level - 1]
+ 					  : circuit->te_metric[level - 1];
+ 
+-		if (circuit->ip_router && circuit->ip_addrs->count > 0) {
+-			lsp_debug(
+-				"ISIS (%s): Circuit has IPv4 active, adding respective TLVs.",
+-				area->area_tag);
+-			struct listnode *ipnode;
+-			struct prefix_ipv4 *ipv4;
+-			for (ALL_LIST_ELEMENTS_RO(circuit->ip_addrs, ipnode,
+-						  ipv4))
+-				lsp_build_internal_reach_ipv4(lsp, area, ipv4,
+-							      metric);
+-		}
++		if (area->advertise_passive_only && !circuit->is_passive) {
++			lsp_debug("ISIS (%s): Circuit is not passive, don't add prefixes.",
++				  area->area_tag);
++		} else {
++			if (circuit->ip_router && circuit->ip_addrs->count > 0) {
++				lsp_debug("ISIS (%s): Circuit has IPv4 active, adding respective TLVs.",
++					  area->area_tag);
++				struct listnode *ipnode;
++				struct prefix_ipv4 *ipv4;
++				for (ALL_LIST_ELEMENTS_RO(circuit->ip_addrs, ipnode, ipv4))
++					lsp_build_internal_reach_ipv4(lsp, area, ipv4, metric);
++			}
+ 
+-		if (circuit->ipv6_router && circuit->ipv6_non_link->count > 0) {
+-			struct listnode *ipnode;
+-			struct prefix_ipv6 *ipv6;
++			if (circuit->ipv6_router && circuit->ipv6_non_link->count > 0) {
++				struct listnode *ipnode;
++				struct prefix_ipv6 *ipv6;
+ 
+-			for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_non_link,
+-						  ipnode, ipv6))
+-				lsp_build_internal_reach_ipv6(lsp, area, ipv6,
+-							      metric);
++				for (ALL_LIST_ELEMENTS_RO(circuit->ipv6_non_link, ipnode, ipv6))
++					lsp_build_internal_reach_ipv6(lsp, area, ipv6, metric);
++			}
+ 		}
+ 
+ 		switch (circuit->circ_type) {
+diff --git a/tests/topotests/isis_topo1/test_isis_topo1.py b/tests/topotests/isis_topo1/test_isis_topo1.py
+index 1cec2f16f0..5d65b353cf 100644
+--- a/tests/topotests/isis_topo1/test_isis_topo1.py
++++ b/tests/topotests/isis_topo1/test_isis_topo1.py
+@@ -148,12 +148,9 @@ def test_isis_route_installation():
+         filename = "{0}/{1}/{1}_route.json".format(CWD, rname)
+         expected = json.loads(open(filename, "r").read())
+ 
+-        def compare_isis_installed_routes(router, expected):
+-            "Helper function to test ISIS routes installed in rib."
+-            actual = router.vtysh_cmd("show ip route json", isjson=True)
+-            return topotest.json_cmp(actual, expected)
+-
+-        test_func = functools.partial(compare_isis_installed_routes, router, expected)
++        test_func = functools.partial(
++            _helper_compare_isis_installed_routes, router, expected
++        )
+         (result, _) = topotest.run_and_expect(test_func, None, wait=1, count=10)
+         assertmsg = "Router '{}' routes mismatch".format(rname)
+         assert result, assertmsg
+@@ -565,6 +562,21 @@ def test_isis_advertise_passive_only():
+     )
+     assert result is True, result
+ 
++    logger.info("Checking router for installed ISIS routes with advertise-passive-only")
++
++    # routes must be installed
++    rname = "r1"
++    router = r1
++    filename = "{0}/{1}/{1}_route.json".format(CWD, rname)
++    expected = json.loads(open(filename, "r").read())
++
++    test_func = functools.partial(
++        _helper_compare_isis_installed_routes, router, expected
++    )
++    (result, _) = topotest.run_and_expect(test_func, None, wait=1, count=10)
++    assertmsg = "Router '{}' routes mismatch:\n{}".format(rname, _)
++    assert result, assertmsg
++
+ 
+ def test_isis_hello_padding_during_adjacency_formation():
+     """Check that IIH packets is only padded when adjacency is still being formed
+@@ -842,3 +854,9 @@ def parse_topology(lines, level):
+             continue
+ 
+     return areas
++
++
++def _helper_compare_isis_installed_routes(router, expected):
++    "Helper function to test ISIS routes installed in rib."
++    actual = router.vtysh_cmd("show ip route json", isjson=True)
++    return topotest.json_cmp(actual, expected)
+-- 
+2.50.1
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## FRR: fix isisd advertise-passive-only routes installation

The patch 0008-isis-fix-advertise-passive-only-routes-install.patch fixes installing routes even when advertise-passive-only is enabled.

Previously active circuits were ignored completely, patch makes isisd just not to advertise prefixes from active circuits, but install routes from them and do all other processing.

FRR PR: https://github.com/FRRouting/frr/pull/19593

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T6516

## Related PR(s)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
