### PR TITLE
ddclient: T6981: Upgrade ddclient to v4.0.0

### DIFF
--- a/scripts/package-build/ddclient/package.toml
+++ b/scripts/package-build/ddclient/package.toml
@@ -1,4 +1,4 @@
 [[packages]]
 name = "ddclient"
-commit_id = "debian/3.11.2-1"
+commit_id = "ae21b1deee"
 scm_url = "https://salsa.debian.org/debian/ddclient"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Upgrade ddclient to version 4.0.0.

Details provided in the [linked PR](vyos/vyos-1x/pull/5123).

Note: We moved from [GitHub](https://github.com/ddclient/ddclient) to [Debian Salsa](https://salsa.debian.org/debian/ddclient) in the past to pull in ddclient source. However, Debian Salsa doesn't catch up with GitHub releases that often. We are still using Debian Salsa as our source (because it has all the necessary Debian packaging toolchain setup), but are using a non-tagged (but stable) commit id to pull in the sources in combination with the necessary patches for the build.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6981

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
vyos/vyos-1x/pull/5123

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest
-->

```
vyos@current-2604:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_dynamic.py 
test_01_dyndns_service_standard (__main__.TestServiceDDNS.test_01_dyndns_service_standard) ... ok
test_02_dyndns_service_ipv6 (__main__.TestServiceDDNS.test_02_dyndns_service_ipv6) ... ok
test_03_dyndns_service_dual_stack (__main__.TestServiceDDNS.test_03_dyndns_service_dual_stack) ... ok
test_04_dyndns_rfc2136 (__main__.TestServiceDDNS.test_04_dyndns_rfc2136) ... ok
test_05_dyndns_hostname (__main__.TestServiceDDNS.test_05_dyndns_hostname) ... ok
test_06_dyndns_web_options (__main__.TestServiceDDNS.test_06_dyndns_web_options) ... ok
test_07_dyndns_dynamic_interface (__main__.TestServiceDDNS.test_07_dyndns_dynamic_interface) ... ok
test_08_dyndns_vrf (__main__.TestServiceDDNS.test_08_dyndns_vrf) ... ok

----------------------------------------------------------------------
Ran 8 tests in 524.777s

OK
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
