### PR TITLE
kernel: T8847: Enable PSI metric data

### DIFF
--- a/scripts/package-build/linux-kernel/config/80-psi.config
+++ b/scripts/package-build/linux-kernel/config/80-psi.config
@@ -1,0 +1,5 @@
+#
+# Enable Pressure Stall Information (PSI) metrics
+#
+# See: https://docs.kernel.org/accounting/psi.html
+CONFIG_PSI=y


### PR DESCRIPTION
## Change summary

Enable the kernel [Pressure Stall Information][PSI] accounting feature. This allows users to gather data on CPU and memory starvation. It's very useful to help find cases where the system performance is impacted by overloaded CPUs.

[PSI]: https://docs.kernel.org/accounting/psi.html

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
* https://docs.kernel.org/accounting/psi.html
* https://facebookmicrosites.github.io/psi/docs/overview

## How to test / Smoketest result
Simple check to see if the values show up in `/proc`.
```
cat /proc/pressure/cpu
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
