### PR TITLE
oci: T8366: remove features from container image which are not supported

### DIFF
--- a/scripts/iso-to-oci
+++ b/scripts/iso-to-oci
@@ -48,6 +48,15 @@ rm -rf $UNSQUASHFS/usr/lib/x86_64-linux-gnu/libwireshark.so*
 rm -rf $UNSQUASHFS/lib/modules/*amd64-vyos
 rm -rf $UNSQUASHFS/root/.gnupg
 
+# delete features not supported in container - only remove the node.def files,
+# this is sufficient to not make the feature pop up on the CLI
+rm -rf $UNSQUASHFS/opt/vyatta/share/vyatta-cfg/templates/container
+rm -rf $UNSQUASHFS/opt/vyatta/share/vyatta-cfg/templates/system/option/kernel
+rm -rf $UNSQUASHFS/opt/vyatta/share/vyatta-cfg/templates/system/option/startup-beep
+rm -rf $UNSQUASHFS/opt/vyatta/share/vyatta-cfg/templates/system/option/root-partition-auto-resize
+rm -rf $UNSQUASHFS/opt/vyatta/share/vyatta-cfg/templates/system/option/reboot-on-panic
+rm -rf $UNSQUASHFS/opt/vyatta/share/vyatta-cfg/templates/system/option/performance
+
 # create a symbolic link to the configuration
 ln -s /opt/vyatta/etc/config $UNSQUASHFS/config
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Running containers on VyOS on a container platform seems like an odd use-case so we remove it in the beginning.

Also interacting with the Kernel and safety reboots will be removed from the "system options" tree.

* `system option kernel`
* `system option startup-beep`
* `system option root-partition-auto-resize`
* `system option reboot-on-panic`
* `system option performance`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Feature removal VyOS on container

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8366

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
