### PR TITLE
linux-kernel: T8496: Add kernel config needed for PWRU

### DIFF
--- a/scripts/package-build/linux-kernel/config/30-pwru.config
+++ b/scripts/package-build/linux-kernel/config/30-pwru.config
@@ -1,0 +1,20 @@
+# Prerequisites for the PWRU (https://github.com/cilium/pwru) flags
+
+# Explicitly need to disable / remove this value from defconfig
+# "... is not set" will remove from the config and not throw an error compared to
+# "... = n"
+# CONFIG_DEBUG_INFO_NONE is not set
+
+# Explicitly need to enable debug info
+CONFIG_DEBUG_INFO=y
+# let the toolchain decide DWARF4 vs DWARF5
+CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y
+
+# PWRU flags copied directly from PWRU readme
+CONFIG_DEBUG_INFO_BTF=y
+CONFIG_KPROBES=y
+CONFIG_PERF_EVENTS=y
+CONFIG_BPF=y
+CONFIG_BPF_SYSCALL=y
+CONFIG_FUNCTION_TRACER=y
+CONFIG_FPROBE=y


### PR DESCRIPTION
PWRU (https://github.com/cilium/pwru) is a very useful tool to debug complex networking issues on Linux, as it allows you to trace how packets travel through the kernel functions

## Change summary
This PR adds the kernel flags required for PWRU

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): Additional Kernel Flags enabling debug functionality

## Related Task(s)
https://vyos.dev/T8496

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@vyos-test-01:/config$ uname -r
6.6.135-vyos+test2
vyos@vyos-test-01:/config$ sudo ./pwru --output-limit-lines 5
2026/04/27 19:44:40 Attaching kprobes (via kprobe-multi)...
1388 / 1388 [--------------------------------------------------------------------------------------------------] 100.00% ? p/s
2026/04/27 19:44:40 Attached (ignored 0)
2026/04/27 19:44:40 Listening for events..
SKB                CPU PROCESS          NETNS      MARK/x        IFACE       PROTO  MTU   LEN   TUPLE FUNC
0xffff8efadaeeea00 1   ~/sbin/sshd:3330 0          0               0         0x0000 0     0     :0->:0() __build_skb_around
0xffff8efadaeeea00 1   ~/sbin/sshd:3330 0          0               0         0x0000 0     0     :0->:0() tcp_skb_entail
0xffff8efadaeeea00 1   ~/sbin/sshd:3330 0          0               0         0x0000 0     252   :0->:0() __tcp_transmit_skb
0xffff8efadaeeea00 1   ~/sbin/sshd:3330 0          0               0         0x0000 0     252   :0->:0() skb_clone
0xffff8efadaeeeae8 1   ~/sbin/sshd:3330 4026531840 0             eth0:2      0x0800 9170  192   10.151.0.31:43008->10.151.0.1:4789(udp) __skb_clone
2026/04/27 19:44:40 Printed 5 events, exiting program..
2026/04/27 19:44:40 Detaching kprobes...
5 / 5 [-------------------------------------------------------------------------------------------------------] 100.00% 23 p/s
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
