### PR TITLE
T8099: Update strongswan to 6.0.6

### DIFF
--- a/data/live-build-config/hooks/live/30-strongswan-configs.chroot
+++ b/data/live-build-config/hooks/live/30-strongswan-configs.chroot
@@ -6,37 +6,21 @@
 # Since we do not do remote access IPsec, the simplest solution
 # is to disable it entirely from the start.
 
-import re
-
-# Disable the 'cisco_unity' option in charon.conf
-with open('/etc/strongswan.d/charon.conf', 'r') as f:
-    charon_conf = f.read()
-    charon_conf = re.sub(r'# (cisco_unity = no)', r"\1", charon_conf)
-
-with open('/etc/strongswan.d/charon.conf', 'w') as f:
-    f.write(charon_conf)
-
-
-
 # Prevent the 'cisco_unity' plugin from loading
 with open('/etc/strongswan.d/charon/unity.conf', 'r') as f:
     unity_conf = f.read()
-    unity_conf = re.sub(r'load = yes', r'load = no', unity_conf)
+    unity_conf = unity_conf.replace('load = yes', 'load = no')
 
 with open('/etc/strongswan.d/charon/unity.conf', 'w') as f:
     f.write(unity_conf)
 
-
-
 # Prevent the 'farp' plugin from loading
 with open('/etc/strongswan.d/charon/farp.conf', 'r') as f:
     farp_conf = f.read()
-
-    farp_conf = re.sub(r'load = yes', r'load = no', farp_conf)
+    farp_conf = farp_conf.replace('load = yes', 'load = no')
 
 with open('/etc/strongswan.d/charon/farp.conf', 'w') as f:
     f.write(farp_conf)
-
 
 # Add ike-name to logging
 charon_logging = """

--- a/scripts/package-build/strongswan/package.toml
+++ b/scripts/package-build/strongswan/package.toml
@@ -1,6 +1,6 @@
 [[packages]]
 name = "strongswan"
-commit_id = "debian/5.9.11-2"
+commit_id = "debian/6.0.6-1"
 scm_url = "https://salsa.debian.org/debian/strongswan.git"
 
 # systemd now contains pkg-config files and systemd-dev is not needed
@@ -14,7 +14,7 @@ set -e
 export DEBEMAIL="maintainers@vyos.net"
 export DEBFULLNAME="VyOS Package Maintainers"
 
-dch -v "5.9.11-2+vyos0" "Patchset for DMVPN support" -b
+dch -v "6.0.6-1+vyos0" "Patchset for DMVPN support" -b
 dpkg-buildpackage -uc -us -tc -b -d
 cd ..; ./build-vici.sh
 """

--- a/scripts/package-build/strongswan/package.toml
+++ b/scripts/package-build/strongswan/package.toml
@@ -3,8 +3,14 @@ name = "strongswan"
 commit_id = "debian/5.9.11-2"
 scm_url = "https://salsa.debian.org/debian/strongswan.git"
 
