### PR TITLE
Kernel: T8035: update Linux Kernel to v6.6.117

### DIFF
--- a/data/defaults.toml
+++ b/data/defaults.toml
@@ -14,7 +14,7 @@ vyos_mirror = "https://packages.vyos.net/repositories/current"
 vyos_branch = "current"
 release_train = "current"
 
-kernel_version = "6.6.114"
+kernel_version = "6.6.117"
 kernel_flavor = "vyos"
 bootloaders = "syslinux,grub-efi"
 

--- a/scripts/package-build/linux-kernel/patches/kernel/0001-linkstate-ip-device-attribute.patch
+++ b/scripts/package-build/linux-kernel/patches/kernel/0001-linkstate-ip-device-attribute.patch
@@ -101,7 +101,7 @@ index 798497c8b192..0b4510b06ab5 100644
  };
  
 diff --git a/net/ipv6/addrconf.c b/net/ipv6/addrconf.c
-index 1c3b0ba289fb..075da0727e7d 100644
+index 0e49ee83533b..227e9e439fea 100644
 --- a/net/ipv6/addrconf.c
 +++ b/net/ipv6/addrconf.c
 @@ -5671,6 +5671,7 @@ static inline void ipv6_store_devconf(struct ipv6_devconf *cnf,
@@ -112,7 +112,7 @@ index 1c3b0ba289fb..075da0727e7d 100644
  }
  
  static inline size_t inet6_ifla6_size(void)
-@@ -7113,6 +7114,13 @@ static const struct ctl_table addrconf_sysctl[] = {
+@@ -7115,6 +7116,13 @@ static const struct ctl_table addrconf_sysctl[] = {
  		.extra1		= (void *)SYSCTL_ZERO,
  		.extra2		= (void *)SYSCTL_ONE,
  	},


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Summary

* 6.6.117 https://lwn.net/Articles/1047686/
* 6.6.116 https://lwn.net/Articles/1044545/
* 6.6.115 https://lwn.net/Articles/1043996/

<img width="807" height="290" alt="image" src="https://github.com/user-attachments/assets/9eea50f8-e909-45be-b682-27ebd4ce986a" />


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8035

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
