### PR TITLE
T8101: Add secure boot Kernel kexec options

### DIFF
--- a/scripts/package-build/linux-kernel/arch/arm64/configs/vyos_defconfig
+++ b/scripts/package-build/linux-kernel/arch/arm64/configs/vyos_defconfig
@@ -267,7 +267,8 @@ CONFIG_TRACEPOINTS=y
 CONFIG_CRASH_CORE=y
 CONFIG_KEXEC_CORE=y
 CONFIG_KEXEC=y
-# CONFIG_KEXEC_FILE is not set
+CONFIG_KEXEC_FILE=y
+CONFIG_KEXEC_SIG=y
 # CONFIG_CRASH_DUMP is not set
 # end of Kexec and crash features
 # end of General setup

--- a/scripts/package-build/linux-kernel/arch/x86/configs/vyos_defconfig
+++ b/scripts/package-build/linux-kernel/arch/x86/configs/vyos_defconfig
@@ -292,7 +292,8 @@ CONFIG_TRACEPOINTS=y
 CONFIG_CRASH_CORE=y
 CONFIG_KEXEC_CORE=y
 CONFIG_KEXEC=y
-# CONFIG_KEXEC_FILE is not set
+CONFIG_KEXEC_FILE=y
+CONFIG_KEXEC_SIG=y
 # CONFIG_CRASH_DUMP is not set
 # end of Kexec and crash features
 # end of General setup


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add Secure Boot - compatible kexec Kernel options

 - Required if system uses Secure Boot
 - Allows `systemctl kexec` or `kexec` to load signed kernels safely

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8101

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
