### PR TITLE
T9099: improve test framework - add safeguards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,15 @@ build_dir := build
 ARCH := $(shell dpkg-architecture -qDEB_HOST_ARCH)
 ISO_PATH := $(build_dir)/live-image-$(ARCH).hybrid.iso
 
+# Test targets forward extra CLI arguments (e.g. `make test -- --match foo`)
+# to their scripts via $(MAKECMDGOALS). Those extra words are also goals as
+# far as make is concerned, so without this they'd fall through to the `%:`
+# flavor rule below and run build-vyos-image with garbage arguments.
+TEST_TARGETS := test test-no-interfaces test-no-interfaces-no-vpp test-interfaces test-vpp testc testcvpp testraid testsb testtpm test-ci-qcow2 test-image-update qemu-live
+ifneq ($(filter $(TEST_TARGETS),$(firstword $(MAKECMDGOALS))),)
+$(eval $(filter-out $(firstword $(MAKECMDGOALS)),$(MAKECMDGOALS)):;@:)
+endif
+
 .PHONY: all
 all:
 	@echo "Make what specifically?"

--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -599,11 +599,19 @@ def BOOTLOADERchooseSerialConsole(child, live: bool) -> None:
         time.sleep(BOOTLOADER_SLEEP)
         child.send(KEY_RETURN)
         time.sleep(BOOTLOADER_SLEEP)
+        # GRUB submenus never time out on their own, so confirm we actually
+        # landed on this submenu before navigating further - otherwise a
+        # dropped keypress leaves the VM stuck here until the login wait
+        # elsewhere expires
+        child.expect('Select console type', timeout=BOOTLOADER_TMO)
+
         # Select console type
         child.send(KEY_DOWN)
         time.sleep(BOOTLOADER_SLEEP)
         child.send(KEY_RETURN)
         time.sleep(BOOTLOADER_SLEEP)
+        child.expect(r'ttyS \(serial\)', timeout=BOOTLOADER_TMO)
+
         # *ttyS (serial)
         child.send(KEY_DOWN)
         time.sleep(BOOTLOADER_SLEEP)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Harden both the testsuite for navigating trogh GRUB serial console settings as well as a sleeping Makefile issue where  a atch-all rule was eating forwarded test arguments.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9099

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
