### PR TITLE
T8943: migrate branch refs current->rolling (rollout 1c)

### DIFF
--- a/.github/workflows/check-unused-imports.yml
+++ b/.github/workflows/check-unused-imports.yml
@@ -2,7 +2,7 @@ name: Check for unused imports using Pylint
 on:
   pull_request:
     branches:
-      - current
+      - rolling
       - sagitta
       - equuleus
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@ name: "Perform CodeQL Analysis"
 on:
   push:
     branches:
-      - current
+      - rolling
       - circinus
       - sagitta
     paths:
@@ -13,7 +13,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
-      - current
+      - rolling
       - circinus
       - sagitta
     paths:

--- a/.github/workflows/linit-j2.yml
+++ b/.github/workflows/linit-j2.yml
@@ -4,7 +4,7 @@ name: J2 Lint
 on:
   pull_request:
     branches:
-      - current
+      - rolling
       - sagitta
       - equuleus
   workflow_dispatch:

--- a/.github/workflows/package-smoketest.yml
+++ b/.github/workflows/package-smoketest.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - current
+      - rolling
       - circinus
       - sagitta
     paths:
@@ -15,7 +15,7 @@ on:
       - '!docker-vyos/**'
   pull_request_target:
     branches:
-      - current
+      - rolling
       - circinus
       - sagitta
     paths:

--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [current]
+    branches: [rolling]
   workflow_dispatch:
     inputs:
       sync_branch:

--- a/.github/workflows/trigger-docker-image-build.yml
+++ b/.github/workflows/trigger-docker-image-build.yml
@@ -5,7 +5,7 @@ on:
     types:
       - closed
     branches:
-      - current
+      - rolling
       - circinus
       - sagitta
 

--- a/.github/workflows/trigger_rebuild_packages.yml
+++ b/.github/workflows/trigger_rebuild_packages.yml
@@ -3,7 +3,7 @@ name: Trigger to build package
 on:
   push:
     branches:
-      - current
+      - rolling
 
 jobs:
   changes:


### PR DESCRIPTION
Rollout 1c reference migration. Own trunk refs current->rolling; action-ref to vyos/.github -> production; HIGH-producer pins already swept. Tracking: T8943