### PR TITLE
T6455: build zerotier-one with extosdep support

### DIFF
--- a/scripts/package-build/zerotier-one/package.toml
+++ b/scripts/package-build/zerotier-one/package.toml
@@ -3,15 +3,17 @@ name = "zerotier-one"
 commit_id = "1.16.0"
 scm_url = "https://github.com/zerotier/ZeroTierOne.git"
 
+pre_build_hook = "git apply ../patches/zerotier-one/0001-extosdep-config-update-nudge.patch"
+
 build_cmd = """
-make -j"$(nproc)" ZT_SSO_SUPPORTED=0
+make -j"$(nproc)" ZT_EXTOSDEP=1 ZT_SSO_SUPPORTED=0
 mkdir -p tmp/usr/sbin
 install -m0755 zerotier-one tmp/usr/sbin/zerotier-one
 ln -s /usr/sbin/zerotier-one tmp/usr/sbin/zerotier-cli
 ln -s /usr/sbin/zerotier-one tmp/usr/sbin/zerotier-idtool
 
 fpm --input-type dir --output-type deb --name zerotier-one \
-    --version "1.16.0" --deb-compression gz \
+    --version "1.16.0" --iteration "vyos1" --deb-compression gz \
     --maintainer "VyOS Package Maintainers <maintainers@vyos.net>" \
     --description "ZeroTier virtual networking daemon" \
     --license "MPL-2.0" --chdir tmp .

--- a/scripts/package-build/zerotier-one/patches/zerotier-one/0001-extosdep-config-update-nudge.patch
+++ b/scripts/package-build/zerotier-one/patches/zerotier-one/0001-extosdep-config-update-nudge.patch
@@ -63,10 +63,10 @@ index d7028902c..c1951239f 100644
  	static bool mgmtRecv(void* cookie, void* data, unsigned long len, std::function<unsigned(unsigned, const std::string&, const std::string&, std::string&)>);
  	static bool mgmtWritable(void*);
 diff --git a/service/OneService.cpp b/service/OneService.cpp
-index 227b575f7..d93758649 100644
+index 41d790516..ea8e4ce3c 100644
 --- a/service/OneService.cpp
 +++ b/service/OneService.cpp
-@@ -3607,6 +3607,9 @@ class OneServiceImpl : public OneService {
+@@ -3599,6 +3599,9 @@ class OneServiceImpl : public OneService {
  #endif
  					syncManagedStuff(n, true, true, true);
  					n.tap()->setMtu(nwc->mtu);
@@ -76,7 +76,7 @@ index 227b575f7..d93758649 100644
  				}
  				else {
  					_nets.erase(nwid);
-@@ -3619,6 +3622,9 @@ class OneServiceImpl : public OneService {
+@@ -3611,6 +3614,9 @@ class OneServiceImpl : public OneService {
  				if (n.tap()) {	 // sanity check
  #if defined(__WINDOWS__) && ! defined(ZT_SDK)
  					std::string winInstanceId(((WindowsEthernetTap*)(n.tap().get()))->instanceId());

--- a/scripts/package-build/zerotier-one/patches/zerotier-one/0001-extosdep-config-update-nudge.patch
+++ b/scripts/package-build/zerotier-one/patches/zerotier-one/0001-extosdep-config-update-nudge.patch
@@ -1,5 +1,5 @@
 diff --git a/osdep/ExtOsdep.cpp b/osdep/ExtOsdep.cpp
-index 4efab5a6c..7550cf55a 100644
+index 4efab5a6c..771668d72 100644
 --- a/osdep/ExtOsdep.cpp
 +++ b/osdep/ExtOsdep.cpp
 @@ -256,6 +256,18 @@ bool ExtOsdep::getBindAddrs(std::map<InetAddress, std::string>& ret)
@@ -21,6 +21,14 @@ index 4efab5a6c..7550cf55a 100644
  ExtOsdepTap::ExtOsdepTap(
  	const char* homePath,
  	const MAC& mac,
+@@ -499,6 +511,7 @@ bool ExtOsdepTap::removeIp(const InetAddress& ip)
+ 	for (auto i = allIps.begin(); i != allIps.end(); ++i) {
+ 		if (*i == ip) {
+ 			doRemoveIp(*i);
++			allIps.erase(i);
+ 			return true;
+ 		}
+ 	}
 diff --git a/osdep/ExtOsdep.hpp b/osdep/ExtOsdep.hpp
 index d7028902c..c1951239f 100644
 --- a/osdep/ExtOsdep.hpp

--- a/scripts/package-build/zerotier-one/patches/zerotier-one/0001-extosdep-config-update-nudge.patch
+++ b/scripts/package-build/zerotier-one/patches/zerotier-one/0001-extosdep-config-update-nudge.patch
@@ -1,0 +1,80 @@
+diff --git a/osdep/ExtOsdep.cpp b/osdep/ExtOsdep.cpp
+index 4efab5a6c..7550cf55a 100644
+--- a/osdep/ExtOsdep.cpp
++++ b/osdep/ExtOsdep.cpp
+@@ -256,6 +256,18 @@ bool ExtOsdep::getBindAddrs(std::map<InetAddress, std::string>& ret)
+ 	return resp->result;
+ }
+ 
++void ExtOsdep::configUpdate(uint64_t nwid, uint64_t revision)
++{
++	zt_eod_msg_configupdate msg;
++	memset(&msg, 0, sizeof(msg));
++	msg.cmd = ZT_EOD_MSG_CONFIGUPDATE;
++	msg.nwid = nwid;
++	msg.revision = revision;
++
++	Mutex::Lock l(eodMutex);
++	__eodSend(msg);
++}
++
+ ExtOsdepTap::ExtOsdepTap(
+ 	const char* homePath,
+ 	const MAC& mac,
+diff --git a/osdep/ExtOsdep.hpp b/osdep/ExtOsdep.hpp
+index d7028902c..c1951239f 100644
+--- a/osdep/ExtOsdep.hpp
++++ b/osdep/ExtOsdep.hpp
+@@ -34,6 +34,7 @@
+ #define ZT_EOD_MSG_ADDROUTERESP		17
+ #define ZT_EOD_MSG_DELROUTE			18
+ #define ZT_EOD_MSG_DELROUTERESP		19
++#define ZT_EOD_MSG_CONFIGUPDATE		20
+ 
+ struct zt_eod_msg_addtap {
+ 	unsigned char cmd;
+@@ -105,6 +106,12 @@ struct zt_eod_msg_route {
+ 	unsigned char src[16];
+ } __attribute__((packed));
+ 
++struct zt_eod_msg_configupdate {
++	unsigned char cmd;
++	uint64_t nwid;
++	uint64_t revision;
++} __attribute__((packed));
++
+ struct zt_eod_mgmt_req {
+ 	uint32_t method;
+ 	uint32_t pathlen;
+@@ -144,6 +151,7 @@ class ExtOsdep {
+ 
+ 	static void routeAddDel(bool, const InetAddress& target, const InetAddress& via, const InetAddress& src, const char* ifaceName);
+ 	static bool getBindAddrs(std::map<InetAddress, std::string>&);
++	static void configUpdate(uint64_t nwid, uint64_t revision);
+ 
+ 	static bool mgmtRecv(void* cookie, void* data, unsigned long len, std::function<unsigned(unsigned, const std::string&, const std::string&, std::string&)>);
+ 	static bool mgmtWritable(void*);
+diff --git a/service/OneService.cpp b/service/OneService.cpp
+index 227b575f7..d93758649 100644
+--- a/service/OneService.cpp
++++ b/service/OneService.cpp
+@@ -3607,6 +3607,9 @@ class OneServiceImpl : public OneService {
+ #endif
+ 					syncManagedStuff(n, true, true, true);
+ 					n.tap()->setMtu(nwc->mtu);
++#ifdef ZT_EXTOSDEP
++					ExtOsdep::configUpdate(nwid, (uint64_t)nwc->netconfRevision);
++#endif
+ 				}
+ 				else {
+ 					_nets.erase(nwid);
+@@ -3619,6 +3622,9 @@ class OneServiceImpl : public OneService {
+ 				if (n.tap()) {	 // sanity check
+ #if defined(__WINDOWS__) && ! defined(ZT_SDK)
+ 					std::string winInstanceId(((WindowsEthernetTap*)(n.tap().get()))->instanceId());
++#endif
++#ifdef ZT_EXTOSDEP
++					ExtOsdep::configUpdate(nwid, (uint64_t)n.config().netconfRevision);
+ #endif
+ 					*nuptr = (void*)0;
+ 					n.tap().reset();


### PR DESCRIPTION
## Summary

Build the ZeroTier agent package with extosdep (external interface mgmt) support for the alternative VyOS ZeroTier integration in vyos/vyos-1x#5211. Please consider that *before* merging this.

This also adds a small *optional* patch for the `CONFIGUPDATE` notification proposed upstream in zerotier/ZeroTierOne#2587.

## Changes

- Build `zerotier-one` with `ZT_EXTOSDEP=1` and `ZT_SSO_SUPPORTED=0`.
- Apply the minimal extosdep config-update/IP-bookkeeping patch before the custom `make`/`fpm` build.
- Add package iteration `vyos1` so the patched build is distinguishable.