### PR TITLE
Testsuite: T8375: verify proper serial console settings

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -535,6 +535,33 @@ def basic_cli_tests(c):
     c.sendline('show version all | grep -e "vpp" -e "vyos-1x"')
     c.expect(op_mode_prompt)
 
+    # Get serial console interface name from flavor definition
+    c.sendline('cat /usr/share/vyos/flavor.json | jq -r ".console_type"')
+    c.expect(op_mode_prompt)
+    lines = [l.strip() for l in c.before.splitlines() if l.strip()]
+    console_type = lines[-1].decode('utf-8').strip() # e.g. ttyS
+
+    c.sendline('cat /usr/share/vyos/flavor.json | jq -r ".console_num"')
+    c.expect(op_mode_prompt)
+    lines = [l.strip() for l in c.before.splitlines() if l.strip()]
+    console_num = lines[-1].decode('utf-8').strip() # e.g. 0
+
+    # Get serial console speed from flavor definition
+    c.sendline('cat /usr/share/vyos/flavor.json | jq -r ".console_speed"')
+    c.expect(op_mode_prompt)
+    lines = [l.strip() for l in c.before.splitlines() if l.strip()]
+    console_speed = lines[-1].decode('utf-8').strip() # e.g. 115200
+
+    # Ensure serial console with kernel option is set in CLI, done automatically by image installer
+    c.sendline('show configuration commands | match "system console"')
+    c.expect(rf'set system console device {console_type}{console_num} kernel\r\r\nset system console device {console_type}{console_num} speed \'{console_speed}\'')
+    c.expect(op_mode_prompt)
+
+    # Validate GRUB has the right console_type defined
+    c.sendline('cat /boot/grub/grub.cfg.d/20-vyos-defaults-autoload.cfg | grep "set console_type"')
+    c.expect(f'set console_type="{console_type}"')
+    c.expect(op_mode_prompt)
+
 if args.qemu_cmd:
     tmp = get_qemu_cmd(qemu_name, args.uefi, args.disk, raid=diskname_raid, iso_img=args.iso, vnc_enabled=args.vnc, secure_boot=args.sbtest)
     os.system(tmp)

--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -528,7 +528,7 @@ def basic_cli_tests(c):
     c.expect(op_mode_prompt)
     c.sendline('show system memory detail | no-more')
     c.expect(op_mode_prompt)
-    c.sendline('show configuration commands | match kernel')
+    c.sendline('show configuration commands | match "option kernel"')
     c.expect(op_mode_prompt)
     c.sendline('cat /proc/cmdline')
     c.expect(op_mode_prompt)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Now that the serial console definition is dynamically generated by the image installer, depending on the flavor data, it is time to validate the resulting CLI nodes and GRUB config.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8375

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1152
* https://github.com/vyos/vyos-1x/pull/5092
* https://github.com/vyos/vyos-documentation/pull/1820

## How to test / Smoketest result

Embedded into the smoketest platform, e.g. `make testc`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
