### PR TITLE
linux-kernel: T8506: Use scripts/kconfig/merge_config.sh for merging kernel config fragments

### DIFF
--- a/scripts/package-build/linux-kernel/build-kernel.sh
+++ b/scripts/package-build/linux-kernel/build-kernel.sh
@@ -26,27 +26,31 @@ KERNEL_SUFFIX=-$(awk -F "= " '/kernel_flavor/ {print $2}' ../../../../data/defau
 
 echo "I: Generate Kernel config"
 ARCH=$(dpkg --print-architecture)
+# array to hold config fragments for merging
+# allows safe handling of paths with spaces and avoids word-splitting issues
+# The first entry is the base defconfig; subsequent entries are merged on top.
+KCONFIG_MERGE_FRAGMENTS=()
 if [ "${ARCH}" = "arm64" ]; then
-    KERNEL_CONFIG=arch/arm64/configs/vyos_defconfig
-    cp ${CWD}/config/arm64/vyos_defconfig ${KERNEL_CONFIG}
+    KCONFIG_MERGE_FRAGMENTS+=("${CWD}/config/arm64/vyos_defconfig")
 elif [ "${ARCH}" = "amd64" ]; then
-    KERNEL_CONFIG=arch/x86/configs/vyos_defconfig
-    cp ${CWD}/config/x86/vyos_defconfig ${KERNEL_CONFIG}
+    KCONFIG_MERGE_FRAGMENTS+=("${CWD}/config/x86/vyos_defconfig")
 else
     echo "E: unsupported architecture"
     exit 1
 fi
-
-for KRN_CONF_SNIPPET in $(ls ${CWD}/config/*.config)
-do
-    echo "I: adding configuration snippet ${KRN_CONF_SNIPPET}"
-    cat ${KRN_CONF_SNIPPET} >> ${KERNEL_CONFIG}
-done
+# NOTE: do NOT export KCONFIG_CONFIG here. KCONFIG_CONFIG is interpreted by
+# kbuild as the path to the OUTPUT .config file. Exporting it globally would
+# cause `make vyos_defconfig` (and the rest of the kernel build) to write the
+# resulting config to that path instead of producing a normal `.config` in the
+# kernel source root, which breaks downstream steps that expect `linux/.config`
+# to exist.
 
 # VyOS requires some small Kernel Patches - apply them here
 # It's easier to have them here and make use of the upstream
 # repository instead of maintaining a full Kernel Fork.
 # Saving time/resources is essential :-)
+# Note that the patches should be applied BEFORE the kernel config is generated
+# because patches may add new options!
 PATCH_DIR=${CWD}/patches/kernel
 for patch in $(ls ${PATCH_DIR})
 do
@@ -62,19 +66,51 @@ TRUSTED_KEYS_FILE=trusted_keys.pem
 echo -n "" > $TRUSTED_KEYS_FILE
 GIT_ROOT=$(git rev-parse --show-toplevel)
 CERTS=$(find ${GIT_ROOT}/data/certificates -name "*.pem" -type f || true)
+TRUSTED_KEYS_FRAGMENT_TMP=""
 if [ ! -z "${CERTS}" ]; then
   # add known public keys to Kernel certificate chain
   for file in $CERTS; do
     cat $file >> $TRUSTED_KEYS_FILE
   done
   # Force Kernel module signing and embed public keys
-  echo "CONFIG_SYSTEM_TRUSTED_KEYRING" >> $KERNEL_CONFIG
-  echo "CONFIG_SYSTEM_TRUSTED_KEYS=\"$TRUSTED_KEYS_FILE\"" >> $KERNEL_CONFIG
+  TRUSTED_KEYS_FRAGMENT_TMP=$(mktemp --suffix=.config)
+  echo "CONFIG_SYSTEM_TRUSTED_KEYRING=y" > $TRUSTED_KEYS_FRAGMENT_TMP
+  echo "CONFIG_SYSTEM_TRUSTED_KEYS=\"$TRUSTED_KEYS_FILE\"" >> $TRUSTED_KEYS_FRAGMENT_TMP
 fi
 
-echo "I: make vyos_defconfig"
-# Select Kernel configuration - currently there is only one
-make vyos_defconfig
+echo "I: Merge Kernel config snippets"
+# Collect config fragments into the fragment array
+for fragment in "${CWD}"/config/*.config; do
+    [ -f "${fragment}" ] || continue
+    echo "I: adding configuration snippet ${fragment}"
+    KCONFIG_MERGE_FRAGMENTS+=("${fragment}")
+done
+if [ -n "${TRUSTED_KEYS_FRAGMENT_TMP}" ]; then
+    echo "I: adding configuration snippet ${TRUSTED_KEYS_FRAGMENT_TMP}"
+    KCONFIG_MERGE_FRAGMENTS+=("${TRUSTED_KEYS_FRAGMENT_TMP}")
+fi
+
+# Use the kernel's own merge_config.sh to properly merge all config fragments.
+# This writes .config into the current (kernel source) dir.
+# The first fragment in the array is the base defconfig; the remaining ones
+# are merged on top of it. merge_config.sh will run `make alldefconfig` at
+# the end to expand defaults, this replaces the previous separate
+# `make vyos_defconfig` step.
+# This will contain some warnings about "<symbol> not in final .config"
+# which can mostly be ignored, but may provide relevant insight so we
+# don't suppress it.
+echo "I: Run scripts/kconfig/merge_config.sh to produce .config"
+
+if [ ${#KCONFIG_MERGE_FRAGMENTS[@]} -eq 0 ]; then
+    echo "E: No config fragments found for merging, cannot proceed"
+    exit 1
+fi
+scripts/kconfig/merge_config.sh "${KCONFIG_MERGE_FRAGMENTS[@]}"
+
+if [ ! -f .config ]; then
+    echo "E: merge_config.sh did not produce a .config in $(pwd)"
+    exit 1
+fi
 
 echo "I: Generate environment file containing Kernel variable"
 EPHEMERAL_KEY="/tmp/ephemeral.key"
@@ -94,7 +130,7 @@ make bindeb-pkg BUILD_TOOLS=1 LOCALVERSION=${KERNEL_SUFFIX} KDEB_PKGVERSION=${KE
 
 # Back to the old Kernel build-scripts directory
 cd $CWD
-EPHEMERAL_KERNEL_KEY=$(grep -E "^CONFIG_MODULE_SIG_KEY=" ${KERNEL_SRC}/$KERNEL_CONFIG | awk -F= '{print $2}' | tr -d \")
+EPHEMERAL_KERNEL_KEY=$(grep -E "^CONFIG_MODULE_SIG_KEY=" "${KERNEL_SRC}/.config" | awk -F= '{print $2}' | tr -d \")
 if test -f "${EPHEMERAL_KEY}"; then
     rm -f ${EPHEMERAL_KEY}
 fi


### PR DESCRIPTION
Using `scripts/kconfig/merge_config.sh` for merging config fragments provides validation and insights compared to the previously used simple concatenation

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
`scripts/package-build/linux-kernel/build-kernel.sh`  has been adjusted to use kernel's `scripts/kconfig/merge_config.sh` to merge config fragments

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8506

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
...I built a functional kernel.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
