### PR TITLE
T9013: Add FRR patch to fix BMP connect source-interface deletion

### DIFF
--- a/scripts/package-build/frr/patches/frr/0025-bgpd-fix-bmp-connect-deletion-with-source-interface.patch
+++ b/scripts/package-build/frr/patches/frr/0025-bgpd-fix-bmp-connect-deletion-with-source-interface.patch
@@ -1,0 +1,31 @@
+From d8923603c8aab212e923dccc16de9bb4c22c6846 Mon Sep 17 00:00:00 2001
+From: Nataliia Solomko <natalirs1985@gmail.com>
+Date: Wed, 24 Jun 2026 16:03:45 +0300
+Subject: [PATCH] bgpd: fix bmp connect deletion with source-interface
+
+bmp_connect() rejects deletion when source-interface is provided.
+The check compares the configured source-interface with the one
+in the command. It uses !strcmp(), which is true when the strings
+are equal. But this result feeds an if-block that rejects the
+deletion. So the command is rejected exactly when the
+source-interface is correct, and accepted when it is wrong.
+Fix by changing !strcmp() to strcmp().
+---
+ bgpd/bgp_bmp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bgpd/bgp_bmp.c b/bgpd/bgp_bmp.c
+index 40f70f5a7c..f8c3f1c838 100644
+--- a/bgpd/bgp_bmp.c
++++ b/bgpd/bgp_bmp.c
+@@ -2996,7 +2996,7 @@ DEFPY(bmp_connect,
+ 		/* connection deletion need same hostname port and interface */
+ 		if (ba->ifsrc || srcif)
+ 			if ((!ba->ifsrc) || (!srcif) ||
+-			    !strcmp(ba->ifsrc, srcif)) {
++			    strcmp(ba->ifsrc, srcif)) {
+ 				vty_out(vty,
+ 					"%% No such active connection found\n");
+ 				return CMD_WARNING;
+-- 
+2.51.0


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9013
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Before the fix:
```
vyos(config-bgp-bmp)# 
vyos(config-bgp-bmp)# bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth1
vyos(config-bgp-bmp)# do show running-config 
Building configuration...

Current configuration:
!
frr version 10.5.2
frr defaults traditional
hostname vyos
log syslog notifications
log timestamp precision 3
no log unique-id
service integrated-vtysh-config
!
ip route 0.0.0.0/0 XX.XX.XX.254 eth2 tag 210 210
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp reject-as-sets
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 bmp targets test
  bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth1
 exit
exit
!
end
vyos(config-bgp-bmp)# no bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth1
% No such active connection found
vyos(config-bgp-bmp)# no bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth0
vyos(config-bgp-bmp)# do show running-config 
Building configuration...

Current configuration:
!
frr version 10.5.2
frr defaults traditional
hostname vyos
log syslog notifications
log timestamp precision 3
no log unique-id
service integrated-vtysh-config
!
ip route 0.0.0.0/0 XX.XX.XX.254 eth2 tag 210 210
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp reject-as-sets
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 bmp targets test
 exit
exit
!
end
vyos(config-bgp-bmp)# 
```

After the fix:
```
vyos(config-bgp-bmp)# 
vyos(config-bgp-bmp)# bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth1
vyos(config-bgp-bmp)# do show running-config 
Building configuration...

Current configuration:
!
frr version 10.6.1
frr defaults traditional
hostname vyos
log syslog notifications
log timestamp precision 3
no log unique-id
service integrated-vtysh-config
!
ip route 0.0.0.0/0 xx.xx.xx.254 eth2 tag 210 210
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp reject-as-sets
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 bmp targets test
  bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth1
 exit
exit
!
end
vyos(config-bgp-bmp)# no bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth1
vyos(config-bgp-bmp)# do show running-config 
Building configuration...

Current configuration:
!
frr version 10.6.1
frr defaults traditional
hostname vyos
log syslog notifications
log timestamp precision 3
no log unique-id
service integrated-vtysh-config
!
ip route 0.0.0.0/0 xx.xx.xx.254 eth2 tag 210 210
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp reject-as-sets
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 bmp targets test
 exit
exit
!
end
vyos(config-bgp-bmp)# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
