### PR TITLE
Kernel: T9010: update existing patches to remove "hunk off" notices

### DIFF
--- a/scripts/package-build/linux-kernel/patches/kernel/0001-linkstate-ip-device-attribute.patch
+++ b/scripts/package-build/linux-kernel/patches/kernel/0001-linkstate-ip-device-attribute.patch
@@ -27,6 +27,7 @@ Refreshed against Linux 6.18.x:
  8 files changed, 34 insertions(+)
 
 diff --git a/Documentation/networking/ip-sysctl.rst b/Documentation/networking/ip-sysctl.rst
+index 7a637e87005f..982c76d0b0ab 100644
 --- a/Documentation/networking/ip-sysctl.rst
 +++ b/Documentation/networking/ip-sysctl.rst
 @@ -2042,6 +2042,17 @@ src_valid_mark - BOOLEAN
@@ -48,6 +49,7 @@ diff --git a/Documentation/networking/ip-sysctl.rst b/Documentation/networking/i
  	- 1 - Allows you to have multiple network interfaces on the same
  	  subnet, and have the ARPs for each interface be answered
 diff --git a/include/linux/inetdevice.h b/include/linux/inetdevice.h
+index dccbeb25f701..b16f70e491d6 100644
 --- a/include/linux/inetdevice.h
 +++ b/include/linux/inetdevice.h
 @@ -139,6 +139,7 @@ static inline void ipv4_devconf_setall(struct in_device *in_dev)
@@ -59,6 +61,7 @@ diff --git a/include/linux/inetdevice.h b/include/linux/inetdevice.h
  struct in_ifaddr {
  	struct hlist_node	addr_lst;
 diff --git a/include/linux/ipv6.h b/include/linux/ipv6.h
+index 7294e4e89b79..5243afbd98b8 100644
 --- a/include/linux/ipv6.h
 +++ b/include/linux/ipv6.h
 @@ -91,6 +91,7 @@ struct ipv6_devconf {
@@ -70,6 +73,7 @@ diff --git a/include/linux/ipv6.h b/include/linux/ipv6.h
  	struct ctl_table_header *sysctl_header;
  };
 diff --git a/include/uapi/linux/ip.h b/include/uapi/linux/ip.h
+index 5bd7ce934d74..cfe694a9810f 100644
 --- a/include/uapi/linux/ip.h
 +++ b/include/uapi/linux/ip.h
 @@ -189,6 +189,7 @@ enum
@@ -81,6 +85,7 @@ diff --git a/include/uapi/linux/ip.h b/include/uapi/linux/ip.h
  };
  
 diff --git a/include/uapi/linux/ipv6.h b/include/uapi/linux/ipv6.h
+index d4d3ae774b26..8495f1b69a64 100644
 --- a/include/uapi/linux/ipv6.h
 +++ b/include/uapi/linux/ipv6.h
 @@ -200,6 +200,7 @@ enum {
@@ -92,6 +97,7 @@ diff --git a/include/uapi/linux/ipv6.h b/include/uapi/linux/ipv6.h
  };
  
 diff --git a/net/ipv4/devinet.c b/net/ipv4/devinet.c
+index 942a887bf089..e6df2bfc4e40 100644
 --- a/net/ipv4/devinet.c
 +++ b/net/ipv4/devinet.c
 @@ -2652,6 +2652,7 @@ static struct devinet_sysctl_table {
@@ -103,9 +109,10 @@ diff --git a/net/ipv4/devinet.c b/net/ipv4/devinet.c
  };
  
 diff --git a/net/ipv6/addrconf.c b/net/ipv6/addrconf.c
+index b2e1328371d3..769d4e1f5cbf 100644
 --- a/net/ipv6/addrconf.c
 +++ b/net/ipv6/addrconf.c
