### PR TITLE
T8065: Dehardcode qemu settings to allow run tests on arch arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ SHELL := /bin/bash
 
 build_dir := build
 
+arch ?= $(shell dpkg --print-architecture 2>/dev/null || echo amd64)
+
 .PHONY: all
 all:
 	@echo "Make what specifically?"
@@ -13,8 +15,8 @@ all:
 .PHONY: checkiso
 .ONESHELL:
 checkiso:
-	if [ ! -f build/live-image-amd64.hybrid.iso ]; then
-		echo "Could not find build/live-image-amd64.hybrid.iso"
+	if [ ! -f build/live-image-$(arch).hybrid.iso ]; then
+		echo "Could not find build/live-image-$(arch).hybrid.iso"
 		exit 1
 	fi
 
@@ -31,7 +33,7 @@ test-no-interfaces: checkiso
 .PHONY: test-no-interfaces-no-vpp
 .ONESHELL:
 test-no-interfaces-no-vpp: checkiso
-	scripts/check-qemu-install --debug --configd --smoketest --uefi --no-interfaces --no-vpp build/live-image-amd64.hybrid.iso
+	scripts/check-qemu-install --debug --configd --smoketest --uefi --no-interfaces --no-vpp --arch $(arch) build/live-image-$(arch).hybrid.iso
 
 .PHONY: test-interfaces
 .ONESHELL:

--- a/data/build-flavors/generic-arm64.toml
+++ b/data/build-flavors/generic-arm64.toml
@@ -1,0 +1,74 @@
+# Generic (aka "universal") ISO image
+
+image_format = "iso"
+
+[[includes_chroot]]
+  path = "opt/vyatta/etc/config.boot.default"
+  data = '''
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server time1.vyos.net {
+        }
+        server time2.vyos.net {
+        }
+        server time3.vyos.net {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyAMA0 {
+            speed "115200"
+        }
+    }
+    host-name "vyos"
+    login {
+        operator-group default {
+            command-policy {
+                allow "*"
+            }
+        }
+        user vyos {
+            authentication {
+                encrypted-password "$6$QxPS.uk6mfo$9QBSo8u1FkH16gMyAVhus6fU3LOzvLR9Z9.82m3tiHFAxTtIkhaZSWssSgzt4v4dGAL8rhVQxTg0oAG9/q11h/"
+                plaintext-password ""
+            }
+        }
+    }
+    option {
+        reboot-on-upgrade-failure 5
+    }
+    syslog {
+        local {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}
+'''
+
+[boot_settings]
+    console_type = "ttyAMA"
+    console_num = '0'
+    console_speed = "115200"

--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -55,6 +55,20 @@ now = datetime.now()
 tpm_folder = '/tmp/vyos_tpm_test'
 qemu_name = 'VyOS-QEMU'
 
+# Map QEMU arch
+QEMU_CONFIG = {
+    "amd64": {
+        "bin": "qemu-system-x86_64",
+        "machine": "pc",
+        "bios": "/usr/share/OVMF/OVMF_CODE.fd",
+    },
+    "arm64": {
+        "bin": "qemu-system-aarch64",
+        "machine": "virt",
+        "bios": "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
+    },
+}
+
 # getch.py
 KEY_F2 = chr(27) + chr(91) + chr(49) + chr(50) + chr(126)
 KEY_F10 = chr(27) + chr(91) + chr(50) + chr(49) + chr(126)
