### PR TITLE
T8068: qemu-system-aarch64 is not included to the Dockerfile for arm64 arch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -279,6 +279,7 @@ RUN if dpkg-architecture -ii386 || dpkg-architecture -iamd64; then \
 # Packages for arm64 platform
 RUN if dpkg-architecture -iarm64; then \
       apt-get update && apt-get install -y \
+        python3-pexpect \
         ipxe-qemu \
         qemu-system-aarch64 \
         qemu-efi-aarch64; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -266,7 +266,7 @@ RUN GO_VERSION_INSTALL="1.23.2" ; \
 RUN echo "export PATH=/opt/go/bin:$PATH" >> /etc/bash.bashrc
 
 # Packages needed for Qemu test-suite
-# This is for now only supported on i386 and amd64 platforms
+# Packages for i386 and amd64 platforms
 RUN if dpkg-architecture -ii386 || dpkg-architecture -iamd64; then \
       apt-get update && apt-get install -y \
         python3-pexpect \
@@ -274,6 +274,14 @@ RUN if dpkg-architecture -ii386 || dpkg-architecture -iamd64; then \
         qemu-system-x86 \
         qemu-utils \
         qemu-kvm; \
+    fi
+
+# Packages for arm64 platform
+RUN if dpkg-architecture -iarm64; then \
+      apt-get update && apt-get install -y \
+        ipxe-qemu \
+        qemu-system-aarch64 \
+        qemu-efi-aarch64; \
     fi
 
 # Packages needed for building vmware and GCE images


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add QEMU packages for ARM64 platform.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8068
* https://vyos.dev/T8067

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
