### PR TITLE
hooks: T8541: inject flavor serial console settings once into config.boot.default

### DIFF
--- a/data/live-build-config/hooks/live/95-serial.chroot
+++ b/data/live-build-config/hooks/live/95-serial.chroot
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# We do have different default console configurations per flavor used. We will
+# set the serial console to the default configuration for the flavor.
+WRITE_CONFIG="/usr/libexec/vyos/write-config-file-value.py"
+if ! test -x $WRITE_CONFIG; then
+    echo "E: missing script to implant serial config settings"
+    exit 1
+fi
+
+default_config_file=$(python3 -c 'from vyos.defaults import config_default; print(config_default)')
+device=$(jq -r '"\(.console_type)\(.console_num)"' /usr/share/vyos/flavor.json)
+speed=$(jq -r '.console_speed' /usr/share/vyos/flavor.json)
+
+if [ -n "$device" ] && [ -n "$speed" ] && [ -f $default_config_file ]; then
+    $WRITE_CONFIG --path "system console device $device speed" \
+        --value "$speed" \
+        --config-file $default_config_file
+    $WRITE_CONFIG --path "system console device $device kernel" \
+        --config-file $default_config_file
+else
+    echo "E: Could not implant serial console settings in: $default_config_file"
+    exit 1
+fi


### PR DESCRIPTION
We do have different default console configurations per flavor used. We will set the serial console to the default configuration for the flavor once during ISO image assembly.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8541

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/5146

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
