### PR TITLE
build: T7828: use tomli instead of toml in the package build script

### DIFF
--- a/scripts/package-build/build.py
+++ b/scripts/package-build/build.py
@@ -18,7 +18,7 @@
 import glob
 import shutil
 import sys
-import toml
+import tomli
 import os
 
 from argparse import ArgumentParser
@@ -207,8 +207,8 @@ if __name__ == '__main__':
     args = arg_parser.parse_args()
 
     # Load package configuration
-    with open(args.config, 'r') as file:
-        config = toml.load(file)
+    with open(args.config, 'rb') as file:
+        config = tomli.load(file)
 
     packages = config['packages']
     patch_dir = Path(args.patch_dir)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Use python3-tomli in the build script. That allows us to get rid of the python3-toml dependency since this is the last place where it was used. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
