### PR TITLE
Testsuite: T9217: use separate SCSI controller for RAID-1 UEFI testcase

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -302,8 +302,14 @@ def get_qemu_cmd(name, enable_uefi, disk_img, raid=None, iso_img=None, tpm=False
         -device scsi-hd,bus=scsi0.0,drive=drive-hd1,id=hd1,bootindex=1'
 
     if raid:
-        cmd += f' -drive format={disk_format},file={raid},if=none,media=disk,id=drive-hd2,readonly=off' \
-               f' -device scsi-hd,bus=scsi0.0,drive=drive-hd2,id=hd2,bootindex=2'
+        # RAID member disks each get their own virtio-scsi-pci controller.
+        # OVMF only appears to honor QEMU's per-device "bootindex" when disks
+        # sit behind separate PCI controllers - sharing one controller via
+        # SCSI LUN makes it always boot LUN 0 regardless of bootindex, which
+        # breaks the RAID-failure simulation's boot-priority swap under UEFI.
+        cmd += f' -device virtio-scsi-pci,id=scsi1' \
+               f' -drive format={disk_format},file={raid},if=none,media=disk,id=drive-hd2,readonly=off' \
+               f' -device scsi-hd,bus=scsi1.0,drive=drive-hd2,id=hd2,bootindex=2'
 
     if tpm:
         cmd += f' -chardev socket,id=chrtpm,path={tpm_sock}' \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

`sudo make testraid -- --uefi` fails. Install and first boot succeed normally under UEFI, but the test then simulates a failed RAID-1 member by wiping the primary disk and rebooting off the surviving mirror disk. That reboot never reaches a login prompt. 

OVMF only honors QEMU's per-device "bootindex" when disks sit behind separate PCI controllers; sharing one virtio-scsi-pci controller via SCSI LUN makes it always boot LUN 0 regardless of bootindex.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9217

## How to test / Smoketest result

Now both testcases run to completion:
* "sudo make testraid"
* "sudo make testraid -- --uefi"

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
