### PR TITLE
T8636: add FRR patches that fix pathd no cmds

### DIFF
--- a/scripts/package-build/frr/patches/frr/0021-pathd-add-optional-protocol-to-no-mpls-te-import.patch
+++ b/scripts/package-build/frr/patches/frr/0021-pathd-add-optional-protocol-to-no-mpls-te-import.patch
@@ -1,0 +1,177 @@
+From fb892c9871e984fed3e240f4b4da5089dd9cbd8f Mon Sep 17 00:00:00 2001
+From: Kyrylo Yatsenko <hedrok@gmail.com>
+Date: Mon, 20 Apr 2026 23:02:27 +0300
+Subject: [PATCH 1/2] pathd: add optional protocol to 'no mpls-te import'
+
+Command `mpls-te import ospfv2|ospfv3|isis` had `no` version without
+last option, so frr-reload.py failed when it was removed.
+
+To fix:
+* Merge `no` and not `no` versions
+* Make protocol optional parameter in case of `no`
+* If protocol is given in `no` version, check that currently import for
+  this protocol is activated, otherwise ignore command.
+* Create helper function `path_ted_start_importing_igp`.
+
+Signed-off-by: Kyrylo Yatsenko <hedrok@gmail.com>
+---
+ pathd/path_ted.c | 92 ++++++++++++++++++++++++++++--------------------
+ 1 file changed, 53 insertions(+), 39 deletions(-)
+
+diff --git a/pathd/path_ted.c b/pathd/path_ted.c
+index a7442e7080..caa19178fd 100644
+--- a/pathd/path_ted.c
++++ b/pathd/path_ted.c
+@@ -25,11 +25,12 @@
+ static struct ls_ted *path_ted_create_ted(void);
+ static void path_ted_register_vty(void);
+ static void path_ted_unregister_vty(void);
+-static uint32_t path_ted_start_importing_igp(const char *daemon_str);
++static uint32_t path_ted_start_importing_igp(enum igp_import daemon);
+ static uint32_t path_ted_stop_importing_igp(void);
+ static enum zclient_send_status path_ted_link_state_sync(void);
+ static void path_ted_timer_handler_sync(struct event *thread);
+ static void path_ted_timer_handler_refresh(struct event *thread);
++static enum igp_import str2igp_import(const char *str);
+ 
+ extern struct zclient *pathd_zclient;
+ 
+@@ -66,18 +67,18 @@ uint32_t path_ted_teardown(void)
+  * @return		true if ok
+  *
+  */
+-uint32_t path_ted_start_importing_igp(const char *daemon_str)
++uint32_t path_ted_start_importing_igp(enum igp_import daemon)
+ {
+ 	uint32_t status = 0;
+ 
+-	if (strcmp(daemon_str, "ospfv2") == 0)
+-		ted_state_g.import = IMPORT_OSPFv2;
+-	else if (strcmp(daemon_str, "ospfv3") == 0) {
+-		ted_state_g.import = IMPORT_UNKNOWN;
+-		return 1;
+-	} else if (strcmp(daemon_str, "isis") == 0)
+-		ted_state_g.import = IMPORT_ISIS;
+-	else {
++	switch (daemon) {
++	case IMPORT_OSPFv2:
++	case IMPORT_ISIS:
++		ted_state_g.import = daemon;
++		break;
++	case IMPORT_OSPFv3:
++	case IMPORT_UNKNOWN:
++	default:
+ 		ted_state_g.import = IMPORT_UNKNOWN;
+ 		return 1;
+ 	}
+@@ -406,7 +407,8 @@ DEFUN (no_path_ted,
+ /* clang-format off */
+ DEFPY(path_ted_import,
+        path_ted_import_cmd,
+-       "mpls-te import <ospfv2|ospfv3|isis>$import_daemon",
++       "[no] mpls-te import ![ospfv2|ospfv3|isis]$import_daemon",
++       NO_STR
+        "Enable the TE database (TED) fill with remote igp data\n"
+        "import\n"
+        "Origin ospfv2\n"
+@@ -414,34 +416,32 @@ DEFPY(path_ted_import,
+        "Origin isis\n")
+ /* clang-format on */
+ {
+-
+-	if (ted_state_g.enabled)
+-		if (path_ted_start_importing_igp(import_daemon)) {
+-			vty_out(vty, "Unable to start importing\n");
+-			return CMD_WARNING;
+-		}
+-	return CMD_SUCCESS;
+-}
+-
+-/* clang-format off */
+-DEFUN (no_path_ted_import,
+-       no_path_ted_import_cmd,
+-       "no mpls-te import",
+-       NO_STR
+-       NO_STR
+-       "Disable the TE Database fill with remote igp data\n")
+-/* clang-format on */
+-{
+-
+-	if (ted_state_g.import) {
+-		if (path_ted_stop_importing_igp()) {
+-			vty_out(vty, "Unable to stop importing\n");
+-			return CMD_WARNING;
++	enum igp_import daemon;
++
++	if (no) {
++		if (ted_state_g.import) {
++			/* If no import_daemon given - disable current, otherwise check */
++			if (import_daemon != NULL) {
++				daemon = str2igp_import(import_daemon);
++				if (daemon != ted_state_g.import) {
++					PATH_TED_DEBUG("%s: PATHD-TED: Requested to disable import for %s, but import is active for another daemon. Ignoring.",
++						       __func__, import_daemon);
++					return CMD_SUCCESS;
++				}
++			}
++			if (path_ted_stop_importing_igp()) {
++				vty_out(vty, "Unable to stop importing\n");
++				return CMD_WARNING;
++			}
+ 		} else {
+-			PATH_TED_DEBUG(
+-				"%s: PATHD-TED: Importing igp data already OFF",
+-				__func__);
++			PATH_TED_DEBUG("%s: PATHD-TED: Importing igp data already OFF", __func__);
+ 		}
++	} else {
++		if (ted_state_g.enabled)
++			if (path_ted_start_importing_igp(str2igp_import(import_daemon))) {
++				vty_out(vty, "Unable to start importing\n");
++				return CMD_WARNING;
++			}
+ 	}
+ 	return CMD_SUCCESS;
+ }
+@@ -505,6 +505,22 @@ uint32_t path_ted_config_write(struct vty *vty)
+ 	return 0;
+ }
+ 
++/**
++ * Convert string to igp_import
++ */
++static enum igp_import str2igp_import(const char *str)
++{
++	if (!str)
++		return IMPORT_UNKNOWN;
++	if (strcmp(str, "isis") == 0)
++		return IMPORT_ISIS;
++	else if (strcmp(str, "ospfv2") == 0)
++		return IMPORT_OSPFv2;
++	else if (strcmp(str, "ospfv3") == 0)
++		return IMPORT_OSPFv3;
++	return IMPORT_UNKNOWN;
++}
++
+ /**
+  * Register the fn's for CLI and hook for config show
+  *
+@@ -517,7 +533,6 @@ static void path_ted_register_vty(void)
+ 	install_element(SR_TRAFFIC_ENG_NODE, &path_ted_on_cmd);
+ 	install_element(SR_TRAFFIC_ENG_NODE, &no_path_ted_cmd);
+ 	install_element(SR_TRAFFIC_ENG_NODE, &path_ted_import_cmd);
+-	install_element(SR_TRAFFIC_ENG_NODE, &no_path_ted_import_cmd);
+ 
+ 	install_element(CONFIG_NODE, &debug_path_ted_cmd);
+ 	install_element(ENABLE_NODE, &debug_path_ted_cmd);
+@@ -537,7 +552,6 @@ static void path_ted_unregister_vty(void)
+ 	uninstall_element(SR_TRAFFIC_ENG_NODE, &path_ted_on_cmd);
+ 	uninstall_element(SR_TRAFFIC_ENG_NODE, &no_path_ted_cmd);
+ 	uninstall_element(SR_TRAFFIC_ENG_NODE, &path_ted_import_cmd);
+-	uninstall_element(SR_TRAFFIC_ENG_NODE, &no_path_ted_import_cmd);
+ }
+ 
+ /**
+-- 
+2.51.2
+

--- a/scripts/package-build/frr/patches/frr/0022-pathd-add-optional-parameters-to-no-index-cmd.patch
+++ b/scripts/package-build/frr/patches/frr/0022-pathd-add-optional-parameters-to-no-index-cmd.patch
@@ -1,0 +1,93 @@
+From f53e78b89a08d9dfaeb58789567429b714112470 Mon Sep 17 00:00:00 2001
+From: Kyrylo Yatsenko <hedrok@gmail.com>
+Date: Wed, 22 Apr 2026 09:32:22 +0300
+Subject: [PATCH 2/2] pathd: add optional parameters to `no index` cmd
+
+`no index` didn't have all parameters of `index` command, so
+frr-reload.py had problems with that.
+
+Merge `no index` and `index` commands to fix this. `no` version ignores
+all additional parameters, which are made optional in case of `no`.
+
+Signed-off-by: Kyrylo Yatsenko <hedrok@gmail.com>
+---
+ pathd/path_cli.c | 36 ++++++++++++------------------------
+ 1 file changed, 12 insertions(+), 24 deletions(-)
+
+diff --git a/pathd/path_cli.c b/pathd/path_cli.c
+index 7eeec7b40e..e81ead545e 100644
+--- a/pathd/path_cli.c
++++ b/pathd/path_cli.c
+@@ -486,15 +486,16 @@ int segment_list_has_prefix(
+  */
+ /* clang-format off */
+ DEFPY_YANG(srte_segment_list_segment, srte_segment_list_segment_cmd,
+-      "index (0-4294967295)$index <[mpls$has_mpls_label label (16-1048575)$label] "
++      "[no] index (0-4294967295)$index ![mpls$has_mpls_label label (16-1048575)$label"
+       "|"
+-      "[nai$has_nai <"
++      "nai$has_nai <"
+       "prefix <A.B.C.D/M$prefix_ipv4|X:X::X:X/M$prefix_ipv6>"
+       "<algorithm$has_algo (0-1)$algo| iface$has_iface_id (0-4294967295)$iface_id>"
+       "| adjacency$has_adj "
+       "<A.B.C.D$adj_src_ipv4 A.B.C.D$adj_dst_ipv4|X:X::X:X$adj_src_ipv6 X:X::X:X$adj_dst_ipv6>"
+-      ">]"
+-      ">",
++      ">"
++      "]",
++      NO_STR
+       "Index\n"
+       "Index Value\n"
+       "MPLS or IP Label\n"
+@@ -518,8 +519,13 @@ DEFPY_YANG(srte_segment_list_segment, srte_segment_list_segment_cmd,
+ 	char xpath[XPATH_MAXLEN];
+ 	int status = CMD_SUCCESS;
+ 
+-
+ 	snprintf(xpath, sizeof(xpath), "./segment[index='%s']", index_str);
++
++	if (no) {
++		nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
++		return nb_cli_apply_changes(vty, NULL);
++	}
++
+ 	nb_cli_enqueue_change(vty, xpath, NB_OP_CREATE, NULL);
+ 
+ 	if (has_mpls_label != NULL) {
+@@ -549,21 +555,6 @@ DEFPY_YANG(srte_segment_list_segment, srte_segment_list_segment_cmd,
+ 	return nb_cli_apply_changes(vty, NULL);
+ }
+ 
+-DEFPY_YANG(srte_segment_list_no_segment,
+-      srte_segment_list_no_segment_cmd,
+-      "no index (0-4294967295)$index",
+-      NO_STR
+-      "Index\n"
+-      "Index Value\n")
+-{
+-	char xpath[XPATH_MAXLEN];
+-
+-	snprintf(xpath, sizeof(xpath), "./segment[index='%s']", index_str);
+-	nb_cli_enqueue_change(vty, xpath, NB_OP_DESTROY, NULL);
+-
+-	return nb_cli_apply_changes(vty, NULL);
+-}
+-
+ void cli_show_srte_segment_list_segment(struct vty *vty,
+ 					const struct lyd_node *dnode,
+ 					bool show_defaults)
+@@ -1364,10 +1355,7 @@ void path_cli_init(void)
+ 	install_element(SEGMENT_ROUTING_NODE, &sr_no_traffic_eng_cmd);
+ 	install_element(SR_TRAFFIC_ENG_NODE, &srte_segment_list_cmd);
+ 	install_element(SR_TRAFFIC_ENG_NODE, &srte_no_segment_list_cmd);
+-	install_element(SR_SEGMENT_LIST_NODE,
+-			&srte_segment_list_segment_cmd);
+-	install_element(SR_SEGMENT_LIST_NODE,
+-			&srte_segment_list_no_segment_cmd);
++	install_element(SR_SEGMENT_LIST_NODE, &srte_segment_list_segment_cmd);
+ 	install_element(SR_TRAFFIC_ENG_NODE, &srte_policy_cmd);
+ 	install_element(SR_TRAFFIC_ENG_NODE, &srte_no_policy_cmd);
+ 	install_element(SR_POLICY_NODE, &srte_policy_name_cmd);
+-- 
+2.51.2
+


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

My changes for `no index *` and `no mpls-te-import *` are now merged in upstream FRR, so I'm adding two commits as patches:

7735ca88019a4fc6a9affee9df276b9c99773148
    pathd: add optional parameters to `no index` cmd
d421a3360bdb6eba18777388325b003b8bc985bc:
    pathd: add optional protocol to 'no mpls-te import'

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8636

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

As described in task.

1. Enable pathd in /etc/frr/daemons
2. Add
```
!
segment-routing
 traffic-eng
  mpls-te on
  mpls-te import ospfv2
  segment-list sl1
   index 25 mpls label 500
  exit
 exit
exit
!
```
to /etc/frr/frr.conf
3. Run `systemctl restart frr`
4. Make sure new configuration was loaded: `vtysh -c 'write terminal'`
5. cp /etc/frr/frr.conf frr.conf
6. Change frr.conf to have:
```
!
segment-routing
 traffic-eng
  mpls-te on
  segment-list sl1
   index 25 mpls label 700
  exit
 exit
exit
!
```
7. Run `sudo /usr/lib/frr/frr-reload.py --reload frr.conf`. Before fix commands `no mpls-te import ospfv2` and `no index 25 mpls label 500` failed, with these patches - runs ok.
8. Make sure reload was successful with `vtysh -c 'write terminal'`



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
