### PR TITLE
ci: T9047: dispatch docker-image rebuild against production ref

### DIFF
--- a/.github/workflows/trigger-docker-image-build.yml
+++ b/.github/workflows/trigger-docker-image-build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     
     env:
-      REF: main  # Used for curl to trigger image build
+      REF: production  # Used for curl to trigger image build
 
     steps:
       - name: Checkout vyos/vyos-build repo


### PR DESCRIPTION
## What

One-line repoint: `env.REF` in `.github/workflows/trigger-docker-image-build.yml` changes from `main` to `production`.

## Why

This workflow curl-dispatches `VyOS-Networks/vyos-reusable-workflows`'s `build-docker-image.yml` via `workflow_dispatch`, hardcoding the target ref via `env.REF`. `main` on that repo is frozen at commit `376feb69` (2026-05-29) — it predates the vyosbot-PAT→App-token migration and still uses the retired `secrets.PAT` checkout pattern. `secrets.PAT` resolves empty in that execution context, so every dispatched run has been failing immediately at the checkout step:

```
The process '/usr/bin/git' failed with exit code 128
could not read Username for 'https://github.com': terminal prompts disabled
```

The fix for this exact bug already shipped — [vyos-reusable-workflows#123](https://github.com/VyOS-Networks/vyos-reusable-workflows/pull/123) (merged 2026-05-31) replaced the PAT-based checkout with a vyos-bot App installation-token mint, but only on `production`. `main` was never updated, and this caller was never repointed to the branch that has the fix.

The already-working automated path (`VyOS-Networks/vyos-stream-builds`'s `vyos-docker-image-build.yml`) already correctly targets `build-docker-image.yml@production` via `workflow_call` and has run 10/10 success since 2026-03-27 — this PR brings this caller's direct-`workflow_dispatch` path in line with that convention.

## Verification

Cause + fix both independently verified this session (checked-run annotations from the most recent failing run, direct content diff between `main`/`production` refs, PR #123's merge metadata). Dispatch-and-confirm-success against the live workflow is a **post-merge step** owned by the controller, not part of this PR — see IS-576 findings for the full verification-status table.

## Related

Advances: IS-576

🤖 Generated by [robots](https://vyos.io)
