### PR TITLE
T8943: scripts/package-build: migrate broken commit_id refs after 1c rename

### DIFF
--- a/scripts/package-build/libnss-mapuser/package.toml
+++ b/scripts/package-build/libnss-mapuser/package.toml
@@ -1,6 +1,6 @@
 [[packages]]
 name = "libnss-mapuser"
-commit_id = "current"
+commit_id = "rolling"
 scm_url = "https://github.com/vyos/libnss-mapuser.git"
 
 [dependencies]

--- a/scripts/package-build/libpam-radius-auth/package.toml
+++ b/scripts/package-build/libpam-radius-auth/package.toml
@@ -1,6 +1,6 @@
 [[packages]]
 name = "libpam-radius-auth"
-commit_id = "current"
+commit_id = "rolling"
 scm_url = "https://github.com/vyos/libpam-radius-auth.git"
 
 [dependencies]

--- a/scripts/package-build/tacacs/package.toml
+++ b/scripts/package-build/tacacs/package.toml
@@ -1,18 +1,18 @@
 [[packages]]
 name = "libtacplus-map"
-commit_id = "master"
+commit_id = "rolling"
 scm_url = "https://github.com/vyos/libtacplus-map.git"
 build_cmd = "dpkg-buildpackage -us -uc -tc -b"
 
 [[packages]]
 name = "libpam-tacplus"
-commit_id = "master"
+commit_id = "rolling"
 scm_url = "https://github.com/vyos/libpam-tacplus.git"
 build_cmd = "sudo dpkg -i ../libtacplus-map*.deb; dpkg-buildpackage -us -uc -tc -b"
 
 [[packages]]
 name = "libnss-tacplus"
-commit_id = "master"
+commit_id = "rolling"
 scm_url = "https://github.com/vyos/libnss-tacplus.git"
 build_cmd = "sudo dpkg -i ../libtac*.deb ../libpam-tacplus*.deb; dpkg-buildpackage -us -uc -tc -b"
 

--- a/scripts/package-build/vpp/package.toml
+++ b/scripts/package-build/vpp/package.toml
@@ -1,6 +1,6 @@
 [[packages]]
 name = "vyos-vpp-patches"
-commit_id = "current"
+commit_id = "rolling"
 scm_url = "https://github.com/vyos/vyos-vpp-patches"
 build_cmd = "/bin/true"
 apply_patches = false

--- a/scripts/package-build/vyos-1x/package.toml
+++ b/scripts/package-build/vyos-1x/package.toml
@@ -1,4 +1,4 @@
 [[packages]]
 name = "vyos-1x"
-commit_id = "current"
+commit_id = "rolling"
 scm_url = "https://github.com/vyos/vyos-1x.git"


### PR DESCRIPTION
## Summary

[T8943](https://vyos.dev/T8943) Rollout 1c renamed the default branch of seven `vyos`-owned repos that `scripts/package-build/` clones, but [#1204](https://github.com/vyos/vyos-build/pull/1204) only swept `.github/workflows/`. Seven `commit_id` values in `scripts/package-build/*/package.toml` were missed and now break `build.py`.

## Why this breaks builds

`build.py` (line 90-92) runs:

```python
git clone <scm_url> <repo_dir>
git checkout <commit_id>
```

GitHub's branch-rename redirect works for the REST API and the web UI, **not** for git refs in a fresh clone. After the 1c rename, `git checkout current` (or `master`) errors with `pathspec ... did not match any file(s) known to git`.

Empirically verified:

```
$ git clone --depth 1 https://github.com/vyos/vyos-1x.git /tmp/test
$ cd /tmp/test && git checkout current
error: pathspec 'current' did not match any file(s) known to git
```

## Changes

Seven `commit_id` values in five files, all pointing to `vyos`-owned repos whose default branch was renamed `current`/`master` → `rolling` in 1c:

| File | Sub-package | scm_url | before | after |
|---|---|---|---|---|
| `libnss-mapuser/package.toml` | libnss-mapuser | `vyos/libnss-mapuser` | `current` | `rolling` |
| `libpam-radius-auth/package.toml` | libpam-radius-auth | `vyos/libpam-radius-auth` | `current` | `rolling` |
| `vpp/package.toml` | vyos-vpp-patches | `vyos/vyos-vpp-patches` | `current` | `rolling` |
| `vyos-1x/package.toml` | vyos-1x | `vyos/vyos-1x` | `current` | `rolling` |
| `tacacs/package.toml` | libtacplus-map | `vyos/libtacplus-map` | `master` | `rolling` |
| `tacacs/package.toml` | libpam-tacplus | `vyos/libpam-tacplus` | `master` | `rolling` |
| `tacacs/package.toml` | libnss-tacplus | `vyos/libnss-tacplus` | `master` | `rolling` |

Post-rename default branches verified via `gh api repos/vyos/<r> --jq .default_branch` for all seven.

## Out of scope

- **LTS branches** (`sagitta`/`circinus`/`equuleus`): scanned, no `vyos`-owned `commit_id="current"`/`"master"` refs found. Only third-party `evgeny-gridasov/openvpn-otp` `master` on circinus, unaffected by 1c.
- **Tagged / SHA-pinned / `debian/*` refs**: independent of 1c renames.
- **`stable/2510`** on upstream `FDio/vpp` in `vpp/package.toml`: third-party, unaffected.

## Test plan

- [ ] `scripts/package-build/build.py vyos-1x` succeeds (clone + checkout `rolling`).
- [ ] `scripts/package-build/build.py libnss-mapuser` succeeds.
- [ ] `scripts/package-build/build.py libpam-radius-auth` succeeds.
- [ ] `scripts/package-build/build.py vpp` succeeds.
- [ ] `scripts/package-build/build.py tacacs` succeeds (all 3 sub-packages clone + checkout `rolling`).

## Backport

- [ ] No — LTS branches are unaffected.

Advances: T8943

🤖 Generated by [robots](https://vyos.io)