### PR TITLE
T5498: initramfs-tools: Add script executing fsck during boot

### DIFF
--- a/data/live-build-config/includes.chroot/etc/initramfs-tools/scripts/init-premount/run_e2fsck
+++ b/data/live-build-config/includes.chroot/etc/initramfs-tools/scripts/init-premount/run_e2fsck
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+PREREQS=""
+prereqs() { echo "$PREREQS"; }
+
+case "$1" in
+    prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+source /scripts/functions
+log_begin_msg "Running e2fsck"
+
+persistent_partition=`blkid -L persistence -o device`
+if test -n "${persistent_partition}"; then
+  e2fsck -p "${persistent_partition}"
+  rc=$?
+  if [ "${rc}" -le 1 ]; then
+    log_success_msg "fsck succeded"
+  elif [ "${rc}" -eq 2 ]; then
+    log_success_msg "fsck succeded, but the system should be rebooted, reboot will occur shortly"
+    log_end_msg
+    reboot
+  else
+    log_failure_msg "fsck failed returning code ${rc}"
+  fi
+else
+  log_warning_msg "No partition named persistence found"
+fi
+
+log_end_msg


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
Add a hacked init-premount script to initramfs-tools that runs e2fsck -p on the partition containing the root partition (it looks for the label persistence, other filters could be choosen).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T5498

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Since it's just another file in the chroot-include, I don't see that smoketests are applicable.
In the output of `dumpe2fs` shows at `Last checked` a more recent date than the end of 2024.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
