### PR TITLE
flavor: T8375: add flavor.json during build into resulting image

### DIFF
--- a/data/architectures/amd64.toml
+++ b/data/architectures/amd64.toml
@@ -12,4 +12,6 @@ packages = [
   "amd64-microcode"
 ]
 
-serial_interface = "ttyS0,115200"
+console_type = "ttyS"
+console_num = "0"
+console_speed = "115200"

--- a/data/architectures/arm64.toml
+++ b/data/architectures/arm64.toml
@@ -5,4 +5,7 @@ packages = [
 ]
 bootloaders = "grub-efi"
 squashfs_compression_type = "xz -b 256k -always-use-fragments -no-recovery"
-serial_interface = "ttyAMA0,115200"
+
+console_type = "ttyAMA"
+console_num = "0"
+console_speed = "115200"

--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -439,6 +439,12 @@ def build():
 
             build_config['version'] = version
 
+        flavor_data = {
+            'console_type': build_config["console_type"],
+            'console_num': build_config["console_num"],
+            'console_speed': build_config["console_speed"]
+        }
+
         version_data = {
             'version': version,
             'flavor': build_config["build_flavor"],
@@ -479,6 +485,8 @@ DOCUMENTATION_URL="{build_config['documentation_url']}"
         os.makedirs(vyos_data_dir, exist_ok=True)
         with open(os.path.join(vyos_data_dir, 'version.json'), 'w') as f:
             json.dump(version_data, f)
+        with open(os.path.join(vyos_data_dir, 'flavor.json'), 'w') as f:
+            json.dump(flavor_data, f)
         with open(os.path.join(binary_includes_dir, 'version.json'), 'w') as f:
             json.dump(version_data, f)
 
@@ -631,8 +639,8 @@ DOCUMENTATION_URL="{build_config['documentation_url']}"
                 --archive-areas "{{debian_archive_areas}}" \
                 --backports true \
                 --binary-image iso-hybrid \
-                --bootappend-live "boot=live components hostname=vyos username=live nopersistence noautologin nonetworking union=overlay console="{{serial_interface}}" console=tty0 net.ifnames=0 biosdevname=0" \
-                --bootappend-live-failsafe "live components memtest noapic noapm nodma nomce nolapic nomodeset nosmp nosplash vga=normal console="{{serial_interface}}" console=tty0 net.ifnames=0 biosdevname=0" \
+                --bootappend-live "boot=live components hostname=vyos username=live nopersistence noautologin nonetworking union=overlay console="{{console_type}}{{console_num}},{{console_speed}}" console=tty0 net.ifnames=0 biosdevname=0" \
+                --bootappend-live-failsafe "live components memtest noapic noapm nodma nomce nolapic nomodeset nosmp nosplash vga=normal console="{{console_type}}{{console_num}},{{console_speed}}" console=tty0 net.ifnames=0 biosdevname=0" \
                 --bootloaders "{{bootloaders}}" \
                 --checksums "sha256" \
                 --chroot-squashfs-compression-type "{{squashfs_compression_type}}" \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

In order for amd64 or arm64 images to know their serial console settings, we embed a new file named `flavor.json` under `/usr/share/vyos` into the resulting image. The file holds configuration parameters unique to the build flavor.
   
Corresponding library functions are available via a Python `vyos.flavor` module.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8375

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/5092

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
