### PR TITLE
T7873: Bump Suricata version to 7.0.10

### DIFF
--- a/data/live-build-config/archives/bookworm-backports.pref.chroot
+++ b/data/live-build-config/archives/bookworm-backports.pref.chroot
@@ -2,6 +2,10 @@ Package: iproute2
 Pin: release n=bookworm-backports
 Pin-Priority: 600
 
+Package: suricata libhtp2
+Pin: release n=bookworm-backports
+Pin-Priority: 600
+
 Package: *
 Pin: release n=bookworm-backports
 Pin-Priority: -100


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
It is required to bump the Suricata package version to address multiple vulnerabilities. 
This version of package (suricata 7.0.*) is available in bookworm-backports repository only. It also requires libhtp2 package of specific version from bookworm-backports.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7873

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
