### PR TITLE
openssl: T9083: fix APT detected package downgrade despite identical versions

### DIFF
--- a/scripts/package-build/openssl/package.toml
+++ b/scripts/package-build/openssl/package.toml
@@ -2,4 +2,5 @@
 name = "openssl"
 commit_id = "debian/openssl-3.0.20-1_deb12u2"
 scm_url = "https://salsa.debian.org/debian/openssl.git"
-build_cmd = "dpkg-buildpackage -us -uc -tc -b"
+pre_build_hook = "git reset --hard HEAD && git clean -ffdx"
+build_cmd = "sed -i '1s/)/+vyos1)/' debian/changelog && dpkg-buildpackage -us -uc -tc -b"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

VyOS rolling APT repo (packages.vyos.net/repositories/rolling) publishing its own openssl/libssl3 packages, pinned at priority 600 (higher than Debian's 500) causes a "poisoning" of the APT cache policy inside the chroot:

```
    openssl:
      Installed: 3.0.20-1~deb12u2
      Candidate: 3.0.20-1~deb12u2
      Version table:
        * 3.0.20-1~deb12u2 500   <- debian bookworm + bookworm-security
        * 3.0.20-1~deb12u2 600   <- packages.vyos.net rolling  (same version string, higher pin)
        * 3.0.17-1~deb12u2 500   <- bookworm-updates
``` 

This results in APT seeing a version-string tie between Debian's build and the VyOS repo build of the same package and, because of the pin-priority swap, classifies switching to the VyOS repo copy as a "downgrade".

This is fixed by appending a clear VyOS related marked to the package version, preventing any possible downgrade detection.

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9083

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
