### PR TITLE
Makefile: T8294: autodetect CPU architecture for smoketests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 SHELL := /bin/bash
-
-arch ?= $(shell dpkg --print-architecture 2>/dev/null || echo amd64)
 build_dir := build
+
+ARCH := $(shell dpkg-architecture -qDEB_HOST_ARCH)
+ISO_PATH := $(build_dir)/live-image-$(ARCH).hybrid.iso
 
 .PHONY: all
 all:
@@ -14,60 +15,60 @@ all:
 .PHONY: checkiso
 .ONESHELL:
 checkiso:
-	if [ ! -f build/live-image-$(arch).hybrid.iso ]; then
-		echo "Could not find build/live-image-$(arch).hybrid.iso"
+	if [ ! -f $(ISO_PATH) ]; then
+		echo "Could not find $(ISO_PATH)"
 		exit 1
 	fi
 
 .PHONY: test
 .ONESHELL:
 test: checkiso
-	scripts/check-qemu-install --debug --configd --match="$(MATCH)" --smoketest --uefi --cpu 4 --memory 8 --iso build/live-image-amd64.hybrid.iso $(filter-out $@,$(MAKECMDGOALS))
+	scripts/check-qemu-install --debug --configd --match="$(MATCH)" --smoketest --uefi --cpu 4 --memory 8 --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: test-no-interfaces
 .ONESHELL:
 test-no-interfaces: checkiso
-	scripts/check-qemu-install --debug --configd --smoketest --uefi --no-interfaces --cpu 4 --memory 8 --huge-page-size 2M --huge-page-count 1800 --iso build/live-image-amd64.hybrid.iso
+	scripts/check-qemu-install --debug --configd --smoketest --uefi --no-interfaces --cpu 4 --memory 8 --huge-page-size 2M --huge-page-count 1800 --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: test-no-interfaces-no-vpp
 .ONESHELL:
 test-no-interfaces-no-vpp: checkiso
-	scripts/check-qemu-install --debug --configd --smoketest --uefi --no-interfaces --no-vpp --arch $(arch) --iso build/live-image-$(arch).hybrid.iso
+	scripts/check-qemu-install --debug --configd --smoketest --uefi --no-interfaces --no-vpp --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: test-interfaces
 .ONESHELL:
 test-interfaces: checkiso
-	scripts/check-qemu-install --debug --configd --match="interfaces_" --smoketest --uefi --iso build/live-image-amd64.hybrid.iso
+	scripts/check-qemu-install --debug --configd --match="interfaces_" --smoketest --uefi --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: test-vpp
 .ONESHELL:
 test-vpp: checkiso
-	scripts/check-qemu-install --debug --configd --match="vpp" --smoketest --uefi --cpu 4 --memory 8 --huge-page-size 2M --huge-page-count 1800 --iso build/live-image-amd64.hybrid.iso
+	scripts/check-qemu-install --debug --configd --match="vpp" --smoketest --uefi --cpu 4 --memory 8 --huge-page-size 2M --huge-page-count 1800 --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: testc
 .ONESHELL:
 testc: checkiso
-	scripts/check-qemu-install --debug --configd --match="!vpp" --cpu 2 --memory 7 --configtest --iso build/live-image-amd64.hybrid.iso $(filter-out $@,$(MAKECMDGOALS))
+	scripts/check-qemu-install --debug --configd --match="!vpp" --cpu 2 --memory 7 --configtest --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: testcvpp
 .ONESHELL:
 testcvpp: checkiso
-	scripts/check-qemu-install --debug --configd --match="vpp" --cpu 4 --memory 8 --huge-page-size 2M --huge-page-count 1800 --configtest --iso build/live-image-amd64.hybrid.iso $(filter-out $@,$(MAKECMDGOALS))
+	scripts/check-qemu-install --debug --configd --match="vpp" --cpu 4 --memory 8 --huge-page-size 2M --huge-page-count 1800 --configtest --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: testraid
 .ONESHELL:
 testraid: checkiso
-	scripts/check-qemu-install --debug --configd --raid --iso build/live-image-amd64.hybrid.iso $(filter-out $@,$(MAKECMDGOALS))
+	scripts/check-qemu-install --debug --configd --raid --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: testsb
 .ONESHELL:
 testsb: checkiso
-	scripts/check-qemu-install --debug --uefi --sbtest --iso build/live-image-amd64.hybrid.iso $(filter-out $@,$(MAKECMDGOALS))
+	scripts/check-qemu-install --debug --uefi --sbtest --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: testtpm
 .ONESHELL:
 testtpm: checkiso
-	scripts/check-qemu-install --debug --tpmtest --iso build/live-image-amd64.hybrid.iso $(filter-out $@,$(MAKECMDGOALS))
+	scripts/check-qemu-install --debug --tpmtest --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: test-ci-qcow2
 .ONESHELL:
@@ -76,18 +77,18 @@ test-ci-qcow2:
 		echo "Could not find any QCOW2 disk image"
 		exit 1
 	fi
