### PR TITLE
T8599: Make source packages required and fix them

### DIFF
--- a/scripts/package-build/build.py
+++ b/scripts/package-build/build.py
@@ -136,9 +136,26 @@ def build_package(package: list, patch_dir: Path) -> None:
             if (repo_dir / 'patches'):
                 apply_patches(repo_dir, patch_dir / repo_name)
 
-        # Sanitize the commit ID and build a tarball for the package
-        commit_id_sanitized = package['commit_id'].replace('/', '_')
-        tarball_name = f"{repo_name}_{commit_id_sanitized}.tar.gz"
+        # Create original tarball for dpkg-source to be happy
+        package_version = run(['dpkg-parsechangelog', '--show-field', 'Version', '--file', repo_dir / 'debian/changelog'], capture_output=True, check=False)
+        if package_version.stdout:
+            package_version = package_version.stdout.decode().strip()
+            package_version = package_version.rsplit('-', maxsplit=1)[0]
+            if ':' in package_version:
+                package_version = package_version.split(':', maxsplit=1)[1]
+        else:
+            # On failure fallback to sanitized commit ID
+            package_version = package['commit_id'].replace('/', '_')
+
+        package_name = run(['dpkg-parsechangelog', '--show-field', 'Source', '--file', repo_dir / 'debian/changelog'], capture_output=True, check=False)
+        if package_name.stdout:
+            package_name = package_name.stdout.decode().strip()
+        else:
+            # On failure fallback to repo name
+            package_name = repo_name
+
+        # Build a tarball for the package
+        tarball_name = f'{package_name}_{package_version}.orig.tar.gz'
         run(['tar', '--exclude=.git', '--exclude=.github', '-czf', tarball_name, '-C', str(repo_dir.parent), repo_name], check=True)
         print(f"I: Tarball created: {tarball_name}")
 
@@ -151,18 +168,18 @@ def build_package(package: list, patch_dir: Path) -> None:
             try:
                 run('sudo mk-build-deps --install --tool "apt-get --yes --no-install-recommends"', cwd=repo_dir, check=True, shell=True)
                 run('sudo dpkg -i *build-deps*.deb', cwd=repo_dir, check=True, shell=True)
+                # Clean up or dpkg-source will see this as changes to binary files
+                cleanup_build_deps(repo_dir)
             except CalledProcessError as e:
                 print(f"Failed to build package {repo_name}: {e}")
 
         # Build the package, check if we have build_cmd in the package.toml
         try:
-            build_cmd = package.get('build_cmd', 'dpkg-buildpackage -uc -us -tc -F --source-option=--tar-ignore=.git --source-option=--tar-ignore=.github')
+            build_cmd = package.get('build_cmd', r'dpkg-buildpackage -uc -us -tc -F --source-option=--tar-ignore=.git --source-option=--tar-ignore=.github --source-option=--extend-diff-ignore="^\.github(?:/.*)?$"')
             run(build_cmd, cwd=repo_dir, check=True, shell=True)
         except CalledProcessError as e:
-            print(e)
-            print("I: Source packages build failed, ignoring - building binaries only")
-            build_cmd = package.get('build_cmd', 'dpkg-buildpackage -uc -us -tc -b')
-            run(build_cmd, cwd=repo_dir, check=True, shell=True)
+            print(f"E: Package build failed for package '{repo_name}': {e}")
+            sys.exit(1)
 
     except CalledProcessError as e:
         print(f"Failed to build package {repo_name}: {e}")
@@ -176,8 +193,9 @@ def cleanup_build_deps(repo_dir: Path) -> None:
     """Clean up build dependency packages"""
     try:
         if repo_dir.exists():
-            for file in glob.glob(str(repo_dir / '*build-deps*.deb')):
-                os.remove(file)
+            for suffix in ('deb', 'buildinfo', 'changes'):
+                for file in glob.glob(str(repo_dir / f'*build-deps*.{suffix}')):
+                    os.remove(file)
             print("I: Cleaned up build dependency packages")
     except Exception as e:
         print(f"Error cleaning up build dependencies: {e}")

--- a/scripts/package-build/build.py
+++ b/scripts/package-build/build.py
@@ -153,8 +153,17 @@ def build_package(package: list, patch_dir: Path) -> None:
             # On failure fallback to repo name
             package_name = repo_name
 
+        # 1.0 version needs 'native' format - without '.orig'
+        # 3.0 needs '.orig'
+        source_format_suffix = ''
+        if (repo_dir / 'debian/source/format').exists():
+            with open(repo_dir / 'debian/source/format') as f:
+                source_format_version = f.read()
+                if '3.0' in source_format_version:
+                    source_format_suffix = '.orig'
+
         # Build a tarball for the package
-        tarball_name = f'{package_name}_{package_version}.orig.tar.gz'
+        tarball_name = f'{package_name}_{package_version}{source_format_suffix}.tar.gz'
         run(['tar', '--exclude=.git', '--exclude=.github', '-czf', tarball_name, '-C', str(repo_dir.parent), repo_name], check=True)
         print(f"I: Tarball created: {tarball_name}")
 