-@@ -5716,6 +5716,7 @@ static void ipv6_store_devconf(const struct ipv6_devconf *cnf,
+@@ -5718,6 +5718,7 @@ static void ipv6_store_devconf(const struct ipv6_devconf *cnf,
  		READ_ONCE(cnf->accept_untracked_na);
  	array[DEVCONF_ACCEPT_RA_MIN_LFT] = READ_ONCE(cnf->accept_ra_min_lft);
  	array[DEVCONF_FORCE_FORWARDING] = READ_ONCE(cnf->force_forwarding);
@@ -113,7 +120,7 @@ diff --git a/net/ipv6/addrconf.c b/net/ipv6/addrconf.c
  }
  
  static inline size_t inet6_ifla6_size(void)
-@@ -7251,6 +7252,13 @@ static const struct ctl_table addrconf_sysctl[] = {
+@@ -7253,6 +7254,13 @@ static const struct ctl_table addrconf_sysctl[] = {
  		.extra1		= (void *)SYSCTL_ZERO,
  		.extra2		= (void *)SYSCTL_ONE,
  	},
@@ -128,9 +135,10 @@ diff --git a/net/ipv6/addrconf.c b/net/ipv6/addrconf.c
  		.procname	= "ioam6_id",
  		.data		= &ipv6_devconf.ioam6_id,
 diff --git a/net/ipv6/route.c b/net/ipv6/route.c
+index f89220929c4e..8f92ef14d884 100644
 --- a/net/ipv6/route.c
 +++ b/net/ipv6/route.c
-@@ -714,6 +714,14 @@ static inline void rt6_probe(struct fib6_nh *fib6_nh)
+@@ -717,6 +717,14 @@ static inline void rt6_probe(struct fib6_nh *fib6_nh)
  }
  #endif
  
@@ -145,7 +153,7 @@ diff --git a/net/ipv6/route.c b/net/ipv6/route.c
  /*
   * Default Router Selection (RFC 2461 6.3.6)
   */
-@@ -755,6 +763,8 @@ static int rt6_score_route(const struct fib6_nh *nh, u32 fib6_flags, int oif,
+@@ -758,6 +766,8 @@ static int rt6_score_route(const struct fib6_nh *nh, u32 fib6_flags, int oif,
  
  	if (!m && (strict & RT6_LOOKUP_F_IFACE))
  		return RT6_NUD_FAIL_HARD;

--- a/scripts/package-build/linux-kernel/patches/kernel/0002-build-linux-perf-package.patch
+++ b/scripts/package-build/linux-kernel/patches/kernel/0002-build-linux-perf-package.patch
@@ -20,15 +20,16 @@ iterated over every package); since v6.7 the package build is driven
 per-package from debian/rules, so we have to extend that mechanism
 instead.
 ---
- scripts/package/builddeb      | 16 ++++++++++++++++
- scripts/package/debian/rules  |  3 ++-
- scripts/package/mkdebian      | 12 ++++++++++++
+ scripts/package/builddeb     | 16 ++++++++++++++++
+ scripts/package/debian/rules |  3 ++-
+ scripts/package/mkdebian     | 12 ++++++++++++
  3 files changed, 30 insertions(+), 1 deletion(-)
 
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
+index ba1defc61652..61e5d3b8447d 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
-@@ -156,6 +156,20 @@ install_libc_headers () {
+@@ -162,6 +162,20 @@ install_libc_headers () {
  	mv "$pdir/usr/include/asm" "$pdir/usr/include/${DEB_HOST_MULTIARCH}"
  }
  
@@ -49,7 +50,7 @@ diff --git a/scripts/package/builddeb b/scripts/package/builddeb
  package=$1
  
  case "${package}" in
-@@ -167,4 +181,6 @@ linux-libc-dev)
+@@ -173,4 +187,6 @@ linux-libc-dev)
  	install_libc_headers "${package}";;
  linux-headers-*)
  	install_kernel_headers "${package}";;
@@ -57,6 +58,7 @@ diff --git a/scripts/package/builddeb b/scripts/package/builddeb
 +	install_perf "${package}";;
  esac
 diff --git a/scripts/package/debian/rules b/scripts/package/debian/rules
+index a417a7f8bbc1..3b6905034b4c 100755
 --- a/scripts/package/debian/rules
 +++ b/scripts/package/debian/rules
 @@ -27,13 +27,14 @@ make-opts = ARCH=$(ARCH) KERNELRELEASE=$(KERNELRELEASE) \
@@ -76,6 +78,7 @@ diff --git a/scripts/package/debian/rules b/scripts/package/debian/rules
  mk-files = $(patsubst binary-%,debian/%.files,$1)
  package = $($(@:binary-%=%-package))
 diff --git a/scripts/package/mkdebian b/scripts/package/mkdebian
+index d4b007b38a47..45a5f06b803d 100755
 --- a/scripts/package/mkdebian
 +++ b/scripts/package/mkdebian
 @@ -247,6 +247,18 @@ Description: Linux kernel headers for ${KERNELRELEASE} on $debarch


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Just update the existing Kernel patches to cleanly apply to the latest Kernel version.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9010

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1224

## How to test / Smoketest result

Kernel compiles and no "hunk off" lines appear.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
