### PR TITLE
ci: T8490: fix typo in grub live-theme (icon_heigh -> icon_height)

### DIFF
--- a/data/live-build-config/bootloaders/grub-pc/live-theme/theme.txt
+++ b/data/live-build-config/bootloaders/grub-pc/live-theme/theme.txt
@@ -31,7 +31,7 @@ terminal-font: "Unifont Regular 16"
         item_padding = 0
         item_spacing = 4
 	icon_width = 0
-	icon_heigh = 0
+	icon_height = 0
 	item_icon_space = 0
 }
 


### PR DESCRIPTION
## What
Fix `icon_heigh` → `icon_height` in the GRUB2 PC live-theme `boot_menu` block.

## Why
`icon_height` is the GRUB2 boot_menu property; `icon_heigh` is a typo (an unknown property GRUB ignores). Icons are already disabled here via `icon_width = 0` + `item_icon_space = 0`, so the correction is **behaviour-neutral**. Clears this repo's lone typos-check hit ahead of the T8490 ruleset pilot active flip.

Phase-0 CodeRabbit: no findings. Tracking: Phorge T8490 · Jira [IS-555](https://vyos.atlassian.net/browse/IS-555) (typos-ruleset pilot, Phase 2 Task 2.4).

🤖 Generated by [robots](https://vyos.io)


[IS-555]: https://vyos.atlassian.net/browse/IS-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