### PR TITLE
T8311: fix initramfs hook "dpkg-architecture: command not found"

### DIFF
--- a/data/live-build-config/includes.chroot/etc/initramfs-tools/hooks/10-vyos-addons
+++ b/data/live-build-config/includes.chroot/etc/initramfs-tools/hooks/10-vyos-addons
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+MULTIARCH="$(uname -m)-linux-gnu"
 PREREQ=""
 prereqs()
 {


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit f4877564276947 ("T8311: De-hardcode arch for live-build-config 10-vyos-addons") introduced a regression where an unavailable third-party helper script was invoked during initramfs hook execution, breaking the ISO build process.

```
update-initramfs: Generating /boot/initrd.img-6.6.127-vyos
live-boot: core filesystems devices utils wget blockdev.
/etc/initramfs-tools/hooks/10-vyos-addons: line 3: dpkg-architecture: command not found
```

The `dpkg-architecture` helper, provided by the dpkg-dev package, is not available during hook execution. The same result can be achieved using GNU `coreutils` instead:

On x86_64 (aka amd64) both yield the same result:
```
$ echo $(uname -m)-linux-gnu
x86_64-linux-gnu
$ echo $(dpkg-architecture -qDEB_HOST_MULTIARCH)
x86_64-linux-gnu
```

On aarch64 (aka arm64) both yield the same result:
```
$ echo $(uname -m)-linux-gnu
aarch64-linux-gnu
$ echo $(dpkg-architecture -qDEB_HOST_MULTIARCH)
aarch64-linux-gnu
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8311

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1124
* https://github.com/vyos/vyos-build/pull/1125


## How to test / Smoketest result

After the fix, building a new ISO and navigation to the `live-boot` section shows no more errors:
```
update-initramfs: Generating /boot/initrd.img-6.6.124-vyos
live-boot: core filesystems devices utils wget blockdev.
(Reading database ... 29750 files and directories currently installed.)
Purging configuration files for smartmontools (7.3-1+b1) ...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
