### PR TITLE
Kernel: T9103: fix arm64 syscalltbl path breaking linux-perf package build

### DIFF
--- a/scripts/package-build/linux-kernel/patches/kernel/0005-arm64-fix-relative-syscalltbl-path-in-Makefile.sysc.patch
+++ b/scripts/package-build/linux-kernel/patches/kernel/0005-arm64-fix-relative-syscalltbl-path-in-Makefile.sysc.patch
@@ -1,0 +1,57 @@
+From: Christian Breunig <christian@breunig.cc>
+Date: Sat, 18 Jul 2026 18:30:00 +0000
+Subject: [PATCH] arm64: fix relative syscalltbl path in Makefile.syscalls
+
+Building the "linux-perf" Debian package (added by
+0002-build-linux-perf-package.patch, via install_perf() invoking
+"make -C tools/perf ... install") reproducibly fails on an arm64 build
+host with:
+
+  make[9]: *** No rule to make target
+  '.../tools/perf/libperf/arch/arm64/include/generated/uapi/asm/unistd_64.h'.
+  Stop.
+
+Root cause: tools/lib/perf/Makefile's "uapi-asm-generic:" recipe invokes
+scripts/Makefile.asm-headers without "-C $(srctree)", so it inherits
+whatever working directory tools/lib/perf/Makefile itself was invoked
+with - which is tools/lib/perf/, not the kernel source root. This is
+harmless for the generic default:
+
+  syscalltbl := $(srctree)/scripts/syscall.tbl
+
+...which is absolute and thus resolves correctly regardless of the
+working directory. arch/arm64/kernel/Makefile.syscalls, however,
+overrides this with a relative path:
+
+  syscalltbl = arch/arm64/tools/syscall_%.tbl
+
+When SRCARCH=arm64 (true both for the target kernel and, on a native
+arm64 build host, for tools/perf's own build), this relative path is
+looked up relative to tools/lib/perf/ instead of the kernel root, does
+not exist there, and the "unistd_%.h" pattern rule that depends on it
+can no longer be matched - so make reports no rule for the target at
+all, rather than a missing-prerequisite error.
+
+This only surfaces on a native arm64 build host: on x86_64 hosts (the
+common case for cross-building arm64 kernels) tools/perf builds for the
+x86_64 host architecture, which has no such override and always uses
+the safe, absolute default path.
+
+Fix by making arm64's override absolute too, matching the default and
+every other reference in this file's callers.
+---
+ arch/arm64/kernel/Makefile.syscalls | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/kernel/Makefile.syscalls b/arch/arm64/kernel/Makefile.syscalls
+index 0542a718871a..958f2335ec1b 100644
+--- a/arch/arm64/kernel/Makefile.syscalls
++++ b/arch/arm64/kernel/Makefile.syscalls
+@@ -3,4 +3,4 @@
+ syscall_abis_32 +=
+ syscall_abis_64 += renameat rlimit memfd_secret
+
+-syscalltbl = arch/arm64/tools/syscall_%.tbl
++syscalltbl = $(srctree)/arch/arm64/tools/syscall_%.tbl
+--
+2.39.5


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Building linux-perf-* on a native arm64 build host failed with "No rule to make target '.../unistd_64.h'" because arch/arm64/kernel/Makefile.syscalls overrides syscalltbl with a path relative to the kernel root, but tools/lib/perf/Makefile invokes the header generator from tools/lib/perf/ instead. Make the override absolute, matching the srctree-prefixed default.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9103

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
