### PR TITLE
T8132: Update the APT mirror list before a package build

### DIFF
--- a/scripts/package-build/build.py
+++ b/scripts/package-build/build.py
@@ -33,7 +33,6 @@ def ensure_dependencies(dependencies: list) -> None:
         return
 
     print("I: Ensure Debian build dependencies are met")
-    run(['sudo', 'apt-get', 'update'], check=True)
     run(['sudo', 'apt-get', 'install', '-y'] + dependencies, check=True)
 
 
@@ -212,6 +211,9 @@ if __name__ == '__main__':
 
     packages = config['packages']
     patch_dir = Path(args.patch_dir)
+
+    # Update APT mirror list before the build
+    run(['sudo', 'apt-get', 'update'], check=True)
 
     # Load global dependencies
     global_dependencies = config.get('dependencies', {}).get('packages', [])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
The repository update process must be independent of the existence of package/package.toml dependencies.
This may lead to build failures for certain packages. Always update the APT mirror list before building.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Update APT mirror before building binary

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8132

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

For example, before the change:
```
E: Failed to fetch https://packages.vyos.net/repositories/current/pool/main/n/net-snmp/libsnmp-base_5.9.4%2bdfsg-1_all.deb  404  Not Found [IP: x.x.x.x 443]
E: Failed to fetch https://packages.vyos.net/repositories/current/pool/main/n/net-snmp/libsnmp40_5.9.4%2bdfsg-1_amd64.deb  404  Not Found [IP: x.x.x.x 443]
E: Failed to fetch https://packages.vyos.net/repositories/current/pool/main/n/net-snmp/libnetsnmptrapd40_5.9.4%2bdfsg-1_amd64.deb  404  Not Found [IP: x.x.x.x 443]
E: Failed to fetch https://packages.vyos.net/repositories/current/pool/main/n/net-snmp/libsnmp-dev_5.9.4%2bdfsg-1_amd64.deb  404  Not Found [IP: x.x.x.x 443]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
(Reading database ... 39488 files and directories currently installed.)
Removing keepalived-build-deps (1:2.3.3-1) ...
mk-build-deps: Unable to install all build-dep packages
Failed to build package keepalived: Command 'sudo mk-build-deps --install --tool "apt-get --yes --no-install-recommends"' returned non-zero exit status 29.
dpkg-buildpackage: info: source package keepalived
dpkg-buildpackage: info: source version 1:2.3.3-1
dpkg-buildpackage: info: source distribution unstable
dpkg-buildpackage: info: source changed by Vincent Bernat <bernat@debian.org>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --tar-ignore=.git --tar-ignore=.github --before-build .
dpkg-checkbuilddeps: error: Unmet build dependencies: libglib2.0-dev libip4tc-dev libipset-dev libjson-c-dev libnfnetlink-dev libnftnl-dev libnl-3-dev libnl-genl-3-dev libnl-nf-3-dev libpopt-dev libsnmp-dev libssl-dev libsystemd-dev
dpkg-buildpackage: warning: build dependencies/conflicts unsatisfied; aborting
dpkg-buildpackage: warning: (Use -d flag to override.)
Command 'dpkg-buildpackage -uc -us -tc -F --source-option=--tar-ignore=.git --source-option=--tar-ignore=.github' returned non-zero exit status 3.
I: Source packages build failed, ignoring - building binaries only
dpkg-buildpackage: info: source package keepalived
dpkg-buildpackage: info: source version 1:2.3.3-1
dpkg-buildpackage: info: source distribution unstable
dpkg-buildpackage: info: source changed by Vincent Bernat <bernat@debian.org>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --before-build .
dpkg-checkbuilddeps: error: Unmet build dependencies: libglib2.0-dev libip4tc-dev libipset-dev libjson-c-dev libnfnetlink-dev libnftnl-dev libnl-3-dev libnl-genl-3-dev libnl-nf-3-dev libpopt-dev libsnmp-dev libssl-dev libsystemd-dev
dpkg-buildpackage: warning: build dependencies/conflicts unsatisfied; aborting
dpkg-buildpackage: warning: (Use -d flag to override.)
Failed to build package keepalived: Command 'dpkg-buildpackage -uc -us -tc -b' returned non-zero exit status 3.
I: Cleaned up build dependency packages
vyos_bld@2788c7dc4314:/vyos/work/tmp/vyos-build/scripts/package-build/keepalived$ 

```

After the fix:
```
vyos_bld@2788c7dc4314:/vyos/work/tmp/T8132/vyos-build/scripts/package-build/keepalived$ ls -l *.deb
-rw-r--r-- 1 vyos_bld vyos_bld  587864 Dec 29 14:59 keepalived_2.3.3-1_amd64.deb
-rw-r--r-- 1 vyos_bld vyos_bld 1050572 Dec 29 14:59 keepalived-dbgsym_2.3.3-1_amd64.deb
vyos_bld@2788c7dc4314:/vyos/work/tmp/T8132/vyos-build/scripts/package-build/keepalived$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
