### PR TITLE
frr: T7947: add a patch to fix the memory leark with default-originate in route-maps

### DIFF
--- a/scripts/package-build/frr/patches/frr/0010-bgpd-Fix-memory-leak-for-default-originate-with-route-map.patch
+++ b/scripts/package-build/frr/patches/frr/0010-bgpd-Fix-memory-leak-for-default-originate-with-route-map.patch
@@ -1,0 +1,47 @@
+From 74c1d4f8c01a54c6536ba752df27afee84b0f4a7 Mon Sep 17 00:00:00 2001
+From: Donatas Abraitis <donatas@opensourcerouting.org>
+Date: Mon, 8 Jan 2024 19:21:56 +0200
+Subject: [PATCH] bgpd: Fix memory leak for default-originate with route-map
+
+```
+Direct leak of 40 byte(s) in 1 object(s) allocated from:
+    0 0x7fc4b81eed28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
+    1 0x7fc4b7bd60bb in qcalloc lib/memory.c:105
+    2 0x56221dc19207 in aspath_dup bgpd/bgp_aspath.c:689
+    3 0x56221daacd42 in route_set_aspath_prepend bgpd/bgp_routemap.c:2283
+    4 0x7fc4b7c3891a in route_map_apply_ext lib/routemap.c:2687
+    5 0x56221dace552 in subgroup_default_originate bgpd/bgp_updgrp_adv.c:906
+    6 0x56221dabf79c in update_group_default_originate_route_map_walkcb bgpd/bgp_updgrp.c:2105
+    7 0x56221dabde4e in update_group_walkcb bgpd/bgp_updgrp.c:1721
+    8 0x7fc4b7b9d398 in hash_walk lib/hash.c:270
+    9 0x56221dac94cb in update_group_af_walk bgpd/bgp_updgrp.c:2062
+    10 0x56221dac9b0f in update_group_walk bgpd/bgp_updgrp.c:2071
+    11 0x56221dac9fd5 in update_group_refresh_default_originate_route_map bgpd/bgp_updgrp.c:2118
+    12 0x7fc4b7c7fc54 in event_call lib/event.c:1974
+    13 0x7fc4b7bb9276 in frr_run lib/libfrr.c:1214
+    14 0x56221d9217fd in main bgpd/bgp_main.c:510
+    15 0x7fc4b6bf2c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)
+```
+
+tmp_pi.attr should be flushed since it's already interned (new_attr) or the
+origin value is used (attr).
+
+Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>
+---
+ bgpd/bgp_updgrp_adv.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bgpd/bgp_updgrp_adv.c b/bgpd/bgp_updgrp_adv.c
+index c466d8719776..7ecebe3020cf 100644
+--- a/bgpd/bgp_updgrp_adv.c
++++ b/bgpd/bgp_updgrp_adv.c
+@@ -914,8 +914,8 @@ void subgroup_default_originate(struct update_subgroup *subgrp, bool withdraw)
+ 						bgp_attr_flush(new_attr);
+ 						new_attr = bgp_attr_intern(
+ 							tmp_pi.attr);
+-						bgp_attr_flush(tmp_pi.attr);
+ 					}
++					bgp_attr_flush(tmp_pi.attr);
+ 					subgroup_announce_reset_nhop(
+ 						(peer_cap_enhe(peer, afi, safi)
+ 							 ? AF_INET6


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Import a patch for the bug that causes BGPd to crash when default-originate statements are used in route-maps.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
