### PR TITLE
kea: T7853: Offer subnet for any interface address

### DIFF
--- a/scripts/package-build/isc-kea/.gitignore
+++ b/scripts/package-build/isc-kea/.gitignore
@@ -1,2 +1,2 @@
-isc-kea/
-kea-packaging/
+/isc-kea/
+/kea-packaging/

--- a/scripts/package-build/isc-kea/package.toml
+++ b/scripts/package-build/isc-kea/package.toml
@@ -2,4 +2,4 @@
 name = "isc-kea"
 commit_id = "Kea-3.0.2"
 scm_url = "https://gitlab.isc.org/isc-projects/kea.git"
-build_cmd = "cd ..; ./build.sh"
+pre_build_hook = "cd ..; ./prebuild.sh"

--- a/scripts/package-build/isc-kea/patches/isc-kea/0001-3162-Check-all-interface-addresses-for-matching-subn.patch
+++ b/scripts/package-build/isc-kea/patches/isc-kea/0001-3162-Check-all-interface-addresses-for-matching-subn.patch
@@ -1,0 +1,59 @@
+From 7d4662a0e26fae27583883a8c8138b62792fc3cf Mon Sep 17 00:00:00 2001
+From: sarthurdev <965089+sarthurdev@users.noreply.github.com>
+Date: Sat, 20 Sep 2025 23:00:20 +0200
+Subject: [PATCH] [#3162] Check all interface addresses for matching subnet
+
+---
+ src/lib/dhcpsrv/cfg_subnets4.cc | 31 +++++++++++++++++++------------
+ 1 file changed, 19 insertions(+), 12 deletions(-)
+
+diff --git a/src/lib/dhcpsrv/cfg_subnets4.cc b/src/lib/dhcpsrv/cfg_subnets4.cc
+index 13286bb6d4..f25349f63a 100644
+--- a/src/lib/dhcpsrv/cfg_subnets4.cc
++++ b/src/lib/dhcpsrv/cfg_subnets4.cc
+@@ -393,23 +393,30 @@ CfgSubnets4::selectSubnet(const SubnetSelector& selector) const {
+         if (subnet) {
+             return (subnet);
+         } else {
+-            // Let's try to get an address from the local interface and
+-            // try to match it to defined subnet.
+-            iface->getAddress4(address);
++            // Let's try to get addresses from the local interface and
++            // try to match one to a defined subnet.
++            for (auto const& addr : iface->getAddresses()) {
++
++                // We only care about IPv4 here
++                if (!addr.get().isV4()) {
++                    continue;
++                }
++
++                address = addr.get();
++                subnet = selectSubnet(address, selector.client_classes_);
++
++                if (subnet) {
++                    return (subnet);
++                }
++            }
+         }
+     }
+ 
+     // Unable to find a suitable address to use for subnet selection.
+-    if (address.isV4Zero()) {
+-        LOG_DEBUG(dhcpsrv_logger, DHCPSRV_DBG_TRACE,
+-                  DHCPSRV_SUBNET4_SELECT_NO_USABLE_ADDRESS);
+-
+-        return (ConstSubnet4Ptr());
+-    }
++    LOG_DEBUG(dhcpsrv_logger, DHCPSRV_DBG_TRACE,
++              DHCPSRV_SUBNET4_SELECT_NO_USABLE_ADDRESS);
+ 
+-    // We have identified an address in the client's packet that can be
+-    // used for subnet selection. Match this packet with the subnets.
+-    return (selectSubnet(address, selector.client_classes_));
++    return (ConstSubnet4Ptr());
+ }
+ 
+ ConstSubnet4Ptr
+-- 
+2.50.1 (Apple Git-155)
+

--- a/scripts/package-build/isc-kea/prebuild.sh
+++ b/scripts/package-build/isc-kea/prebuild.sh
@@ -25,6 +25,3 @@ sed -i '/usr\/share\/doc\/kea/d' debian/*.install
 echo "usr/share/doc/kea/*" >> debian/not-installed
 echo "usr/share/kea/meson-info/*" >> debian/not-installed
 rm -rf debian/isc-kea-doc.install debian/isc-kea-subscriber* debian/isc-kea-premium*
-
-sudo mk-build-deps --install --tool 'apt-get --yes --no-install-recommends'
-dpkg-buildpackage -uc -us -tc -b


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Introduce Kea patch to match subnet based on any interface address

Move repo prep to pre-build hook so patches can be applied and build using build.py

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
DHCP server config
```
set interfaces ethernet eth1 address 192.0.2.1/30
set interfaces ethernet eth1 address 100.64.0.1/24
set interfaces ethernet eth1 description LAN
set interfaces ethernet eth1 vrf red
set vrf bind-to-all
set vrf name red service dhcp-server listen-interface eth1
set vrf name red service dhcp-server shared-network-name LANv4 authoritative
set vrf name red service dhcp-server shared-network-name LANv4 subnet 100.64.0.0/24 range R1 start 100.64.0.10
set vrf name red service dhcp-server shared-network-name LANv4 subnet 100.64.0.0/24 range R1 stop 100.64.0.254
set vrf name red service dhcp-server shared-network-name LANv4 subnet 100.64.0.0/24 subnet-id 1
set vrf name red table 1010
```

Client post-fix:
```
[edit]
vyos@vyos# set interfaces ethernet eth1 address dhcp
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# run show interfaces ethernet eth1
eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether bc:24:11:7a:94:08 brd ff:ff:ff:ff:ff:ff
    altname enp0s19
    altname ens19
    inet 100.64.0.10/24 brd 100.64.0.255 scope global dynamic eth1
       valid_lft 86267sec preferred_lft 86267sec
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
