### PR TITLE
sbom: T8542: bugfix shadowing cmd() function with cmd variable name

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -730,16 +730,16 @@ Pin-Priority: 600
         syft_target_dir = 'chroot'
         syft_base_path = os.getcwd() + f'/{syft_target_dir}'
         base_filename = iso_file.rstrip('.iso')
-        cmd = [['syft', syft_target_dir,
-                '--source-name', 'VyOS', '--source-version', version,
-               '-o', f'cyclonedx-json={base_filename}.cdx.json',
-               '-o', f'spdx-json={base_filename}.spdx.json']]
+        syft_cmd = [['syft', syft_target_dir,
+                     '--source-name', 'VyOS', '--source-version', version,
+                     '-o', f'cyclonedx-json={base_filename}.cdx.json',
+                     '-o', f'spdx-json={base_filename}.spdx.json']]
 
         # syft bug for CycloneDX https://github.com/anchore/syft/issues/4592#issuecomment-4567247328
-        cmd.append(['sed', '-i', '-e', f's@{syft_base_path}@@g', f'{base_filename}.cdx.json'])
-        cmd.append(['sed', '-i', '-e', f's@{syft_base_path}@//@g', f'{base_filename}.spdx.json'])
+        syft_cmd.append(['sed', '-i', '-e', f's@{syft_base_path}@@g', f'{base_filename}.cdx.json'])
+        syft_cmd.append(['sed', '-i', '-e', f's@{syft_base_path}@//@g', f'{base_filename}.spdx.json'])
 
-        for c in cmd:
+        for c in syft_cmd:
             with subprocess.Popen(c, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                   text=True, bufsize=1) as p:
                 for line in p.stdout:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 75a495b237 (`sbom: T8542: create during ISO assembly`) will shadow any subsequent calls to `vyos.utils.process.cmd()` as cmd has be redefined as variable to hold the CLI command strings for SBOM generation using the `syft` binary.

This has been fixed by replacing the cmd variable with another name syft_cmd.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8542

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
