### PR TITLE
Testsuite: T9214: fix GRUB auto-boot race in console-select navigation

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -595,12 +595,18 @@ def BOOTLOADERchooseSerialConsole(child, live: bool) -> None:
 
         # Wait for GRUB
         child.expect(GRUB_STRING, timeout=BOOTLOADER_TMO)
-        time.sleep(BOOTLOADER_LOAD_TMO)
 
+        # Unlike the live ISO menus (10s timeout), the installed system's
+        # top-level menu auto-boots its default entry after ~BOOTLOADER_LOAD_TMO
+        # seconds - the same delay this script would otherwise sleep before
+        # sending any key. Under host load that leaves no margin: GRUB can
+        # auto-boot before "Boot options" is ever selected. Send the first
+        # navigation key immediately to cancel the countdown, then give the
+        # screen time to settle.
         # Select GRUB serial console
         # Boot options
         child.send(KEY_DOWN)
-        time.sleep(BOOTLOADER_SLEEP)
+        time.sleep(BOOTLOADER_LOAD_TMO)
         child.send(KEY_RETURN)
         time.sleep(BOOTLOADER_SLEEP)
         # GRUB submenus never time out on their own, so confirm we actually


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 2d525e9a88 (`Testsuite: T9099: harden GRUB console-select navigation with expect() check`) added `expect()` checks after each GRUB submenu transition in `BOOTLOADERchooseSerialConsole()`, but did not fix the underlying race it described: on the installed system, `BOOTLOADER_LOAD_TMO (5s)` is slept before the first `KEY_DOWN` is sent, while that system's top-level GRUB menu auto-boots its default entry after the same 5s with no margin.

Under host load the countdown could win, so GRUB booted straight past "Boot options" and the new `child.expect('Select console type', ...)` then blocked for the full `BOOTLOADER_TMO` waiting for text that would never appear.

Send the first navigation key immediately after the GRUB banner is detected instead of sleeping first, so the auto-boot countdown is cancelled right away rather than raced against.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9099

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1269

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
