### PR TITLE
T8311: De-hardcode architecture for live-build-config

### DIFF
--- a/data/live-build-config/hooks/live/92-strip-symbols.chroot
+++ b/data/live-build-config/hooks/live/92-strip-symbols.chroot
@@ -9,6 +9,7 @@
 #
 
 # Set variables.
+MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
 STRIPCMD_REGULAR="strip --remove-section=.comment --remove-section=.note --preserve-dates"
 STRIPCMD_DEBUG="strip --strip-debug --remove-section=.comment --remove-section=.note --preserve-dates"
 STRIPCMD_UNNEEDED="strip --strip-unneeded --remove-section=.comment --remove-section=.note --preserve-dates"
@@ -20,7 +21,7 @@ STRIPDIR_UNNEEDED="
 /etc/hsflowd/modules
 /usr/bin
 /usr/lib/openvpn
-/usr/lib/x86_64-linux-gnu
+/usr/lib/${MULTIARCH}
 /usr/lib32
 /usr/lib64
 /usr/libx32

--- a/data/live-build-config/includes.chroot/etc/initramfs-tools/hooks/10-vyos-addons
+++ b/data/live-build-config/includes.chroot/etc/initramfs-tools/hooks/10-vyos-addons
@@ -1,4 +1,6 @@
 #!/bin/sh
+
+MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
 PREREQ=""
 prereqs()
 {
@@ -23,7 +25,7 @@ manual_add_modules igb ixgbe ixgbevf i40e i40evf
 # force_load xxx
 
 # executable to copy to initramfs, with library dependencies
-copy_exec /usr/lib/x86_64-linux-gnu/libnss_dns.so.2
+copy_exec /usr/lib/${MULTIARCH}/libnss_dns.so.2
 
 # missing fsck in initramfs
 copy_exec /usr/sbin/fsck


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
De-hardcode architecture for live-build-config hooks
```
vyos_bld@672bb64a4cb6:/vyos2/T8311/vyos-build$ dpkg-architecture -qDEB_HOST_MULTIARCH
aarch64-linux-gnu
vyos_bld@672bb64a4cb6:/vyos2/T8311/vyos-build$
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): De-hardcode arch for live-build-config

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8311

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
