### PR TITLE
T8085: Do not hardcode values in kernel build scripts

### DIFF
--- a/scripts/package-build/linux-kernel/build-kernel.sh
+++ b/scripts/package-build/linux-kernel/build-kernel.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 CWD=$(pwd)
 KERNEL_SRC=linux
+ARCH=$(dpkg --print-architecture)
 
 set -e
 
@@ -22,7 +23,14 @@ cp -rv ${CWD}/arch/ .
 
 KERNEL_VERSION=$(make kernelversion)
 KERNEL_SUFFIX=-$(awk -F "= " '/kernel_flavor/ {print $2}' ../../../../data/defaults.toml | tr -d \")
-KERNEL_CONFIG=arch/x86/configs/vyos_defconfig
+
+if [ "${ARCH}" = "arm64" ]; then
+    KERNEL_CONFIG=arch/arm64/configs/vyos_defconfig
+else
+    KERNEL_CONFIG=arch/x86/configs/vyos_defconfig
+fi
+
+echo "KERNEL_CONFIG: ${KERNEL_CONFIG}"
 
 # VyOS requires some small Kernel Patches - apply them here
 # It's easier to habe them here and make use of the upstream


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add architecture detection for kernel configuration file to replace the hardcoded value.

We can't specify it with the following one line:
KERNEL_CONFIG=arch/${ARCH}/configs/vyos_defconfig

It is caused by the current directory structure - **amd64** config is stored in **linux/arch/x86** directory in the kernel sources. That's why we have to specify every option separately. Both uname and dpkg utils return this value in format of "x86_64" or "armd64" strings.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8085

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
