### PR TITLE
T5498: Add script to run e2fsck -p to initramfs-tools

### DIFF
--- a/data/live-build-config/includes.chroot/etc/initramfs-tools/scripts/init-premount/run_e2fsck
+++ b/data/live-build-config/includes.chroot/etc/initramfs-tools/scripts/init-premount/run_e2fsck
@@ -15,8 +15,7 @@ log_begin_msg "Running e2fsck"
 
 persistent_partition=`blkid -L persistence -o device`
 
-
-# check unmounted filesystem
+# check if partition has been found and is not mounted
 if test -n "${persistent_partition}" && ! grep -q "^${persistent_partition} " '/proc/mounts'; then
   e2fsck -p "${persistent_partition}"
   rc=$?
@@ -31,8 +30,10 @@ if test -n "${persistent_partition}" && ! grep -q "^${persistent_partition} " '/
   else
     log_failure_msg "fsck failed returning code ${rc}"
   fi
+# in case the partition is mounted
 elif test -n "${persistent_partition}"; then
   log_failure_msg "filesystem already mounted"
+# no partition has been found
 else
   log_warning_msg "No partition named persistence found"
 fi

--- a/data/live-build-config/includes.chroot/etc/initramfs-tools/scripts/init-premount/run_e2fsck
+++ b/data/live-build-config/includes.chroot/etc/initramfs-tools/scripts/init-premount/run_e2fsck
@@ -15,7 +15,7 @@ log_begin_msg "Running e2fsck"
 
 persistent_partition=`blkid -L persistence -o device`
 
-# check if partition has been found and is not mounted
+# this first if checks if a partition with label=='persistence' exists and is not already mounted.
 if test -n "${persistent_partition}" && ! grep -q "^${persistent_partition} " '/proc/mounts'; then
   e2fsck -p "${persistent_partition}"
   rc=$?
@@ -30,10 +30,8 @@ if test -n "${persistent_partition}" && ! grep -q "^${persistent_partition} " '/
   else
     log_failure_msg "fsck failed returning code ${rc}"
   fi
-# in case the partition is mounted
 elif test -n "${persistent_partition}"; then
   log_failure_msg "filesystem already mounted"
-# no partition has been found
 else
   log_warning_msg "No partition named persistence found"
 fi

--- a/data/live-build-config/includes.chroot/etc/initramfs-tools/scripts/init-premount/run_e2fsck
+++ b/data/live-build-config/includes.chroot/etc/initramfs-tools/scripts/init-premount/run_e2fsck
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+PREREQS=""
+prereqs() { echo "$PREREQS"; }
+
+case "$1" in
+    prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+. /scripts/functions
+log_begin_msg "Running e2fsck"
+
+persistent_partition=`blkid -L persistence -o device`
+
+
+# check unmounted filesystem
+if test -n "${persistent_partition}" && ! grep -q "^${persistent_partition} " '/proc/mounts'; then
+  e2fsck -p "${persistent_partition}"
+  rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    log_success_msg "fsck succeeded with no errors found"
+  elif [ "${rc}" -eq 1 ]; then
+    log_success_msg "fsck succeeded"
+  elif [ "${rc}" -eq 2 ]; then
+    log_success_msg "fsck succeeded, but the system should be rebooted, reboot will occur shortly"
+    log_end_msg
+    reboot
+  else
+    log_failure_msg "fsck failed returning code ${rc}"
+  fi
+elif test -n "${persistent_partition}"; then
+  log_failure_msg "filesystem already mounted"
+else
+  log_warning_msg "No partition named persistence found"
+fi
+
+log_end_msg


### PR DESCRIPTION
## Change summary
Because boot=live is set on the kernel's command line, the standard fsck does not work.

Adds a hacked script that looks for a partition labele persistence and runs an `e2fsck -p`, as it would happen normaly during the standard boot time.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T5498

## Related PR(s)
No found.

## How to test / Smoketest result
In my opinion, smoketests are not applicable. Those are checks on a running system. This is an additional file in the initramfs. The chroot-includes should not require any special checks.

If you run `dumpe2fs`, `Last checked` should show a date more recent than the end of 2024.
You can also look in the output from the early boot stages for errors.
As pointed out in https://github.com/vyos/vyos-build/pull/1283#pullrequestreview-5252512927, there should only be a new timestamp after the first boot.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly