### PR TITLE
serial: T8844: fix default config injection leading to invalid boot console

### DIFF
--- a/data/live-build-config/hooks/live/95-serial.chroot
+++ b/data/live-build-config/hooks/live/95-serial.chroot
@@ -2,22 +2,28 @@
 
 # We do have different default console configurations per flavor used. We will
 # set the serial console to the default configuration for the flavor.
-WRITE_CONFIG="/usr/libexec/vyos/write-config-file-value.py"
+WRITE_CONFIG=$(python3 -c 'from vyos.defaults import base_dir; print(f"{base_dir}/write-config-file-value.py")')
 if ! test -x $WRITE_CONFIG; then
     echo "E: missing script to implant serial config settings"
     exit 1
 fi
 
 default_config_file=$(python3 -c 'from vyos.defaults import config_default; print(config_default)')
-device=$(jq -r '"\(.console_type)\(.console_num)"' /usr/share/vyos/flavor.json)
-speed=$(jq -r '.console_speed' /usr/share/vyos/flavor.json)
+flavor_file=$(python3 -c 'from vyos.defaults import directories; print(directories["data"] + "flavor.json" )')
+console_type=$(jq -r '.console_type' $flavor_file)
+device=$(jq -r '"\(.console_type)\(.console_num)"' $flavor_file)
+speed=$(jq -r '.console_speed' $flavor_file)
 
-if [ -n "$device" ] && [ -n "$speed" ] && [ -f $default_config_file ]; then
+# Serial console settings apply only to hardware serial (x86) or UART (ARM).
+if [ "$console_type" != ttyS ] && [ "$console_type" != ttyAMA ]; then
+    echo "I: Skipping serial console implant (console_type=$console_type is not ttyS or ttyAMA)"
+elif [ -n "$device" ] && [ -n "$speed" ] && [ -f $default_config_file ]; then
     $WRITE_CONFIG --path "system console device $device speed" \
         --value "$speed" \
         --config-file $default_config_file
     $WRITE_CONFIG --path "system console device $device kernel" \
         --config-file $default_config_file
+    echo "I: Changed serial console settings in: $default_config_file to $device,$speed"
 else
     echo "E: Could not implant serial console settings in: $default_config_file"
     exit 1


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

With all the latest serial interface changes - and the resulting patching of the default configuration based on the build flavor - the serial console was always injected by a helper named `write-config-file-value.py`, even if the `console_type` was set to tty instead of `ttyS` or `ttyAMA`.

This was a pending issue in the rolling tests for the PROXMOX flavor. It is applicable to every other flavor using `tty` as default console.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8844

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/5193

## How to test / Smoketest result

```
DEBUG - vyos@vyos-CLOUD-INIT:~$ cat /usr/share/vyos/flavor.json | jq -r ".console_type"
DEBUG - cat /usr/share/vyos/flavor.json | jq -r ".console_type"
DEBUG - tty
DEBUG - vyos@vyos-CLOUD-INIT:~$ ip --json addr show dev eth0 | jq -r '.[0].addr_info[] | select(.family=="inet") | "\(.local)/\(.prefixlen)"'
 select(.family=="inet") | "\(.local)/\(.prefixlen)"'dr_info[] |
DEBUG - 192.0.2.1/25
DEBUG - vyos@vyos-CLOUD-INIT:~$ ip --json addr show dev eth0 | jq -r '.[0].addr_info[] | select(.family=="inet6" and .scope=="global" and (.temporary|not)) | "\(.local)/\(.prefixlen)"'
/\(.prefixlen)"'="inet6" and .scope=="global" and (.temporary|not)) | "\(.local)
DEBUG - 2001:db8::1/64
DEBUG - vyos@vyos-CLOUD-INIT:~$ ip -4 --json route show default | jq -r ".[0].gateway"
DEBUG - ip -4 --json route show default | jq -r ".[0].gateway"
DEBUG - 192.0.2.126
DEBUG - vyos@vyos-CLOUD-INIT:~$ip -6 --json route show default | jq -r ".[0].gateway"
DEBUG -  ip -6 --json route show default | jq -r ".[0].gateway"
DEBUG - 2001:db8::ffff
 INFO - Powering off system
DEBUG - vyos@vyos-CLOUD-INIT:~$ poweroff now
 INFO - Shutting down virtual machine
 INFO - Waiting for shutdown...
DEBUG - poweroff now
 INFO - Waiting for shutdown...
DEBUG - poweroff now
 INFO - VM is shut down!
 INFO - Cleaning up
 INFO - Removing disk file: cloud-init-image-amd64.qcow2
```

Smoketest `make 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