@@ -97,6 +111,7 @@ parser.add_argument('--sbtest', help='Execute Secure Boot tests',
 parser.add_argument('--qemu-cmd', help='Only generate QEMU launch command',
                 action='store_true', default=False)
 parser.add_argument('--cpu', help='Set QEMU CPU', type=int, default=2)
+parser.add_argument('--cpu-type', help='Set QEMU CPU type', type=str, default='host')
 parser.add_argument('--memory', help='Set QEMU memory', type=int, default=4)
 parser.add_argument('--vyconf', help='Execute testsuite with vyconfd', action='store_true',
                     default=False)
@@ -104,6 +119,7 @@ parser.add_argument('--no-vpp', help='Execute testsuite without VPP tests',
                 action='store_true', default=False)
 parser.add_argument('--huge-page-size', help='Huge page size (e.g., 2M, 1G)', type=str)
 parser.add_argument('--huge-page-count', help='Number of huge pages to allocate', type=int)
+parser.add_argument('--arch', help='Architecture')
 
 args = parser.parse_args()
 
@@ -146,18 +162,31 @@ OVMF_VARS_TMP = args.disk.replace('.img', '.efivars')
 if args.sbtest:
     shutil.copy('/usr/share/OVMF/OVMF_VARS_4M.ms.fd', OVMF_VARS_TMP)
 
+
+def _kvm_exists():
+    return os.path.exists("/dev/kvm")
+
+
 def get_qemu_cmd(name, enable_uefi, disk_img, raid=None, iso_img=None, tpm=False, vnc_enabled=False, secure_boot=False):
     uefi = ""
     uuid = "f48b60b2-e6ad-49ef-9d09-4245d0585e52"
-    machine = 'pc'
+    arch = getattr(args, 'arch', 'amd64')
+    qemu_arch_config = QEMU_CONFIG.get(arch, QEMU_CONFIG["amd64"])
+    qemu_bin = qemu_arch_config['bin']
+    bios = qemu_arch_config['bios']
+    cpu_type = args.cpu_type
+    machine = qemu_arch_config['machine']
+    accel = ',accel=kvm' if _kvm_exists() else ''
+    enable_kvm = '-enable-kvm' if _kvm_exists() else ''
     vga = '-vga none'
     vnc = ''
+
     if vnc_enabled:
         vga = '-vga virtio'
         vnc = '-vnc :0'
 
     if enable_uefi:
-        uefi = '-bios /usr/share/OVMF/OVMF_CODE.fd'
+        uefi = f'-bios {bios}'
         name = f'{name}-UEFI'
 
         if secure_boot:
@@ -171,26 +200,25 @@ def get_qemu_cmd(name, enable_uefi, disk_img, raid=None, iso_img=None, tpm=False
 
     cdrom = ""
     if iso_img:
-        cdrom = f' -drive file={iso_img},format=raw,if=none,media=cdrom,id=drive-cd1,readonly=on' \
-                f' -device ahci,id=achi0' \
-                f' -device ide-cd,bus=achi0.0,drive=drive-cd1,id=cd1,bootindex=10'
+        cdrom = (
+            f' -drive file={iso_img},format=raw,if=none,media=cdrom,id=drive-cd1,readonly=on'
+            f' -device scsi-cd,bus=scsi0.0,drive=drive-cd1,id=cd1,bootindex=10'
+        )
 
     # RFC7042 section 2.1.2 MAC addresses used for documentation
     macbase = '00:00:5E:00:53'
-    cmd = f'qemu-system-x86_64 \
+    cmd = f'{qemu_bin} \
         -name "{name}" \
         -smp {args.cpu},sockets=1,cores={args.cpu},threads=1 \
-        -cpu host \
-        -machine {machine},accel=kvm \
+        -cpu {cpu_type} \
+        -machine {machine}{accel} \
         {uefi} \
         -m {args.memory}G \
         -vga none \
         -nographic \
         {vga} {vnc}\
         -uuid {uuid} \
-        -cpu host \
-        {cdrom} \
-        -enable-kvm \
+        {enable_kvm} \
         -monitor unix:/tmp/qemu-monitor-socket-{disk_img},server,nowait \
         -netdev user,id=n0,net=192.0.2.0/24,dhcpstart=192.0.2.101,dns=192.0.2.10 -device virtio-net-pci,netdev=n0,mac={macbase}:00,romfile="",host_mtu=1500 \
         -netdev user,id=n1 -device virtio-net-pci,netdev=n1,mac={macbase}:01,romfile="",host_mtu=1500 \
@@ -201,6 +229,7 @@ def get_qemu_cmd(name, enable_uefi, disk_img, raid=None, iso_img=None, tpm=False
         -netdev user,id=n6 -device virtio-net-pci,netdev=n6,mac={macbase}:06,romfile="" \
         -netdev user,id=n7 -device virtio-net-pci,netdev=n7,mac={macbase}:07,romfile="" \
         -device virtio-scsi-pci,id=scsi0 \
+        {cdrom} \
         -drive format=raw,file={disk_img},if=none,media=disk,id=drive-hd1,readonly=off \
         -device scsi-hd,bus=scsi0.0,drive=drive-hd1,id=hd1,bootindex=1'
 
@@ -283,7 +312,8 @@ if not os.path.isfile(args.iso):
 
 if not os.path.exists('/dev/kvm'):
     log.error('KVM not enabled on host, proceeding with software emulation')
-    sys.exit(1)
+    # Some arm platforms do not have kvm, for example Mac arm devices
+    # sys.exit(1)
 
 # Creating diskimage!!
 diskname_raid = None


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Dehardcode qemu settings to allow running smoketests on the arch `arm64`
**I cannot completely check it, due to a lack of arm64 devices with a supported  `/dev/kvm`** 
But it is a good starting point. **It could still fail on the arm64, but at least we allow it for future investigation.**

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8065

## Related PR(s)
https://github.com/vyos/vyos-build/pull/1074
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
