### PR TITLE
T7958: Bump hsflowd version to v2.1.17-1

### DIFF
--- a/scripts/package-build/hsflowd/package.toml
+++ b/scripts/package-build/hsflowd/package.toml
@@ -1,6 +1,6 @@
 [[packages]]
 name = "host-sflow"
-commit_id = "dffc277"
+commit_id = "v2.1.17-1"
 scm_url = "https://github.com/sflow/host-sflow.git"
 build_cmd = "make deb FEATURES='PCAP DROPMON DBUS PSAMPLE VPP'"
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Bump hsflowd version to v2.1.17-1

```
$ git log --oneline dffc277..v2.1.17-1
6949d81 (HEAD, tag: v2.1.17-1, origin/master, origin/HEAD, master) bump version to 2.1.17-1
1edc4d4 fix file-descriptor leak when mod_tcp opens netlink sockets in other network namespaces
e984add improve logging
d521a7a readVNIC logging
ab27cd3 clean up file descriptors in readVNIC
016b990 simplify EVSocket lifecycle
3f9dfdd mod_nlroute improve logging
ba0d630 improve mod_pcap logging
835fcde check FD_SETSIZE
a6a00ed (tag: v2.1.16-1) bump version
f89573d avoid SIGSEGV triggered by retrying collector socket opening which config is missing (e.g. when last SONiC collector is removed)
b6f02df more Dockerfiles add clang
1eec6a5 allow mod_psample to compile on ubuntu20 with newer fields
a0020c9 (tag: v2.1.15-1) reduce mod_epcap logging
998a600 tweak Docker build files
93d7c54 update docker build files
358001e bump version to 2.1.15-1
590656f Fix Debian 12 build and add Debian 13 (#83)
c601aed Accommodate PSAMPLE_ATTR_SAMPLE_PROBABILITY if it appears and warn that it is problematic
db237d2 mod_epcap use BUSY event to allow for default notification from libbpf
0195232 Add EVEventRxOff to unsubscribe,  and BUSY event for bursts of rapid polling


```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Update `hsflowd` version

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7958

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## check
```
vyos@r14:~$ show version all | match hsflow
ii  hsflowd                          2.1.17-1                                 amd64        sFlow(R) monitoring agent
vyos@r14:~$ 

set system sflow agent-address '10.0.0.1'
set system sflow interface 'eth0'
set system sflow sampling-rate '1'
set system sflow server 10.0.0.2

```
Check traffic on the sFlow server:
```
vyos@r16# sudo goflow2 | jq
time=2025-10-27T12:05:06.736Z level=INFO msg="starting GoFlow2"
time=2025-10-27T12:05:06.736Z level=INFO msg="starting collection" scheme=sflow hostname="" port=6343 count=1 workers=2 blocking=false queue_size=1000000
time=2025-10-27T12:05:06.738Z level=INFO msg="starting collection" scheme=netflow hostname="" port=2055 count=1 workers=2 blocking=false queue_size=1000000
{
  "type": "SFLOW_5",
  "time_received_ns": 1761566707347156000,
  "sequence_num": 102,
  "sampling_rate": 1,
  "sampler_address": "10.0.0.1",
  "time_flow_start_ns": 1761566707347156000,
  "time_flow_end_ns": 1761566707347156000,
  "bytes": 102,
  "packets": 1,
  "src_addr": "192.168.122.14",
  "dst_addr": "1.1.1.1",
  "etype": "IPv4",
  "proto": "ICMP",
  "src_port": 0,
  "dst_port": 0,
  "in_if": 1073741823,
  "out_if": 2,
  "src_mac": "52:54:00:8d:67:6e",
  "dst_mac": "52:54:00:d4:d9:a1",
  "src_vlan": 0,
  "dst_vlan": 0,
  "vlan_id": 0,
  "ip_tos": 0,
  "forwarding_status": 0,
  "ip_ttl": 64,
  "ip_flags": 2,
  "tcp_flags": 0,
  "icmp_type": 0,
  "icmp_code": 0,
  "ipv6_flow_label": 0,
  "fragment_id": 18888,
  "fragment_offset": 0,
  "src_as": 0,
  "dst_as": 0,
  "next_hop": "",
  "next_hop_as": 0,
  "src_net": "0.0.0.0/0",
  "dst_net": "0.0.0.0/0",
  "bgp_next_hop": "",
  "bgp_communities": [],
  "as_path": [],
  "mpls_ttl": [],
  "mpls_label": [],
  "mpls_ip": [],
  "observation_domain_id": 0,
  "observation_point_id": 0,
  "layer_stack": [
    "Ethernet",
    "IPv4",
    "ICMP"
  ],
  "layer_size": [
    14,
    20,
    8
  ],
  "ipv6_routing_header_addresses": [],
  "ipv6_routing_header_seg_left": 0
}
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
