### PR TITLE
oci: T9265: add support for ARM64 container image generation

### DIFF
--- a/scripts/iso-to-oci
+++ b/scripts/iso-to-oci
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -euo pipefail
-
 cleanup() {
     if [[ -n "${WORKDIR:-}" && -d "${WORKDIR:-}" ]]; then
         rm -rf "${WORKDIR}"
@@ -57,6 +55,8 @@ xorriso -osirrox on -indev "${ISO}" -extract /live/filesystem.squashfs "${ROOTFS
 echo "I: extracting squashfs content"
 unsquashfs -follow -dest "${UNSQUASHFS}/" "${ROOTFS}/live/filesystem.squashfs" >/dev/null 2>&1
 VERSION="$(jq --raw-output .version "${ROOTFS}/version.json")"
+ARCH="$(jq --raw-output .architecture "${ROOTFS}/version.json")"
+OCI_IMAGE="vyos-${VERSION}-oci-${ARCH}.tar"
 
 # fix locales for correct system configuration loading
 sed -i 's/^LANG=.*$/LANG=C.UTF-8/' "${UNSQUASHFS}/etc/default/locale"
@@ -82,12 +82,12 @@ rm -rf "${UNSQUASHFS}/opt/vyatta/share/vyatta-cfg/templates/system/option/perfor
 ln -s /opt/vyatta/etc/config "${UNSQUASHFS}/config"
 
 # create docker image
-echo "I: generate OCI container image vyos-$VERSION.tar"
-tar -C "${UNSQUASHFS}" -c . -f "vyos-${VERSION}.tar"
+echo "I: generate OCI container image ${OCI_IMAGE}"
+tar -C "${UNSQUASHFS}" -c . -f "${OCI_IMAGE}"
 
 echo "I: to import the previously generated OCI image to your local images run:"
 echo ""
-echo "   docker import vyos-$VERSION.tar vyos:$VERSION --change 'CMD ["/sbin/init"]'"
+echo "   docker import --platform=linux/$ARCH $OCI_IMAGE vyos:$VERSION --change 'CMD ["/sbin/init"]'"
 echo ""
 
 cleanup


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Add CPU architecture support for OCI image generation for use with e.g. containerlab

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9265

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/2226

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