-	rm -f cloud-init-image-amd64.qcow2 ; cp $$(ls -t build/*.qcow2 | head -n 1) cloud-init-image-amd64.qcow2
-	scripts/check-qemu-install --debug --cloud-init --disk cloud-init-image-amd64.qcow2 $(filter-out $@,$(MAKECMDGOALS))
+	rm -f cloud-init-image-$(ARCH).qcow2 ; cp $$(ls -t build/*.qcow2 | head -n 1) cloud-init-image-$(ARCH).qcow2
+	scripts/check-qemu-install --debug --cloud-init --disk cloud-init-image-$(ARCH).qcow2 $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: qemu-live
 .ONESHELL:
 qemu-live: checkiso
-	scripts/check-qemu-install --qemu-cmd --iso build/live-image-amd64.hybrid.iso $(filter-out $@,$(MAKECMDGOALS))
+	scripts/check-qemu-install --qemu-cmd --iso $(ISO_PATH) $(filter-out $@,$(MAKECMDGOALS))
 
 .PHONY: oci
 .ONESHELL:
 oci: checkiso
-	scripts/iso-to-oci build/live-image-amd64.hybrid.iso
+	scripts/iso-to-oci $(ISO_PATH)
 
 .PHONY: clean
 .ONESHELL:

--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -43,6 +43,7 @@ import logging
 import re
 import shutil
 import json
+import platform
 
 from io import BytesIO
 from datetime import datetime
@@ -84,21 +85,20 @@ mok_password = '1234'
 
 # Map QEMU arch
 QEMU_CONFIG = {
-    "amd64": {
-        "bin": "qemu-system-x86_64",
-        "machine": "pc",
-        "bios": "/usr/share/OVMF/OVMF_CODE.fd",
+    'amd64': {
+        'bin' : 'qemu-system-x86_64',
+        'machine' : 'pc',
+        'bios' : '/usr/share/OVMF/OVMF_CODE.fd',
     },
     "arm64": {
-        "bin": "qemu-system-aarch64",
-        "machine": "virt",
-        "bios": "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
+        'bin': 'qemu-system-aarch64',
+        'machine': 'virt,highmem=on',
+        'bios': '/usr/share/qemu-efi-aarch64/QEMU_EFI.fd',
     },
 }
 
 parser = argparse.ArgumentParser(description='Install and start a test VyOS vm.')
 parser.add_argument('--iso', help='ISO file to install')
-parser.add_argument('--arch', help='Architecture')
 parser.add_argument('--disk', help='name of disk image file', nargs='?')
 parser.add_argument('--keep', help='Do not remove disk-image after installation',
                               action='store_true', default=False)
@@ -188,10 +188,18 @@ def get_qemu_cmd(name, enable_uefi, disk_img, raid=None, iso_img=None, tpm=False
     uefi = ""
     uuid = "f48b60b2-e6ad-49ef-9d09-4245d0585e52"
     accel = ',accel=kvm' if _kvm_exists() else ''
-    arch = getattr(args, 'arch', 'amd64')
-    qemu_arch_config = QEMU_CONFIG.get(arch, QEMU_CONFIG['amd64'])
+
+    if platform.machine() in ['amd64', 'x86_64']:
+        architecture = 'amd64'
+    elif platform.machine() in ['arm64', 'aarch64']:
+        architecture = 'arm64'
+    else:
+        raise ValueError('Unsupported architecture!')
+
+    qemu_arch_config = QEMU_CONFIG[architecture]
     qemu_bin = qemu_arch_config['bin']
     bios = qemu_arch_config['bios']
+
     cpu_type = args.cpu_type
     enable_kvm = '-enable-kvm' if _kvm_exists() else ''
     machine = qemu_arch_config['machine']
@@ -216,15 +224,11 @@ def get_qemu_cmd(name, enable_uefi, disk_img, raid=None, iso_img=None, tpm=False
 
     cdrom = ""
     if iso_img:
-        cdrom = f' -drive file={iso_img},format=raw,if=none,media=cdrom,id=drive-cd1,readonly=on' \
-                f' -device ahci,id=achi0' \
-                f' -device ide-cd,bus=achi0.0,drive=drive-cd1,id=cd1,bootindex=10'
-
-        if arch == 'arm64':
-            cdrom = (
-                f' -drive file={iso_img},format=raw,if=none,media=cdrom,id=drive-cd1,readonly=on'
-                f' -device scsi-cd,bus=scsi0.0,drive=drive-cd1,id=cd1,bootindex=10'
-            )
+        cdrom = f' -drive file={iso_img},format=raw,if=none,media=cdrom,id=drive-cd1,readonly=on'
+        if architecture == 'arm64':
+            cdrom = f' {cdrom} -device scsi-cd,bus=scsi0.0,drive=drive-cd1,id=cd1,bootindex=10'
+        else:
+            cdrom = f' {cdrom} -device ahci,id=achi0 -device ide-cd,bus=achi0.0,drive=drive-cd1,id=cd1,bootindex=10'
 
     # RFC7042 section 2.1.2 MAC addresses used for documentation
     macbase = '00:00:5E:00:53'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

We currently have hardcoded values for amd64 in our Makefile.

When calling the smoketests helpers like:
* `make testc`
* `make qemu-live`
* `make test-interfaces`

All expect an amd64 ISO file - if building and arm64 ISO image on an arm64 system, all those helpers do not work as it is hardcoded to amd64.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8294

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