+# systemd now contains pkg-config files and systemd-dev is not needed
+# this changes debian/control so the change is needed before mk-build-deps
+# call so cannot be included in normal patches
+pre_build_hook = "sed -i '/ systemd-dev /d' debian/control"
+
 # build_cmd = "cd ..; yes | ./build.sh; ./build-vici.sh"
 build_cmd = """
+set -e
 export DEBEMAIL="maintainers@vyos.net"
 export DEBFULLNAME="VyOS Package Maintainers"
 

--- a/scripts/package-build/strongswan/patches/strongswan/0001-charon-add-optional-source-and-remote-overrides-for-.patch
+++ b/scripts/package-build/strongswan/patches/strongswan/0001-charon-add-optional-source-and-remote-overrides-for-.patch
@@ -1,8 +1,7 @@
-From db627ec8a8e72bc6b23dc8ab00f4e6b4f448d01c Mon Sep 17 00:00:00 2001
+From 309525ae10f390991f3bda79596142ba14b4994d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Timo=20Ter=C3=A4s?= <timo.teras@iki.fi>
 Date: Mon, 21 Sep 2015 13:41:58 +0300
-Subject: [PATCH 1/3] charon: add optional source and remote overrides for
- initiate
+Subject: [PATCH] charon: add optional source and remote overrides for initiate
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -21,19 +20,19 @@ Signed-off-by: Timo Teräs <timo.teras@iki.fi>
  src/libcharon/control/controller.h            |  3 +
  src/libcharon/plugins/stroke/stroke_control.c |  5 +-
  src/libcharon/plugins/vici/vici_config.c      |  2 +-
- src/libcharon/plugins/vici/vici_control.c     | 64 ++++++++++++++++---
+ src/libcharon/plugins/vici/vici_control.c     | 65 ++++++++++++++++---
  .../processing/jobs/start_action_job.c        |  2 +-
- src/libcharon/sa/ike_sa_manager.c             | 50 ++++++++++++++-
+ src/libcharon/sa/ike_sa_manager.c             | 50 +++++++++++++-
  src/libcharon/sa/ike_sa_manager.h             |  8 ++-
  src/libcharon/sa/trap_manager.c               | 44 +++++--------
  src/swanctl/commands/initiate.c               | 40 +++++++++++-
- 11 files changed, 215 insertions(+), 47 deletions(-)
+ 11 files changed, 216 insertions(+), 47 deletions(-)
 
 diff --git a/src/charon-cmd/cmd/cmd_connection.c b/src/charon-cmd/cmd/cmd_connection.c
-index 2e2cb3c..b9369a8 100644
+index 65e522765..bfa07b812 100644
 --- a/src/charon-cmd/cmd/cmd_connection.c
 +++ b/src/charon-cmd/cmd/cmd_connection.c
-@@ -439,7 +439,7 @@ static job_requeue_t initiate(private_cmd_connection_t *this)
+@@ -453,7 +453,7 @@ static job_requeue_t initiate(private_cmd_connection_t *this)
  	child_cfg = create_child_cfg(this, peer_cfg);
  
  	if (charon->controller->initiate(charon->controller, peer_cfg, child_cfg,
@@ -43,7 +42,7 @@ index 2e2cb3c..b9369a8 100644
  		terminate(pid);
  	}
 diff --git a/src/libcharon/control/controller.c b/src/libcharon/control/controller.c
-index 027f48e..4ce8616 100644
+index 42a4822bb..99133ee94 100644
 --- a/src/libcharon/control/controller.c
 +++ b/src/libcharon/control/controller.c
 @@ -15,6 +15,28 @@
@@ -92,24 +91,23 @@ index 027f48e..4ce8616 100644
  	/**
  	 * unique ID, used for various methods
  	 */
-@@ -417,10 +449,15 @@ METHOD(job_t, initiate_execute, job_requeue_t,
+@@ -438,9 +470,14 @@ METHOD(job_t, initiate_execute, job_requeue_t,
+ {
  	ike_sa_t *ike_sa;
  	interface_listener_t *listener = &job->listener;
- 	peer_cfg_t *peer_cfg = listener->peer_cfg;
 +	host_t *my_host = listener->my_host;
 +	host_t *other_host = listener->other_host;
  
  	ike_sa = charon->ike_sa_manager->checkout_by_config(charon->ike_sa_manager,
--														peer_cfg);
-+														peer_cfg, my_host, other_host);
- 	peer_cfg->destroy(peer_cfg);
+-														listener->peer_cfg);
++														listener->peer_cfg, my_host, other_host);
 +	DESTROY_IF(my_host);
 +	DESTROY_IF(other_host);
 +
  	if (!ike_sa)
  	{
- 		DESTROY_IF(listener->child_cfg);
-@@ -499,6 +536,7 @@ METHOD(job_t, initiate_execute, job_requeue_t,
+ 		listener->status = FAILED;
+@@ -520,6 +557,7 @@ METHOD(job_t, initiate_execute, job_requeue_t,
  
  METHOD(controller_t, initiate, status_t,
  	private_controller_t *this, peer_cfg_t *peer_cfg, child_cfg_t *child_cfg,
@@ -117,7 +115,7 @@ index 027f48e..4ce8616 100644
  	controller_cb_t callback, void *param, level_t max_level, u_int timeout,
  	bool limits)
  {
-@@ -523,6 +561,8 @@ METHOD(controller_t, initiate, status_t,
+@@ -545,6 +583,8 @@ METHOD(controller_t, initiate, status_t,
  			.status = FAILED,
  			.child_cfg = child_cfg,
  			.peer_cfg = peer_cfg,
@@ -127,7 +125,7 @@ index 027f48e..4ce8616 100644
  			.options.limits = limits,
  		},
 diff --git a/src/libcharon/control/controller.h b/src/libcharon/control/controller.h
-index 36a1d46..a130fbb 100644
+index 36a1d4631..a130fbb6b 100644
 --- a/src/libcharon/control/controller.h
 +++ b/src/libcharon/control/controller.h
 @@ -81,6 +81,8 @@ struct controller_t {
@@ -148,7 +146,7 @@ index 36a1d46..a130fbb 100644
  						 level_t max_level, u_int timeout, bool limits);
  
 diff --git a/src/libcharon/plugins/stroke/stroke_control.c b/src/libcharon/plugins/stroke/stroke_control.c
-index 2824c93..21ff6b3 100644
+index 2824c93cb..21ff6b31f 100644
 --- a/src/libcharon/plugins/stroke/stroke_control.c
 +++ b/src/libcharon/plugins/stroke/stroke_control.c
 @@ -109,7 +109,7 @@ static void charon_initiate(private_stroke_control_t *this, peer_cfg_t *peer_cfg
@@ -171,11 +169,11 @@ index 2824c93..21ff6b3 100644
  		switch (status)
  		{
 diff --git a/src/libcharon/plugins/vici/vici_config.c b/src/libcharon/plugins/vici/vici_config.c
-index 5221225..b1486e3 100644
+index dd426df53..324935be1 100644
 --- a/src/libcharon/plugins/vici/vici_config.c
 +++ b/src/libcharon/plugins/vici/vici_config.c
-@@ -2252,7 +2252,7 @@ static void run_start_action(private_vici_config_t *this, peer_cfg_t *peer_cfg,
- 		DBG1(DBG_CFG, "initiating '%s'", child_cfg->get_name(child_cfg));
+@@ -2395,7 +2395,7 @@ static void run_start_action(private_vici_config_t *this, peer_cfg_t *peer_cfg,
+ 		DBG1(DBG_CFG, "vici initiating '%s'", child_cfg->get_name(child_cfg));
  		charon->controller->initiate(charon->controller,
  					peer_cfg->get_ref(peer_cfg), child_cfg->get_ref(child_cfg),
 -					NULL, NULL, 0, 0, FALSE);
@@ -184,7 +182,7 @@ index 5221225..b1486e3 100644
  }
  
 diff --git a/src/libcharon/plugins/vici/vici_control.c b/src/libcharon/plugins/vici/vici_control.c
-index 1c236d2..811d8db 100644
+index 1c236d249..811d8dbc7 100644
 --- a/src/libcharon/plugins/vici/vici_control.c
 +++ b/src/libcharon/plugins/vici/vici_control.c
 @@ -15,6 +15,28 @@
@@ -300,7 +298,7 @@ index 1c236d2..811d8db 100644
  
  /**
 diff --git a/src/libcharon/processing/jobs/start_action_job.c b/src/libcharon/processing/jobs/start_action_job.c
-index 122e5ce..dec458c 100644
+index 122e5cee9..dec458c84 100644
 --- a/src/libcharon/processing/jobs/start_action_job.c
 +++ b/src/libcharon/processing/jobs/start_action_job.c
 @@ -84,7 +84,7 @@ METHOD(job_t, execute, job_requeue_t,
@@ -313,7 +311,7 @@ index 122e5ce..dec458c 100644
  		}
  		children->destroy(children);
 diff --git a/src/libcharon/sa/ike_sa_manager.c b/src/libcharon/sa/ike_sa_manager.c
-index fc31c2a..51e28bc 100644
+index 7796efb65..39852578d 100644
 --- a/src/libcharon/sa/ike_sa_manager.c
 +++ b/src/libcharon/sa/ike_sa_manager.c
 @@ -16,6 +16,28 @@
@@ -345,7 +343,7 @@ index fc31c2a..51e28bc 100644
  #include <string.h>
  #include <inttypes.h>
  
-@@ -1497,7 +1519,8 @@ typedef struct {
+@@ -1515,7 +1537,8 @@ typedef struct {
  } config_entry_t;
  
  METHOD(ike_sa_manager_t, checkout_by_config, ike_sa_t*,
@@ -355,7 +353,7 @@ index fc31c2a..51e28bc 100644
  {
  	enumerator_t *enumerator;
  	entry_t *entry;
-@@ -1508,7 +1531,17 @@ METHOD(ike_sa_manager_t, checkout_by_config, ike_sa_t*,
+@@ -1526,7 +1549,17 @@ METHOD(ike_sa_manager_t, checkout_by_config, ike_sa_t*,
  	u_int segment;
  	int i;
  
@@ -374,7 +372,7 @@ index fc31c2a..51e28bc 100644
  
  	if (!this->reuse_ikesa && peer_cfg->get_ike_version(peer_cfg) != IKEV1)
  	{	/* IKE_SA reuse disabled by config (not possible for IKEv1) */
-@@ -1566,6 +1599,15 @@ METHOD(ike_sa_manager_t, checkout_by_config, ike_sa_t*,
+@@ -1586,6 +1619,15 @@ METHOD(ike_sa_manager_t, checkout_by_config, ike_sa_t*,
  			continue;
  		}
  
@@ -390,7 +388,7 @@ index fc31c2a..51e28bc 100644
  		current_peer = entry->ike_sa->get_peer_cfg(entry->ike_sa);
  		if (current_peer && current_peer->equals(current_peer, peer_cfg))
  		{
-@@ -1592,6 +1634,10 @@ METHOD(ike_sa_manager_t, checkout_by_config, ike_sa_t*,
+@@ -1612,6 +1654,10 @@ METHOD(ike_sa_manager_t, checkout_by_config, ike_sa_t*,
  		{
  			ike_sa->set_peer_cfg(ike_sa, peer_cfg);
  			checkout_new(this, ike_sa);
@@ -402,7 +400,7 @@ index fc31c2a..51e28bc 100644
  	}
  	charon->bus->set_sa(charon->bus, ike_sa);
 diff --git a/src/libcharon/sa/ike_sa_manager.h b/src/libcharon/sa/ike_sa_manager.h
-index 004cc22..50f8246 100644
+index 004cc2216..50f8246f8 100644
 --- a/src/libcharon/sa/ike_sa_manager.h
 +++ b/src/libcharon/sa/ike_sa_manager.h
 @@ -123,7 +123,8 @@ struct ike_sa_manager_t {
@@ -430,19 +428,19 @@ index 004cc22..50f8246 100644
  	/**
  	 * Reset initiator SPI.
 diff --git a/src/libcharon/sa/trap_manager.c b/src/libcharon/sa/trap_manager.c
-index d8d8a42..e7c906e 100644
+index 90a29b29b..0d8447bfe 100644
 --- a/src/libcharon/sa/trap_manager.c
 +++ b/src/libcharon/sa/trap_manager.c
-@@ -523,7 +523,7 @@ METHOD(trap_manager_t, acquire, void,
+@@ -532,7 +532,7 @@ METHOD(trap_manager_t, acquire, void,
  	peer_cfg_t *peer;
  	child_cfg_t *child;
  	ike_sa_t *ike_sa;
--	host_t *host;
-+	host_t *host, *my_host = NULL, *other_host = NULL;
- 	bool wildcard, ignore = FALSE;
+-	host_t *host = NULL;
++	host_t *host = NULL, *my_host = NULL, *other_host = NULL;
+ 	uint32_t allocated_reqid, seq = 0;
+ 	bool wildcard;
  
- 	this->lock->read_lock(this->lock);
-@@ -600,37 +600,27 @@ METHOD(trap_manager_t, acquire, void,
+@@ -617,37 +617,27 @@ METHOD(trap_manager_t, acquire, void,
  	this->lock->unlock(this->lock);
  
  	if (wildcard)
@@ -457,34 +455,32 @@ index d8d8a42..e7c906e 100644
 -
 -			ike_sa->set_peer_cfg(ike_sa, peer);
 -			ike_cfg = ike_sa->get_ike_cfg(ike_sa);
--
++	{
++		ike_cfg_t *ike_cfg;
++		uint16_t port;
++		uint8_t mask;
+ 
 -			port = ike_cfg->get_other_port(ike_cfg);
 -			data->dst->to_subnet(data->dst, &host, &mask);
 -			host->set_port(host, port);
 -			ike_sa->set_other_host(ike_sa, host);
--
++		ike_cfg = peer->get_ike_cfg(peer);
+ 
 -			port = ike_cfg->get_my_port(ike_cfg);
 -			data->src->to_subnet(data->src, &host, &mask);
 -			host->set_port(host, port);
 -			ike_sa->set_my_host(ike_sa, host);
--
++		port = ike_cfg->get_other_port(ike_cfg);
++		data->dst->to_subnet(data->dst, &other_host, &mask);
++		other_host->set_port(other_host, port);
+ 
 -			charon->bus->set_sa(charon->bus, ike_sa);
 -		}
 -	}
 -	else
- 	{
+-	{
 -		ike_sa = charon->ike_sa_manager->checkout_by_config(
 -											charon->ike_sa_manager, peer);
-+		ike_cfg_t *ike_cfg;
-+		uint16_t port;
-+		uint8_t mask;
-+
-+		ike_cfg = peer->get_ike_cfg(peer);
-+
-+		port = ike_cfg->get_other_port(ike_cfg);
-+		data->dst->to_subnet(data->dst, &other_host, &mask);
-+		other_host->set_port(other_host, port);
-+
 +		port = ike_cfg->get_my_port(ike_cfg);
 +		data->src->to_subnet(data->src, &my_host, &mask);
 +		my_host->set_port(my_host, port);
@@ -499,7 +495,7 @@ index d8d8a42..e7c906e 100644
  	if (ike_sa)
  	{
 diff --git a/src/swanctl/commands/initiate.c b/src/swanctl/commands/initiate.c
-index e0fffb9..dcaded5 100644
+index e0fffb907..dcaded59d 100644
 --- a/src/swanctl/commands/initiate.c
 +++ b/src/swanctl/commands/initiate.c
 @@ -14,6 +14,28 @@
@@ -577,3 +573,6 @@ index e0fffb9..dcaded5 100644
  			{"timeout",		't', 1, "timeout in seconds before detaching"},
  			{"raw",			'r', 0, "dump raw response message"},
  			{"pretty",		'P', 0, "dump raw response message in pretty print"},
+-- 
+2.51.2
+

--- a/scripts/package-build/strongswan/patches/strongswan/0002-vici-send-certificates-for-ike-sa-events.patch
+++ b/scripts/package-build/strongswan/patches/strongswan/0002-vici-send-certificates-for-ike-sa-events.patch
@@ -1,21 +1,21 @@
-From 39d537b875e907c63a54d5de8ba6d2ea0ede4604 Mon Sep 17 00:00:00 2001
+From e2b3b94ee03c85e844e98f65a565deb9fddd0857 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Timo=20Ter=C3=A4s?= <timo.teras@iki.fi>
 Date: Mon, 21 Sep 2015 13:42:05 +0300
-Subject: [PATCH 2/3] vici: send certificates for ike-sa events
+Subject: [PATCH] vici: send certificates for ike-sa events
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
 Signed-off-by: Timo Teräs <timo.teras@iki.fi>
 ---
- src/libcharon/plugins/vici/vici_query.c | 50 +++++++++++++++++++++----
- 1 file changed, 42 insertions(+), 8 deletions(-)
+ src/libcharon/plugins/vici/vici_query.c | 52 ++++++++++++++++++++-----
+ 1 file changed, 43 insertions(+), 9 deletions(-)
 
 diff --git a/src/libcharon/plugins/vici/vici_query.c b/src/libcharon/plugins/vici/vici_query.c
-index bacb7b101..19acc0789 100644
+index 98a09fa4a..24132a5b4 100644
 --- a/src/libcharon/plugins/vici/vici_query.c
 +++ b/src/libcharon/plugins/vici/vici_query.c
-@@ -402,7 +402,7 @@ static void list_vips(private_vici_query_t *this, vici_builder_t *b,
+@@ -469,7 +469,7 @@ static void list_vips(private_vici_query_t *this, vici_builder_t *b,
   * List details of an IKE_SA
   */
  static void list_ike(private_vici_query_t *this, vici_builder_t *b,
@@ -24,7 +24,7 @@ index bacb7b101..19acc0789 100644
  {
  	time_t t;
  	ike_sa_id_t *id;
-@@ -411,6 +411,8 @@ static void list_ike(private_vici_query_t *this, vici_builder_t *b,
+@@ -478,6 +478,8 @@ static void list_ike(private_vici_query_t *this, vici_builder_t *b,
  	uint32_t if_id;
  	uint16_t alg, ks;
  	host_t *host;
@@ -33,7 +33,7 @@ index bacb7b101..19acc0789 100644
  
  	b->add_kv(b, "uniqueid", "%u", ike_sa->get_unique_id(ike_sa));
  	b->add_kv(b, "version", "%u", ike_sa->get_version(ike_sa));
-@@ -420,11 +422,43 @@ static void list_ike(private_vici_query_t *this, vici_builder_t *b,
+@@ -487,11 +489,43 @@ static void list_ike(private_vici_query_t *this, vici_builder_t *b,
  	b->add_kv(b, "local-host", "%H", host);
  	b->add_kv(b, "local-port", "%d", host->get_port(host));
  	b->add_kv(b, "local-id", "%Y", ike_sa->get_my_id(ike_sa));
@@ -77,7 +77,7 @@ index bacb7b101..19acc0789 100644
  
  	eap = ike_sa->get_other_eap_id(ike_sa);
  
-@@ -556,7 +590,7 @@ CALLBACK(list_sas, vici_message_t*,
+@@ -624,7 +658,7 @@ CALLBACK(list_sas, vici_message_t*,
  		b = vici_builder_create();
  		b->begin_section(b, ike_sa->get_name(ike_sa));
  
@@ -86,7 +86,7 @@ index bacb7b101..19acc0789 100644
  
  		b->begin_section(b, "child-sas");
  		csas = ike_sa->create_child_sa_enumerator(ike_sa);
-@@ -1774,7 +1808,7 @@ METHOD(listener_t, ike_updown, bool,
+@@ -1847,7 +1881,7 @@ METHOD(listener_t, ike_updown, bool,
  	}
  
  	b->begin_section(b, ike_sa->get_name(ike_sa));
@@ -95,7 +95,7 @@ index bacb7b101..19acc0789 100644
  	b->end_section(b);
  
  	this->dispatcher->raise_event(this->dispatcher,
-@@ -1799,10 +1833,10 @@ METHOD(listener_t, ike_rekey, bool,
+@@ -1872,10 +1906,10 @@ METHOD(listener_t, ike_rekey, bool,
  	b = vici_builder_create();
  	b->begin_section(b, old->get_name(old));
  	b->begin_section(b, "old");
@@ -108,7 +108,7 @@ index bacb7b101..19acc0789 100644
  	b->end_section(b);
  	b->end_section(b);
  
-@@ -1833,7 +1867,7 @@ METHOD(listener_t, ike_update, bool,
+@@ -1906,7 +1940,7 @@ METHOD(listener_t, ike_update, bool,
  	b->add_kv(b, "remote-port", "%d", remote->get_port(remote));
  
  	b->begin_section(b, ike_sa->get_name(ike_sa));
@@ -117,7 +117,7 @@ index bacb7b101..19acc0789 100644
  	b->end_section(b);
  
  	this->dispatcher->raise_event(this->dispatcher,
-@@ -1863,7 +1897,7 @@ METHOD(listener_t, child_updown, bool,
+@@ -1936,7 +1970,7 @@ METHOD(listener_t, child_updown, bool,
  	}
  
  	b->begin_section(b, ike_sa->get_name(ike_sa));
@@ -126,7 +126,7 @@ index bacb7b101..19acc0789 100644
  	b->begin_section(b, "child-sas");
  
  	snprintf(buf, sizeof(buf), "%s-%u", child_sa->get_name(child_sa),
-@@ -1898,7 +1932,7 @@ METHOD(listener_t, child_rekey, bool,
+@@ -1971,7 +2005,7 @@ METHOD(listener_t, child_rekey, bool,
  	b = vici_builder_create();
  
  	b->begin_section(b, ike_sa->get_name(ike_sa));
@@ -135,6 +135,15 @@ index bacb7b101..19acc0789 100644
  	b->begin_section(b, "child-sas");
  
  	b->begin_section(b, old->get_name(old));
+@@ -2010,7 +2044,7 @@ METHOD(listener_t, alert, bool,
+ 	{
+ 		b->begin_section(b, "ike-sa");
+ 		b->begin_section(b, ike_sa->get_name(ike_sa));
+-		list_ike(this, b, ike_sa, time_monotonic(NULL));
++		list_ike(this, b, ike_sa, time_monotonic(NULL), TRUE);
+ 		b->end_section(b);
+ 		b->end_section(b);
+ 	}
 -- 
-2.38.1
+2.51.2
 

--- a/scripts/package-build/strongswan/patches/strongswan/0003-vici-add-support-for-individual-sa-state-changes.patch
+++ b/scripts/package-build/strongswan/patches/strongswan/0003-vici-add-support-for-individual-sa-state-changes.patch
@@ -1,7 +1,7 @@
-From df6b501ed29b838efde0f1cb1c906ab9befc7b45 Mon Sep 17 00:00:00 2001
+From 433e007e0ac53cbc0ede1b5008e28a54126d44aa Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Timo=20Ter=C3=A4s?= <timo.teras@iki.fi>
 Date: Mon, 21 Sep 2015 13:42:11 +0300
-Subject: [PATCH 3/3] vici: add support for individual sa state changes
+Subject: [PATCH] vici: add support for individual sa state changes
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -14,10 +14,10 @@ Signed-off-by: Timo Teräs <timo.teras@iki.fi>
  1 file changed, 105 insertions(+)
 
 diff --git a/src/libcharon/plugins/vici/vici_query.c b/src/libcharon/plugins/vici/vici_query.c
-index 19acc0789..e008885f7 100644
+index 633eabe69..fab684d8d 100644
 --- a/src/libcharon/plugins/vici/vici_query.c
 +++ b/src/libcharon/plugins/vici/vici_query.c
-@@ -1774,8 +1774,16 @@ static void manage_commands(private_vici_query_t *this, bool reg)
+@@ -1846,9 +1846,17 @@ static void manage_commands(private_vici_query_t *this, bool reg)
  	this->dispatcher->manage_event(this->dispatcher, "ike-updown", reg);
  	this->dispatcher->manage_event(this->dispatcher, "ike-rekey", reg);
  	this->dispatcher->manage_event(this->dispatcher, "ike-update", reg);
@@ -25,6 +25,7 @@ index 19acc0789..e008885f7 100644
 +	this->dispatcher->manage_event(this->dispatcher, "ike-state-destroying", reg);
  	this->dispatcher->manage_event(this->dispatcher, "child-updown", reg);
  	this->dispatcher->manage_event(this->dispatcher, "child-rekey", reg);
+ 	this->dispatcher->manage_event(this->dispatcher, "alert", reg);
 +	this->dispatcher->manage_event(this->dispatcher, "child-state-installing", reg);
 +	this->dispatcher->manage_event(this->dispatcher, "child-state-installed", reg);
 +	this->dispatcher->manage_event(this->dispatcher, "child-state-updating", reg);
@@ -34,7 +35,7 @@ index 19acc0789..e008885f7 100644
  	manage_command(this, "list-sas", list_sas, reg);
  	manage_command(this, "list-policies", list_policies, reg);
  	manage_command(this, "list-conns", list_conns, reg);
-@@ -1876,6 +1884,45 @@ METHOD(listener_t, ike_update, bool,
+@@ -1949,6 +1957,45 @@ METHOD(listener_t, ike_update, bool,
  	return TRUE;
  }
  
@@ -80,7 +81,7 @@ index 19acc0789..e008885f7 100644
  METHOD(listener_t, child_updown, bool,
  	private_vici_query_t *this, ike_sa_t *ike_sa, child_sa_t *child_sa, bool up)
  {
-@@ -1955,6 +2002,62 @@ METHOD(listener_t, child_rekey, bool,
+@@ -2054,6 +2101,62 @@ METHOD(listener_t, alert, bool,
  	return TRUE;
  }
  
@@ -143,7 +144,7 @@ index 19acc0789..e008885f7 100644
  METHOD(vici_query_t, destroy, void,
  	private_vici_query_t *this)
  {
-@@ -1975,8 +2078,10 @@ vici_query_t *vici_query_create(vici_dispatcher_t *dispatcher)
+@@ -2075,8 +2178,10 @@ vici_query_t *vici_query_create(vici_dispatcher_t *dispatcher)
  				.ike_updown = _ike_updown,
  				.ike_rekey = _ike_rekey,
  				.ike_update = _ike_update,
@@ -155,5 +156,5 @@ index 19acc0789..e008885f7 100644
  			.destroy = _destroy,
  		},
 -- 
-2.38.1
+2.51.2
 

--- a/scripts/package-build/strongswan/patches/strongswan/0004-VyOS-disable-options-enabled-by-Debian-that-are-unus.patch
+++ b/scripts/package-build/strongswan/patches/strongswan/0004-VyOS-disable-options-enabled-by-Debian-that-are-unus.patch
@@ -1,4 +1,4 @@
-From ee6c0b3ff6e3df5c7aef628621e19a813ff308ed Mon Sep 17 00:00:00 2001
+From 76b5eea5a0fefa38b1a85c29767b5334c70ae446 Mon Sep 17 00:00:00 2001
 From: Christian Poessinger <christian@poessinger.com>
 Date: Tue, 27 Dec 2022 13:36:43 +0000
 Subject: [PATCH] VyOS: disable options enabled by Debian that are unused
@@ -12,14 +12,27 @@ The following options need to be disabled for the DMVPN patchset:
 In addition we have no LED, LDAP and SQL configuration knows, thus we spare
 the plugins.
 ---
- debian/libcharon-extra-plugins.install     |  3 ---
- debian/libstrongswan-extra-plugins.install |  3 ---
- debian/rules                               | 11 ++++++++++-
- debian/strongswan-nm.install               |  2 --
- 4 files changed, 10 insertions(+), 9 deletions(-)
+ debian/libcharon-extauth-plugins.install      |  1 -
+ debian/libcharon-extra-plugins.install        |  9 -------
+ debian/libstrongswan-extra-plugins.install    | 26 -------------------
+ debian/libstrongswan-standard-plugins.install |  4 ---
+ debian/libstrongswan.install                  | 12 ---------
+ debian/rules                                  | 17 +++++++-----
+ debian/strongswan-libcharon.install           |  2 --
+ debian/strongswan-nm.install                  |  5 ----
+ 8 files changed, 10 insertions(+), 66 deletions(-)
 
+diff --git a/debian/libcharon-extauth-plugins.install b/debian/libcharon-extauth-plugins.install
+index 63d0eee92..f58b59984 100644
+--- a/debian/libcharon-extauth-plugins.install
++++ b/debian/libcharon-extauth-plugins.install
+@@ -19,4 +19,3 @@ etc/strongswan.d/charon/eap-mschapv2.conf
+ etc/strongswan.d/charon/xauth-generic.conf
+ etc/strongswan.d/charon-cmd/eap-mschapv2.conf
+ etc/strongswan.d/charon-cmd/xauth-generic.conf
+-etc/strongswan.d/charon-nm/eap-mschapv2.conf
 diff --git a/debian/libcharon-extra-plugins.install b/debian/libcharon-extra-plugins.install
-index 94fbabd88..068708ecb 100644
+index 22ae363ee..ef6dcd7a1 100644
 --- a/debian/libcharon-extra-plugins.install
 +++ b/debian/libcharon-extra-plugins.install
 @@ -13,7 +13,6 @@ usr/lib/ipsec/plugins/libstrongswan-error-notify.so
@@ -38,7 +51,7 @@ index 94fbabd88..068708ecb 100644
  usr/share/strongswan/templates/config/plugins/lookip.conf
  #usr/share/strongswan/templates/config/plugins/medsrv.conf
  #usr/share/strongswan/templates/config/plugins/medcli.conf
-@@ -60,7 +58,6 @@ etc/strongswan.d/charon/error-notify.conf
+@@ -61,7 +59,6 @@ etc/strongswan.d/charon/error-notify.conf
  etc/strongswan.d/charon/forecast.conf
  etc/strongswan.d/charon/ha.conf
  etc/strongswan.d/charon/kernel-libipsec.conf
@@ -46,36 +59,121 @@ index 94fbabd88..068708ecb 100644
  etc/strongswan.d/charon/lookip.conf
  #etc/strongswan.d/charon/medsrv.conf
  #etc/strongswan.d/charon/medcli.conf
+@@ -69,12 +66,6 @@ etc/strongswan.d/charon/tnc-tnccs.conf
+ etc/strongswan.d/charon/unity.conf
+ etc/strongswan.d/charon/xauth-eap.conf
+ etc/strongswan.d/charon/xauth-pam.conf
+-# charon-nm
+-etc/strongswan.d/charon-nm/eap-gtc.conf
+-etc/strongswan.d/charon-nm/eap-identity.conf
+-etc/strongswan.d/charon-nm/eap-md5.conf
+-etc/strongswan.d/charon-nm/eap-tls.conf
+-etc/strongswan.d/charon-nm/eap-ttls.conf
+ # charon-cmd
+ etc/strongswan.d/charon-cmd/eap-gtc.conf
+ etc/strongswan.d/charon-cmd/eap-identity.conf
 diff --git a/debian/libstrongswan-extra-plugins.install b/debian/libstrongswan-extra-plugins.install
-index 2846e2155..00cd0a146 100644
+index d00691503..3db1af5b5 100644
 --- a/debian/libstrongswan-extra-plugins.install
 +++ b/debian/libstrongswan-extra-plugins.install
-@@ -8,7 +8,6 @@ usr/lib/ipsec/plugins/libstrongswan-ctr.so
- usr/lib/ipsec/plugins/libstrongswan-curl.so
- usr/lib/ipsec/plugins/libstrongswan-curve25519.so
- usr/lib/ipsec/plugins/libstrongswan-gcrypt.so
+@@ -13,7 +13,6 @@ usr/lib/ipsec/plugins/libstrongswan-gcrypt.so
+ usr/lib/ipsec/plugins/libstrongswan-gmp.so
+ usr/lib/ipsec/plugins/libstrongswan-hmac.so
+ usr/lib/ipsec/plugins/libstrongswan-kdf.so
 -usr/lib/ipsec/plugins/libstrongswan-ldap.so
- usr/lib/ipsec/plugins/libstrongswan-pkcs11.so
- usr/lib/ipsec/plugins/libstrongswan-test-vectors.so
- usr/lib/ipsec/plugins/libstrongswan-tpm.so
-@@ -20,7 +19,6 @@ usr/share/strongswan/templates/config/plugins/ctr.conf
- usr/share/strongswan/templates/config/plugins/curl.conf
- usr/share/strongswan/templates/config/plugins/curve25519.conf
- usr/share/strongswan/templates/config/plugins/gcrypt.conf
+ usr/lib/ipsec/plugins/libstrongswan-md5.so
+ usr/lib/ipsec/plugins/libstrongswan-mgf1.so
+ usr/lib/ipsec/plugins/libstrongswan-pgp.so
+@@ -38,7 +37,6 @@ usr/share/strongswan/templates/config/plugins/gcrypt.conf
+ usr/share/strongswan/templates/config/plugins/gmp.conf
+ usr/share/strongswan/templates/config/plugins/hmac.conf
+ usr/share/strongswan/templates/config/plugins/kdf.conf
 -usr/share/strongswan/templates/config/plugins/ldap.conf
- usr/share/strongswan/templates/config/plugins/pkcs11.conf
- usr/share/strongswan/templates/config/plugins/test-vectors.conf
- usr/share/strongswan/templates/config/plugins/tpm.conf
-@@ -31,7 +29,6 @@ etc/strongswan.d/charon/ctr.conf
- etc/strongswan.d/charon/curl.conf
- etc/strongswan.d/charon/curve25519.conf
- etc/strongswan.d/charon/gcrypt.conf
+ usr/share/strongswan/templates/config/plugins/md5.conf
+ usr/share/strongswan/templates/config/plugins/mgf1.conf
+ usr/share/strongswan/templates/config/plugins/pgp.conf
+@@ -63,7 +61,6 @@ etc/strongswan.d/charon/gcrypt.conf
+ etc/strongswan.d/charon/gmp.conf
+ etc/strongswan.d/charon/hmac.conf
+ etc/strongswan.d/charon/kdf.conf
 -etc/strongswan.d/charon/ldap.conf
- etc/strongswan.d/charon/pkcs11.conf
- etc/strongswan.d/charon/test-vectors.conf
- etc/strongswan.d/charon/tpm.conf
+ etc/strongswan.d/charon/md5.conf
+ etc/strongswan.d/charon/mgf1.conf
+ etc/strongswan.d/charon/pgp.conf
+@@ -88,7 +85,6 @@ etc/strongswan.d/charon-cmd/gcrypt.conf
+ etc/strongswan.d/charon-cmd/gmp.conf
+ etc/strongswan.d/charon-cmd/hmac.conf
+ etc/strongswan.d/charon-cmd/kdf.conf
+-etc/strongswan.d/charon-cmd/ldap.conf
+ etc/strongswan.d/charon-cmd/md5.conf
+ etc/strongswan.d/charon-cmd/mgf1.conf
+ etc/strongswan.d/charon-cmd/pkcs11.conf
+@@ -98,28 +94,6 @@ etc/strongswan.d/charon-cmd/sha1.conf
+ etc/strongswan.d/charon-cmd/sha2.conf
+ etc/strongswan.d/charon-cmd/tpm.conf
+ etc/strongswan.d/charon-cmd/xcbc.conf
+-# charon-nm configuration files
+-etc/strongswan.d/charon-nm/aes.conf
+-etc/strongswan.d/charon-nm/ccm.conf
+-etc/strongswan.d/charon-nm/chapoly.conf
+-etc/strongswan.d/charon-nm/cmac.conf
+-etc/strongswan.d/charon-nm/ctr.conf
+-etc/strongswan.d/charon-nm/curl.conf
+-etc/strongswan.d/charon-nm/curve25519.conf
+-etc/strongswan.d/charon-nm/fips-prf.conf
+-etc/strongswan.d/charon-nm/gcrypt.conf
+-etc/strongswan.d/charon-nm/gmp.conf
+-etc/strongswan.d/charon-nm/hmac.conf
+-etc/strongswan.d/charon-nm/kdf.conf
+-etc/strongswan.d/charon-nm/ldap.conf
+-etc/strongswan.d/charon-nm/md5.conf
+-etc/strongswan.d/charon-nm/mgf1.conf
+-etc/strongswan.d/charon-nm/pkcs11.conf
+-etc/strongswan.d/charon-nm/rc2.conf
+-etc/strongswan.d/charon-nm/sha1.conf
+-etc/strongswan.d/charon-nm/sha2.conf
+-etc/strongswan.d/charon-nm/tpm.conf
+-etc/strongswan.d/charon-nm/xcbc.conf
+ # TPM libs
+ usr/lib/ipsec/libtpmtss.so.*
+ usr/lib/ipsec/libtpmtss.so
+diff --git a/debian/libstrongswan-standard-plugins.install b/debian/libstrongswan-standard-plugins.install
+index 97aaedabf..973172476 100644
+--- a/debian/libstrongswan-standard-plugins.install
++++ b/debian/libstrongswan-standard-plugins.install
+@@ -14,7 +14,3 @@ etc/strongswan.d/charon/sshkey.conf
+ etc/strongswan.d/charon-cmd/agent.conf
+ etc/strongswan.d/charon-cmd/gcm.conf
+ etc/strongswan.d/charon-cmd/sshkey.conf
+-# charon-nm config files
+-etc/strongswan.d/charon-nm/agent.conf
+-etc/strongswan.d/charon-nm/gcm.conf
+-etc/strongswan.d/charon-nm/sshkey.conf
+diff --git a/debian/libstrongswan.install b/debian/libstrongswan.install
+index 5ce6459ae..7c80a3007 100644
+--- a/debian/libstrongswan.install
++++ b/debian/libstrongswan.install
+@@ -61,18 +61,6 @@ etc/strongswan.d/charon-cmd/random.conf
+ etc/strongswan.d/charon-cmd/resolve.conf
+ etc/strongswan.d/charon-cmd/revocation.conf
+ etc/strongswan.d/charon-cmd/x509.conf
+-# charon-nm config files
+-etc/strongswan.d/charon-nm/constraints.conf
+-etc/strongswan.d/charon-nm/drbg.conf
+-etc/strongswan.d/charon-nm/nonce.conf
+-etc/strongswan.d/charon-nm/openssl.conf
+-etc/strongswan.d/charon-nm/pem.conf
+-etc/strongswan.d/charon-nm/pkcs1.conf
+-etc/strongswan.d/charon-nm/pkcs7.conf
+-etc/strongswan.d/charon-nm/pkcs8.conf
+-etc/strongswan.d/charon-nm/random.conf
+-etc/strongswan.d/charon-nm/revocation.conf
+-etc/strongswan.d/charon-nm/x509.conf
+ # config files
+ etc/strongswan.conf
+ etc/strongswan.d/iptfs.conf
 diff --git a/debian/rules b/debian/rules
-index 2fed1f10f..fa0d21a0c 100755
+index b77e0750d..abc637a1c 100755
 --- a/debian/rules
 +++ b/debian/rules
 @@ -3,6 +3,15 @@ export DEB_LDFLAGS_MAINT_APPEND=-Wl,-O1
@@ -93,8 +191,8 @@ index 2fed1f10f..fa0d21a0c 100755
 +
  CONFIGUREARGS := --libdir=/usr/lib --libexecdir=/usr/lib \
  		--enable-addrblock \
- 		--enable-agent \
-@@ -88,7 +97,7 @@ ifeq ($(DEB_HOST_ARCH_OS),kfreebsd)
+ 		--enable-aes \
+@@ -102,7 +111,7 @@ endif
  deb_systemdsystemunitdir = $(shell pkg-config --variable=systemdsystemunitdir systemd | sed s,^/,,)
  
  override_dh_auto_configure:
@@ -103,13 +201,73 @@ index 2fed1f10f..fa0d21a0c 100755
  
  override_dh_auto_clean:
  	dh_auto_clean
+@@ -143,13 +152,11 @@ ifeq ($(DEB_HOST_ARCH_OS),linux)
+ 	dh_install -p libstrongswan usr/share/strongswan/templates/config/plugins/kernel-netlink.conf
+ 	dh_install -p libstrongswan etc/strongswan.d/charon/kernel-netlink.conf
+ 	dh_install -p libstrongswan etc/strongswan.d/charon-cmd/kernel-netlink.conf
+-	dh_install -p libstrongswan etc/strongswan.d/charon-nm/kernel-netlink.conf
+ 
+ 	dh_install -p libstrongswan-extra-plugins usr/lib/ipsec/plugins/libstrongswan-af-alg.so
+ 	dh_install -p libstrongswan-extra-plugins usr/share/strongswan/templates/config/plugins/af-alg.conf
+ 	dh_install -p libstrongswan-extra-plugins etc/strongswan.d/charon/af-alg.conf
+ 	dh_install -p libstrongswan-extra-plugins etc/strongswan.d/charon-cmd/af-alg.conf
+-	dh_install -p libstrongswan-extra-plugins etc/strongswan.d/charon-nm/af-alg.conf
+ 	# the systemd service file only gets generated on Linux
+ 	dh_install -p strongswan-starter "$(deb_systemdsystemunitdir)/strongswan-starter.service"
+ 	dh_link -p strongswan-starter "$(deb_systemdsystemunitdir)/strongswan-starter.service" "$(deb_systemdsystemunitdir)/ipsec.service"
+@@ -179,12 +186,10 @@ ifeq ($(DEB_HOST_ARCH_CPU),i386)
+ 	dh_install -p libstrongswan-extra-plugins usr/share/strongswan/templates/config/plugins/rdrand.conf
+ 	dh_install -p libstrongswan-extra-plugins etc/strongswan.d/charon/rdrand.conf
+ 	dh_install -p libstrongswan-extra-plugins etc/strongswan.d/charon-cmd/rdrand.conf
+-	dh_install -p libstrongswan-extra-plugins etc/strongswan.d/charon-nm/rdrand.conf
+ 
+ 	dh_install -p libstrongswan-standard-plugins usr/lib/ipsec/plugins/libstrongswan-aesni.so
+ 	dh_install -p libstrongswan-standard-plugins usr/share/strongswan/templates/config/plugins/aesni.conf
+ 	dh_install -p libstrongswan-standard-plugins etc/strongswan.d/charon/aesni.conf
+-	dh_install -p libstrongswan-standard-plugins etc/strongswan.d/charon-nm/aesni.conf
+ 	dh_install -p libstrongswan-standard-plugins etc/strongswan.d/charon-cmd/aesni.conf
+ endif
+ 
+@@ -193,12 +198,10 @@ ifeq ($(DEB_HOST_ARCH_CPU), amd64)
+ 	dh_install -p libstrongswan-extra-plugins usr/share/strongswan/templates/config/plugins/rdrand.conf
+ 	dh_install -p libstrongswan-extra-plugins etc/strongswan.d/charon/rdrand.conf
+ 	dh_install -p libstrongswan-extra-plugins etc/strongswan.d/charon-cmd/rdrand.conf
+-	dh_install -p libstrongswan-extra-plugins etc/strongswan.d/charon-nm/rdrand.conf
+ 
+ 	dh_install -p libstrongswan-standard-plugins usr/lib/ipsec/plugins/libstrongswan-aesni.so
+ 	dh_install -p libstrongswan-standard-plugins usr/share/strongswan/templates/config/plugins/aesni.conf
+ 	dh_install -p libstrongswan-standard-plugins etc/strongswan.d/charon/aesni.conf
+-	dh_install -p libstrongswan-standard-plugins etc/strongswan.d/charon-nm/aesni.conf
+ 	dh_install -p libstrongswan-standard-plugins etc/strongswan.d/charon-cmd/aesni.conf
+ endif
+ 
+diff --git a/debian/strongswan-libcharon.install b/debian/strongswan-libcharon.install
+index 099c2e955..45eafad6f 100644
+--- a/debian/strongswan-libcharon.install
++++ b/debian/strongswan-libcharon.install
+@@ -5,7 +5,6 @@ usr/lib/ipsec/plugins/libstrongswan-socket-default.so
+ usr/share/strongswan/templates/config/plugins/socket-default.conf
+ etc/strongswan.d/charon/socket-default.conf
+ etc/strongswan.d/charon-cmd/socket-default.conf
+-etc/strongswan.d/charon-nm/socket-default.conf
+ # counters
+ usr/lib/ipsec/plugins/libstrongswan-counters.so
+ usr/share/strongswan/templates/config/plugins/counters.conf
+@@ -20,4 +19,3 @@ usr/lib/ipsec/plugins/libstrongswan-bypass-lan.so
+ usr/share/strongswan/templates/config/plugins/bypass-lan.conf
+ etc/strongswan.d/charon/bypass-lan.conf
+ etc/strongswan.d/charon-cmd/bypass-lan.conf
+-etc/strongswan.d/charon-nm/bypass-lan.conf
 diff --git a/debian/strongswan-nm.install b/debian/strongswan-nm.install
-index b0c05d94f..e69de29bb 100644
+index 058193688..e69de29bb 100644
 --- a/debian/strongswan-nm.install
 +++ b/debian/strongswan-nm.install
-@@ -1,2 +0,0 @@
+@@ -1,5 +0,0 @@
+-etc/strongswan.d/charon-nm.conf
 -usr/lib/ipsec/charon-nm
 -usr/share/dbus-1/system.d/nm-strongswan-service.conf
+-etc/strongswan.d/charon-nm.conf
+-usr/share/strongswan/templates/config/strongswan.d/charon-nm.conf
 -- 
-2.30.2
+2.51.2
 

--- a/scripts/package-build/strongswan/patches/strongswan/0005-T8099-enable-Module-Lattice-based-crypto-ML-KEM.patch
+++ b/scripts/package-build/strongswan/patches/strongswan/0005-T8099-enable-Module-Lattice-based-crypto-ML-KEM.patch
@@ -1,0 +1,63 @@
+From 7570cabe74c1dae0ba9b8216090e86a781db810c Mon Sep 17 00:00:00 2001
+From: Kyrylo Yatsenko <hedrok@gmail.com>
+Date: Mon, 8 Jun 2026 22:38:12 +0300
+Subject: [PATCH] T8099: enable Module-Lattice-based crypto (ML-KEM)
+
+---
+ debian/libstrongswan-extra-plugins.install | 4 ++++
+ debian/rules                               | 3 ++-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/debian/libstrongswan-extra-plugins.install b/debian/libstrongswan-extra-plugins.install
+index 3db1af5b5..ae59d6eb5 100644
+--- a/debian/libstrongswan-extra-plugins.install
++++ b/debian/libstrongswan-extra-plugins.install
+@@ -15,6 +15,7 @@ usr/lib/ipsec/plugins/libstrongswan-hmac.so
+ usr/lib/ipsec/plugins/libstrongswan-kdf.so
+ usr/lib/ipsec/plugins/libstrongswan-md5.so
+ usr/lib/ipsec/plugins/libstrongswan-mgf1.so
++usr/lib/ipsec/plugins/libstrongswan-ml.so
+ usr/lib/ipsec/plugins/libstrongswan-pgp.so
+ usr/lib/ipsec/plugins/libstrongswan-pkcs11.so
+ usr/lib/ipsec/plugins/libstrongswan-pkcs12.so
+@@ -39,6 +40,7 @@ usr/share/strongswan/templates/config/plugins/hmac.conf
+ usr/share/strongswan/templates/config/plugins/kdf.conf
+ usr/share/strongswan/templates/config/plugins/md5.conf
+ usr/share/strongswan/templates/config/plugins/mgf1.conf
++usr/share/strongswan/templates/config/plugins/ml.conf
+ usr/share/strongswan/templates/config/plugins/pgp.conf
+ usr/share/strongswan/templates/config/plugins/pkcs11.conf
+ usr/share/strongswan/templates/config/plugins/pkcs12.conf
+@@ -63,6 +65,7 @@ etc/strongswan.d/charon/hmac.conf
+ etc/strongswan.d/charon/kdf.conf
+ etc/strongswan.d/charon/md5.conf
+ etc/strongswan.d/charon/mgf1.conf
++etc/strongswan.d/charon/ml.conf
+ etc/strongswan.d/charon/pgp.conf
+ etc/strongswan.d/charon/pkcs11.conf
+ etc/strongswan.d/charon/pkcs12.conf
+@@ -87,6 +90,7 @@ etc/strongswan.d/charon-cmd/hmac.conf
+ etc/strongswan.d/charon-cmd/kdf.conf
+ etc/strongswan.d/charon-cmd/md5.conf
+ etc/strongswan.d/charon-cmd/mgf1.conf
++etc/strongswan.d/charon-cmd/ml.conf
+ etc/strongswan.d/charon-cmd/pkcs11.conf
+ etc/strongswan.d/charon-cmd/pkcs12.conf
+ etc/strongswan.d/charon-cmd/rc2.conf
+diff --git a/debian/rules b/debian/rules
+index abc637a1c..097ce4b22 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -10,7 +10,8 @@ CONFIGUREARGS_VYOS := --disable-warnings \
+                --disable-mediation \
+                --disable-mysql \
+                --disable-sqlite \
+-               --disable-sql
++               --disable-sql \
++			   --enable-ml
+ 
+ CONFIGUREARGS := --libdir=/usr/lib --libexecdir=/usr/lib \
+ 		--enable-addrblock \
+-- 
+2.51.2
+


### PR DESCRIPTION
## Change summary

* Fix strongswan build (separate commit)
* 30-strongswan-configs.chroot to not change /etc/strongswan.d/charon.conf as the file is part of packagestrongswan-charon that should not be installed
* Rebase all patches
* Enable ML-KEM for Post Quant

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8099

## Related PR(s)

* vyos-1x PR: https://github.com/vyos/vyos-1x/pull/5267

## How to test / Smoketest result

1. Smoketest: `/usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py`
2. To see post quantum availability:

```
vyos@r1:~$ sudo swanctl --list-algs | grep ML_KEM
  ML_KEM_512[ml]
  ML_KEM_768[ml]
  ML_KEM_1024[ml]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly