### PR TITLE
T7936: Drop sFlow plugin from VPP and use native sFlow plugin

### DIFF
--- a/scripts/package-build/vpp/package.toml
+++ b/scripts/package-build/vpp/package.toml
@@ -6,13 +6,6 @@ build_cmd = "/bin/true"
 apply_patches = false
 
 [[packages]]
-name = "vpp-sflow"
-commit_id = "v0.9.02-2"
-scm_url = "https://github.com/sflow/vpp-sflow"
-build_cmd = "/bin/true"
-apply_patches = false
-
-[[packages]]
 name = "vpp"
 commit_id = "stable/2506"
 scm_url = "https://github.com/FDio/vpp"
@@ -22,7 +15,6 @@ apply_patches = false
 pre_build_hook = """
 mkdir -p ../patches/vpp/
 rsync -av ../vyos-vpp-patches/patches/vpp/ ../patches/vpp/
-rsync -av ../vpp-sflow/sflow ../vpp/src/plugins
 """
 
 build_cmd = """


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
VPP 25.06 has its own sFlow plugin; we do not need to build an external plugin
https://github.com/FDio/vpp/tree/stable/2506/src/plugins/sflow
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7936

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
