### PR TITLE
smoketest: T8087: reorganize folderstructure for embedded configttests

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -913,18 +913,19 @@ try:
 
     elif args.smoketest:
         # run default smoketest suite
+        smoketests_path = '/usr/libexec/vyos/tests/smoke'
         if args.match:
             # Remove tests that we don't want to run
             match_str = '-o '.join([f'-name "test_*{name}*.py" ' for name in args.match.split("|")]).strip()
-            c.sendline(f'sudo find /usr/libexec/vyos/tests/smoke -maxdepth 2 -type f -name test_* ! \( {match_str} \) -delete')
+            c.sendline(f'sudo find {smoketests_path} -maxdepth 2 -type f -name test_* ! \( {match_str} \) -delete')
             c.expect(op_mode_prompt)
         if args.no_interfaces:
             # remove interface tests as they consume a lot of time
-            c.sendline('sudo rm -f /usr/libexec/vyos/tests/smoke/cli/test_interfaces_*')
+            c.sendline('sudo rm -f {smoketests_path}/cli/test_interfaces_*')
             c.expect(op_mode_prompt)
         if args.no_vpp:
             # remove VPP tests
-            c.sendline('sudo rm -f /usr/libexec/vyos/tests/smoke/cli/test_vpp*')
+            c.sendline('sudo rm -f {smoketests_path}/cli/test_vpp*')
             c.expect(op_mode_prompt)
 
         if args.vyconf:
@@ -959,23 +960,25 @@ try:
     elif args.configtest:
         # Remove config-tests that we don't want to run
         if args.match:
+            configs_path = '/usr/libexec/vyos/tests/configs'
             if args.match.startswith("!"):
                 # Exclude mode — delete only the matched names
                 names = args.match[1:].split("|")
                 match_str = '-o '.join([f'-name "{name}"' for name in names])
-                cleanup_config_dir_cmd = f'sudo find /usr/libexec/vyos/tests/config -mindepth 1 -maxdepth 1 \\( {match_str} \\) -exec rm -rf {{}} +'
-                cleanup_config_tests_dir_cmd = f'sudo find /usr/libexec/vyos/tests/config-tests -mindepth 1 -maxdepth 1 \\( {match_str} \\) -exec rm -rf {{}} +'
+                cleanup_config_dir_cmd = f'sudo find {configs_path} -mindepth 1 -maxdepth 1 -type f \\( {match_str} \\) -exec rm -rf {{}} +'
+                cleanup_config_tests_dir_cmd = f'sudo find {configs_path}/assert -mindepth 1 -maxdepth 1 -type f \\( {match_str} \\) -exec rm -rf {{}} +'
             else:
                 # Include mode — keep only the matched names, delete the rest
                 names = args.match.split("|")
                 match_str = '-o '.join([f'-name "{name}"' for name in names])
-                cleanup_config_dir_cmd = f'sudo find /usr/libexec/vyos/tests/config -mindepth 1 -maxdepth 1 ! \\( {match_str} \\) -exec rm -rf {{}} +'
-                cleanup_config_tests_dir_cmd = f'sudo find /usr/libexec/vyos/tests/config-tests -mindepth 1 -maxdepth 1 ! \\( {match_str} \\) -exec rm -rf {{}} +'
+                cleanup_config_dir_cmd = f'sudo find {configs_path} -mindepth 1 -maxdepth 1 -type f ! \\( {match_str} \\) -exec rm -rf {{}} +'
+                cleanup_config_tests_dir_cmd = f'sudo find {configs_path}/assert -mindepth 1 -maxdepth 1 -type f ! \\( {match_str} \\) -exec rm -rf {{}} +'
 
             c.sendline(cleanup_config_dir_cmd)
             c.expect(op_mode_prompt)
             c.sendline(cleanup_config_tests_dir_cmd)
             c.expect(op_mode_prompt)
+
 
         log.info('Adding a legacy WireGuard default keypair for migrations')
         c.sendline('sudo mkdir -p /config/auth/wireguard/default')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Configuration files for config tests gathered from lab installations, customers or our own networks were placed in multiple directories - all related to the same thing.

We have had config-tests, configs and config.no-load. This commit re-arranges all the files and places a proper README for the users.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8087

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4893

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