--- a/scripts/package-build/build.py
+++ b/scripts/package-build/build.py
@@ -120,8 +120,7 @@ def build_package(package: list, patch_dir: Path) -> None:
                 print(f'I: execute pre_build_hook for the package "{repo_name}"')
                 run(pre_build_hook, cwd=repo_dir, check=True, shell=True)
             except CalledProcessError as e:
-                print(e)
-                print(f"I: pre_build_hook failed for the {repo_name}")
+                print(f"E: pre_build_hook failed for the {repo_name}")
                 raise
 
         # Apply patches if the 'apply_patches' key is set to True (default) in the package configuration
@@ -171,18 +170,20 @@ def build_package(package: list, patch_dir: Path) -> None:
                 # Clean up or dpkg-source will see this as changes to binary files
                 cleanup_build_deps(repo_dir)
             except CalledProcessError as e:
-                print(f"Failed to build package {repo_name}: {e}")
+                print(f"E: Failed to create/install dependency package for {repo_name}: {e}")
+                raise
 
         # Build the package, check if we have build_cmd in the package.toml
         try:
-            build_cmd = package.get('build_cmd', r'dpkg-buildpackage -uc -us -tc -F --source-option=--tar-ignore=.git --source-option=--tar-ignore=.github --source-option=--extend-diff-ignore="^\.github(?:/.*)?$"')
+            build_cmd = package.get('build_cmd', r'dpkg-buildpackage -uc -us -tc -F --source-option=--tar-ignore=.git --source-option=--tar-ignore=.github --source-option=-i --source-option=--extend-diff-ignore="^\.github(?:/.*)?$"')
             run(build_cmd, cwd=repo_dir, check=True, shell=True)
         except CalledProcessError as e:
-            print(f"E: Package build failed for package '{repo_name}': {e}")
-            sys.exit(1)
+            print(f"E: Build command failed for '{repo_name}': {build_cmd}")
+            raise
 
     except CalledProcessError as e:
         print(f"Failed to build package {repo_name}: {e}")
+        sys.exit(1)
     finally:
         # Clean up repository directory
         # shutil.rmtree(repo_dir, ignore_errors=True)

--- a/scripts/package-build/dropbear/package.toml
+++ b/scripts/package-build/dropbear/package.toml
@@ -2,6 +2,7 @@
 name = "dropbear"
 commit_id = "debian/2022.83-1+deb12u1"
 scm_url = "https://salsa.debian.org/debian/dropbear.git"
+build_cmd = "dpkg-buildpackage -us -uc -tc -b"
 
 [dependencies]
 packages = ["libpam0g-dev"]


### PR DESCRIPTION
## Change summary

T8599: Make source packages required and fix them

A lot of packages failed to build source package.
Stop ignoring source package build errors and fix it.
Also removes rerun when `build_cmd` was used - because of this patch application problems were hidden.

To fix source packages:

* Use <source_package>_<upstream_version>.orig.tar.gz naming for source archive.
* Get `source_package` and `upstream_version` from changelog using dpkg-parsechangelog utility
* Clean build-deps after usage or dpkg-source sees these files as changes relative to upstream.
* Add '.github' to --diff-ignore source option

When patch fails to apply exit with error instead of ignoring it.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): fix source packages build

## Related Task(s)

* https://vyos.dev/T8599

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

Source packages problem:
Try to build `ddclient`, there is message that source package build failed.
After PR: source package build succeeds.

Problem with applying patches in FRR:

Add failing patch, try to build. Result before this PR:

```
dpkg-source: info: applying 0004-does-not-apply.patch
patching file ospf6d/ospf6_auth_trailer.c
Hunk #1 succeeded at 534 (offset -19 lines).
Hunk #2 FAILED at 572.
1 out of 2 hunks FAILED
dpkg-source: info: the patch has fuzz which is not allowed, or is malformed
dpkg-source: info: if patch '0004-does-not-apply.patch' is correctly applied by quilt, use 'quilt refresh' to update it
dpkg-source: info: if the file is present in the unpacked source, make sure it is also present in the orig tarball
dpkg-source: info: restoring quilt backup files for 0004-does-not-apply.patch
dpkg-source: error: LC_ALL=C patch -t -F 0 -N -p1 -u -V never -E -b -B .pc/0004-does-not-apply.patch/ --reject-file=- < frr/debian/patches/0004-does-not-apply.patch subprocess returned exit status 1
dpkg-buildpackage: error: dpkg-source --before-build . subprocess returned exit status 2
```

Inside of build log - package builds successfully, it is extremely easy not to see this.

With PR:

```
dpkg-source: error: LC_ALL=C patch -t -F 0 -N -p1 -u -V never -E -b -B .pc/0004-does-not-apply.patch/ --reject-file=- < frr/debian/patches/0004-does-not-apply.patch subprocess returned exit status 1
dpkg-buildpackage: error: dpkg-source --before-build . subprocess returned exit status 2
Command 'sudo dpkg -i ../*.deb; dpkg-buildpackage -us -uc -tc -b -Ppkg.frr.rtrlib,pkg.frr.lua' returned non-zero exit status 2.
E: Source packages build failed, possibly patches problem
```

With failure.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
