### PR TITLE
Kernel: T9195: Update Linux Kernel to 6.18.44

### DIFF
--- a/data/defaults.toml
+++ b/data/defaults.toml
@@ -14,7 +14,7 @@ vyos_mirror = "https://packages.vyos.net/repositories/rolling"
 vyos_branch = "rolling"
 release_train = "rolling"
 
-kernel_version = "6.18.41"
+kernel_version = "6.18.44"
 kernel_flavor = "vyos"
 bootloaders = "syslinux,grub-efi"
 


### PR DESCRIPTION
## Change summary

Bump `kernel_version` in `data/defaults.toml` from `6.18.41` to `6.18.44`.

Kernel 6.18.39 through 6.18.41 fail to boot on Intel **Denverton (DNV)**, **Ice Lake
Xeon D (ICX-D/CDF)** and **Snowridge (SNR)** platforms. Every rolling nightly from
**2026.08.04** onward is affected, since `97c2a87c0` moved us to 6.18.41.

### Root cause

Upstream `b1b4efea05a5` ("serial: 8250_mid: Disable DMA for selected platforms", in
stable since **v6.18.39**) set `dnv_board.setup` / `dnv_board.exit` to
`PTR_IF(false, ...)` — i.e. NULL — to work around a documented DMA errata (Denverton
DNV60, Ice Lake Xeon D ICXD65, Snowridge SNR44). It did not add NULL checks at the
three call sites in `mid8250_probe()` and `mid8250_remove()`.

We build `CONFIG_SERIAL_8250_MID=y`, so the driver is built in and the NULL function
pointer call happens during early PCI probe. The probing kworker dies with interrupts
disabled and the boot wedges — with our default `console=tty0` cmdline and no
`earlycon`, this presents as a silent hang right after GRUB's "Booting …" line, with
no panic visible at all.

Reproduced on a Supermicro SYS-510D-10C-FN6P (X12SDV-10C-SP6F, BIOS 2.2a 04/28/2026),
booting `2026.08.05-0033-rolling` with `earlycon=efifb keep_bootcon ignore_loglevel`
appended:

```
[   34.910229] CPU: 0 UID: 0 PID: 11 Comm: kworker/0:1 Not tainted 6.18.41-vyos #1 NONE
[   34.910229] Hardware name: Supermicro SYS-510D-10C-FN6P/X12SDV-10C-SP6F, BIOS 2.2a 04/28/2026
[   34.910229] Workqueue: events work_for_cpu_fn
[   34.910229] RIP: 0010:0x0
[   34.910229] Code: Unable to access opcode bytes at 0xffffffffffffffd6.
[   34.910229] CR2: ffffffffffffffd6
[   34.910229] Call Trace:
[   34.910229]  <TASK>
[   34.910229]  mid8250_probe.part.0+0x10c/0x230
[   36.533129]  ? __pfx_mid8250_set_termios+0x10/0x10
[   36.533129]  local_pci_probe+0x41/0x90
[   36.533129]  work_for_cpu_fn+0x16/0x20
[   36.533129]  process_one_work+0x187/0x340
[   36.533129]  worker_thread+0x19d/0x310
[   36.533129]  kthread+0xe6/0x200
[   36.533129]  ret_from_fork+0x1a9/0x1e0
[   36.533129]  ret_from_fork_asm+0x1a/0x30
[   36.533129]  </TASK>
[   36.533129] Modules linked in:
[   36.533129] note: kworker/0:1[11] exited with irqs disabled
```

`Modules linked in:` is empty, consistent with the built-in driver oopsing before any
module loads.

### Fix

