### PR TITLE
T8531: restrict Mergify commands to maintainers team

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,3 +8,19 @@ pull_request_rules:
       label:
         toggle:
           - conflicts
+
+commands_restrictions:
+  backport: &allowed
+    conditions:
+      - or:
+        - sender=@vyos/maintainers
+        - sender=vyosbot
+  copy: *allowed
+  dequeue: *allowed
+  queue: *allowed
+  rebase: *allowed
+  refresh: *allowed
+  requeue: *allowed
+  squash: *allowed
+  unqueue: *allowed
+  update: *allowed


### PR DESCRIPTION
## Summary

Append `commands_restrictions` block to `.github/mergify.yml`, restricting the 10 Mergify slash commands (backport, copy, dequeue, queue, rebase, refresh, requeue, squash, unqueue, update) to members of the `@vyos/maintainers` team, plus the `vyosbot` automation account.

## Test plan

- [ ] Non-maintainer comments `@Mergifyio backport sagitta` on a PR → Mergify refuses
- [ ] Maintainer comments the same → backport PR created
- [ ] Existing conflict-labeling rule continues to fire on conflicting PRs

## References

- Ticket: [T8531](https://vyos.dev/T8531)
- Mergify docs: https://docs.mergify.com/commands/restrictions/

🤖 Generated by [robots](https://vyos.io)