### PR TITLE
docs: AGENTS.md: reflect rollout 1c default-branch rename (current->rolling)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,9 @@ make generic                            # builds the generic flavor
 - See also `CONTRIBUTING.md` for further hints on the commit messages.
 - Linting: unused-imports (Pylint) and J2 lint (note: workflow file is named
   `linit-j2.yml` in this repo — known cosmetic typo). Both inherited from
-  `vyos/.github@current`.
+  `vyos/.github@production`.
 - PR conflicts are flagged automatically via `check-pr-conflicts.yml` (reusable
-  `check-pr-merge-conflict.yml` from `vyos/.github@current`).
+  `check-pr-merge-conflict.yml` from `vyos/.github@production`).
 
 ## Notes for future contributors
 


### PR DESCRIPTION
Updates `AGENTS.md` to reflect the rollout 1c default-branch rename (release-train repos `current`->`rolling`; `vyos/.github` + non-release-train `current`->`production`) and the corresponding `@current`->`@production` reusable-workflow refs.

Tracking: Phorge [T8943](https://vyos.dev/T8943) (the 1c rename that caused the drift).

Doc-only change to `AGENTS.md`. No code or workflow behavior changes.

🤖 Generated by [robots](https://vyos.io)