Upstream `7fb13fd7e9a5` ("serial: 8250_mid: Fix NULL function pointer dereference on
DNV/ICX-D/SNR platforms") adds the missing guards and is in stable as of **v6.18.42**
(applied to `linux-6.18.y` on 2026-08-03). Anything from .42 up resolves it; this PR
takes **.44**, the current 6.18.y tip.

### Patch-set compatibility

All five patches under `scripts/package-build/linux-kernel/patches/kernel/` still
apply. Of the files they touch, only `net/ipv6/route.c` changed between v6.18.41 and
v6.18.44 — `1db34097998c` ("ipv6: Change allocation flags to match rcu_read_lock
section requirements"), which edits `__ip6_del_rt_siblings()` around line 4011. The
`0001-linkstate-ip-device-attribute.patch` hunks are `rt6_link_filter()` /
`rt6_score_route()` around lines 717 and 758. No overlap; context offsets only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Task(s)

* https://vyos.dev/T9195 — Rolling images 2026.08.04+ do not boot on Denverton / Ice
  Lake Xeon D / Snowridge

Supersedes the 6.18.41 bump from `97c2a87c0` (T9067).

## Related PR(s)

None.

## How to test / Smoketest result

**Verified so far**

The diagnosis was confirmed on the affected host without changing images: appending
`initcall_blacklist=mid8250_pci_driver_init` to the 6.18.41 kernel cmdline stops
`8250_mid` from registering, the probe never runs, and the system boots normally. That
isolates the fault to this driver's probe path.

Static verification of the bump itself:

* v6.18.44 source carries the fix — `if (mid->board->setup)` in `mid8250_probe()` and
  `if (mid->board->exit)` in `mid8250_remove()`. v6.18.41 has the bare dereferences.
* Stable boundaries confirmed against `linux-6.18.y`: the regression `1cd54e217c6e` was
  applied 2026-07-18 (v6.18.39), the fix `b2a3eeb57ba2` on 2026-08-03 (v6.18.42).
* All five `patches/kernel/` patches were **applied against the real v6.18.44 sources** of
  the 19 files they touch, and all five pass `git apply --check` (zero fuzz, stricter than
  the quilt path the build uses):

  ```
  PASS  0001-linkstate-ip-device-attribute.patch
  PASS  0002-build-linux-perf-package.patch
  PASS  0003-Kernel-T8914-add-support-for-2.5G-pluggables-on-BCM5.patch
  PASS  0004-l2tp-defer-route-at-tunnel-create.patch
  PASS  0005-arm64-fix-relative-syscalltbl-path-in-Makefile.sysc.patch
  ```

  Of the files those patches touch, only `net/ipv6/route.c` changed in the
  v6.18.41..v6.18.44 range (`1db34097998c`, in `__ip6_del_rt_siblings()` around line 4011),
  which does not overlap patch 0001's `rt6_link_filter()` / `rt6_score_route()` hunks around
  lines 717 and 758.

**A note on CI: the checks on this PR do not exercise this change.**

`package-smoketest.yml` runs on `pull_request_target`, and its `build_iso` job checks out
`repository: ${{ github.repository }}` at `ref: <base branch>` — so it builds `rolling`, not
this PR's head, and `test_config_load` then consumes that artifact. `build_iso` also never
compiles a kernel: live-build apt-installs a prebuilt `linux-image-<kernel_version>-vyos`
from the mirror, where only `linux-image-6.18.41-vyos` currently exists. A green run here
means `rolling` is healthy; it says nothing about 6.18.44. Flagging it so the green ticks
aren't mistaken for validation of the bump.

Per `trigger_rebuild_packages.yml`, whose `linux-kernel` paths-filter includes
`data/defaults.toml`, merging to `rolling` is what dispatches the kernel package build — so
6.18.44 is first compiled, and these patches first applied by the build itself, only after
merge. Hence the local verification above.

**Still pending**

A full ISO build plus boot test on affected hardware (Ice Lake-D SYS-510D-10C-FN6P) and
`make test` on an unaffected x86 platform. I will add results here before this is
merged — happy to hold the PR until then if maintainers prefer.

## Checklist:

- [x] I have read the **CONTRIBUTING** document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

