### PR TITLE
Kernel: T8880: reduce size of Kernel source TAR

### DIFF
--- a/scripts/package-build/linux-kernel/build.py
+++ b/scripts/package-build/linux-kernel/build.py
@@ -113,12 +113,15 @@ def create_tarball(package_name, source_dir=None):
         print(f"I: Failed to create tarball for {package_name}: {e}")
 
 
-def build_package(package: dict, dependencies: list) -> None:
+def build_package(package: dict, dependencies: list,
+                  linux_kernel_tarball: dict | None = None) -> None:
     """Build a package from the repository
 
     Args:
         package (dict): Package information
         dependencies (list): List of additional dependencies
+        linux_kernel_tarball (dict | None): If set, successful ``build_kernel`` fills this
+            for a final-stage tarball after all packages complete.
     """
     timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
     repo_name = package['name']
@@ -135,7 +138,11 @@ def build_package(package: dict, dependencies: list) -> None:
         # Execute the build command
         if package['build_cmd'] == 'build_kernel':
             source_dir = build_kernel(package['kernel_version'])
-            create_tarball(f'{package["name"]}-{package["kernel_version"]}', source_dir)
+            if linux_kernel_tarball is not None:
+                linux_kernel_tarball.clear()
+                linux_kernel_tarball['package_name'] = package['name']
+                linux_kernel_tarball['kernel_version'] = package['kernel_version']
+                linux_kernel_tarball['source_dir'] = source_dir
         elif package['build_cmd'] == 'build_linux_firmware':
             build_linux_firmware(package['commit_id'], package['scm_url'])
             create_tarball(f'{package["name"]}-{package["commit_id"]}', f'{package["name"]}')
@@ -293,11 +300,24 @@ if __name__ == '__main__':
     # Merge defaults into each package
     packages = [merge_dicts(defaults, pkg) for pkg in packages]
 
+    linux_kernel_tarball: dict = {}
+
     for package in packages:
         dependencies = package.get('dependencies', {}).get('packages', [])
 
         # Build the package
-        build_package(package, dependencies)
+        build_package(package, dependencies, linux_kernel_tarball)
 
         # Copy generated .deb packages to parent directory
         copy_packages(Path(package['name']))
+
+    if linux_kernel_tarball:
+        source_dir = linux_kernel_tarball['source_dir']
+        trusted_keys = f'{source_dir}/trusted_keys.pem'
+        if os.path.exists(trusted_keys):
+            os.remove(trusted_keys)
+        run(['make', '-C', source_dir, 'mrproper'], check=True)
+        create_tarball(
+            f'{linux_kernel_tarball["package_name"]}-{linux_kernel_tarball["kernel_version"]}',
+            source_dir,
+        )


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Enable `make mrproper` before packaging kernel source tarball. After enabling PWRU support in T8496, the auto-generated kernel source tarball grew from under 1 GB to ~4 GB, largely due to intermediate build artifacts (for example, vmlinuz.o growing from 54 MB to 618 MB with additional debug symbols).

Since the tarball is intended to contain kernel sources and custom patches and not intermediate objects, we now clean the tree with `make mrproper` before creating the tarball. This keeps package size down while preserving rebuildability.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8880

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-build/pull/1170
* https://github.com/vyos/vyos-build/pull/1177

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
