### PR TITLE
T8135: backport the fix for CVE-2025-68615 (DoS in snmptrapd)

### DIFF
--- a/scripts/package-build/net-snmp/patches/net-snmp/snmptrapd-fix-out-of-bounds-trapoid-acccess.patch
+++ b/scripts/package-build/net-snmp/patches/net-snmp/snmptrapd-fix-out-of-bounds-trapoid-acccess.patch
@@ -1,0 +1,30 @@
+From 307d1856a8d0ac0d32633ea79dd2bd368887f876 Mon Sep 17 00:00:00 2001
+From: Daniil Baturin <daniil@baturin.org>
+Date: Tue, 20 Jan 2026 14:57:10 +0000
+Subject: [PATCH] snmptrapd: Fix out-of-bounds trapOid[] accesses
+
+Based on the original patch for newer net-snmp by Bart Van Assche
+---
+ apps/snmptrapd_handlers.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/apps/snmptrapd_handlers.c b/apps/snmptrapd_handlers.c
+index 9496d31..bd4cc17 100644
+--- a/apps/snmptrapd_handlers.c
++++ b/apps/snmptrapd_handlers.c
+@@ -1112,6 +1112,13 @@ snmp_input(int op, netsnmp_session *session,
+ 	     */
+             if (pdu->trap_type == SNMP_TRAP_ENTERPRISESPECIFIC) {
+                 trapOidLen = pdu->enterprise_length;
++                /*
++                 * Drop packets that would trigger an out-of-bounds trapOid[]
++                 * access.
++                 */
++                if (trapOidLen < 1 || trapOidLen > OID_LENGTH(trapOid) - 2)
++                    return 1;
++
+                 memcpy(trapOid, pdu->enterprise, sizeof(oid) * trapOidLen);
+                 if (trapOid[trapOidLen - 1] != 0) {
+                     trapOid[trapOidLen++] = 0;
+-- 
+2.52.0


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This is a manual backport of the fix to net-snmp 5.9.4.

The history of that fix is:

* In https://github.com/net-snmp/net-snmp/commit/375984f4eb6e15c93fae2b6f82fb3174f81a85e6 , the author added a condition to ensure the OID length was no less than zero (insufficient because zero length triggers the bug).
* In https://github.com/net-snmp/net-snmp/commit/5bf2e55434c24d67627887ad6a5cd8fb5a2ad897 , the condition was corrected to `>=` to avoid handling zero-length OIDs.
* Both changes were later reverted: https://github.com/net-snmp/net-snmp/commit/3a58bc7ece9864891e15c861c55c570cbf2958fb
* They were reverted in favor of a different check for OID length before attempting to manipulate it in any way: https://github.com/net-snmp/net-snmp/commit/4a201ac239d2cedff32a9205d389fdb523487878

The relevant section in net-snmp's master branch is: https://github.com/net-snmp/net-snmp/blob/master/apps/snmptrapd_handlers.c#L1118-L1131

This PR includes a recreation of 4a201ac that applies to the older net-snmp version we use.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
