### PR TITLE
T8265: leave config path hint in raw image install_image

### DIFF
--- a/scripts/image-build/raw_image.py
+++ b/scripts/image-build/raw_image.py
@@ -19,6 +19,8 @@ import os
 import sys
 import shutil
 
+from pathlib import Path
+
 import vyos.utils.process
 
 import vyos.template
@@ -29,6 +31,7 @@ SQUASHFS_FILE = 'live/filesystem.squashfs'
 VERSION_FILE = 'version.json'
 
 from utils import cmd
+from utils import directories as vyos_dirs
 
 def mkdir(path):
     os.makedirs(path, exist_ok=True)
@@ -156,6 +159,13 @@ def install_image(con, version):
     for f in boot_files:
         print(f"I: Copying file {f}")
         shutil.copy(f, vyos_dir)
+
+    # Leave hint in config directory, to be found by subsequent
+    # installations searching for previous config data.
+    # This step is explicitly performed by image_installer.py.
+    config_path = Path(vyos_dir).joinpath(f'rw{vyos_dirs["config"]}')
+    Path(config_path).mkdir(parents=True, exist_ok=True)
+    Path(config_path).joinpath('.vyatta_config').touch()
 
     with open(f"{con.raw_dir}/persistence.conf", 'w') as f:
         f.write("/ union\n")


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When building the raw image, hence qcow2 image, leave the config path file hint `.vyatta_config`. This is used by any subsequent installs using op-mode `image_installer.py` to detect a previous installation.

Note this was a non-issue under the old packer build process, which used an explicit installation; nor is this missing hint of great concern in practice, but is useful for, say, a kvm flavor.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
