### PR TITLE
T8185: correct the install path of config.boot.default entries defined in flavor files

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -586,7 +586,17 @@ DOCUMENTATION_URL="{build_config['documentation_url']}"
         ## Create includes
         if has_nonempty_key(build_config, "includes_chroot"):
             for i in build_config["includes_chroot"]:
-                file_path = os.path.join(chroot_includes_dir, i["path"])
+                check_path = i["path"]
+                # T8185: flavor definition files containing a default config
+                # under [[includes_chroot]] may need corrected install path
+                if check_path == 'opt/vyatta/etc/config.boot.default':
+                    file_path = os.path.join(
+                        chroot_includes_dir,
+                        directories['data'].lstrip(os.sep),
+                        'config.boot.default'
+                    )
+                else:
+                    file_path = os.path.join(chroot_includes_dir, check_path)
                 if debug:
                     print(f"D: Creating chroot include file: {file_path}")
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)

--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -97,6 +97,7 @@ import utils
 import raw_image
 
 from utils import cmd, rc_cmd
+from utils import directories
 
 ## Check if there are missing build dependencies
 deps = {
@@ -605,7 +606,11 @@ DOCUMENTATION_URL="{build_config['documentation_url']}"
         ## Technically it's just another includes.chroot entry,
         ## but it's special enough to warrant making it easier for flavor writers
         if has_nonempty_key(build_config, "default_config"):
-            file_path = os.path.join(chroot_includes_dir, "opt/vyatta/etc/config.boot.default")
+            file_path = os.path.join(
+                chroot_includes_dir,
+                directories['data'].lstrip(os.sep),
+                'config.boot.default'
+            )
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, 'w') as f:
                 f.write(build_config["default_config"])

--- a/scripts/image-build/utils.py
+++ b/scripts/image-build/utils.py
@@ -25,6 +25,9 @@ import shutil
 import defaults
 import vyos
 
+from vyos.defaults import directories
+
+
 def check_build_config():
     if not os.path.exists(defaults.BUILD_CONFIG):
         print("Build config file ({file}) does not exist".format(file=defaults.BUILD_CONFIG))


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

After T6006, the _build-time_ source of truth for `config.boot.default` should reside at
`/usr/share/vyos/config.boot.default`
_No_ file should be installed at
`/opt/vyatta/etc/config.boot.default`
as that is handled at initial boot by vyos-router.

Adjust the install path, as needed, for default configs defined by flavor definition files.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
