### PR TITLE
T8311: move to GNU coreutils when building GLIBC multiarch variable

### DIFF
--- a/data/live-build-config/hooks/live/92-strip-symbols.chroot
+++ b/data/live-build-config/hooks/live/92-strip-symbols.chroot
@@ -9,7 +9,7 @@
 #
 
 # Set variables.
-MULTIARCH="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+MULTIARCH="$(uname -m)-linux-gnu"
 STRIPCMD_REGULAR="strip --remove-section=.comment --remove-section=.note --preserve-dates"
 STRIPCMD_DEBUG="strip --strip-debug --remove-section=.comment --remove-section=.note --preserve-dates"
 STRIPCMD_UNNEEDED="strip --strip-unneeded --remove-section=.comment --remove-section=.note --preserve-dates"

--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -637,7 +637,7 @@ DOCUMENTATION_URL="{build_config['documentation_url']}"
                 --checksums "sha256" \
                 --chroot-squashfs-compression-type "{{squashfs_compression_type}}" \
                 --debian-installer none \
-                --debootstrap-options "--variant=minbase --exclude=isc-dhcp-client,isc-dhcp-common,ifupdown --include=apt-utils,ca-certificates,gnupg2,linux-kbuild-6.1,dpkg-dev" \
+                --debootstrap-options "--variant=minbase --exclude=isc-dhcp-client,isc-dhcp-common,ifupdown --include=apt-utils,ca-certificates,gnupg2,linux-kbuild-6.1" \
                 --distribution "{{debian_distribution}}" \
                 --firmware-binary false \
                 --firmware-chroot false \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Related to commit 39dc9c98c68 (`T8311: fix initramfs hook "dpkg-architecture: command not found`). Drop dpkg-dev implementation in favour of GNU coreutils.

On x86_64 (aka amd64) both yield the same result:
```
$ echo $(uname -m)-linux-gnu
x86_64-linux-gnu
$ echo $(dpkg-architecture -qDEB_HOST_MULTIARCH)
x86_64-linux-gnu
```
On aarch64 (aka arm64) both yield the same result:
```
$ echo $(uname -m)-linux-gnu
aarch64-linux-gnu
$ echo $(dpkg-architecture -qDEB_HOST_MULTIARCH)
aarch64-linux-gnu
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8311

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1127


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
