### PR TITLE
oci: T9265: add CPU architecture (fallback amd64) to image filename

### DIFF
--- a/scripts/iso-to-oci
+++ b/scripts/iso-to-oci
@@ -55,7 +55,8 @@ xorriso -osirrox on -indev "${ISO}" -extract /live/filesystem.squashfs "${ROOTFS
 echo "I: extracting squashfs content"
 unsquashfs -follow -dest "${UNSQUASHFS}/" "${ROOTFS}/live/filesystem.squashfs" >/dev/null 2>&1
 VERSION="$(jq --raw-output .version "${ROOTFS}/version.json")"
-ARCH="$(jq --raw-output .architecture "${ROOTFS}/version.json")"
+# older ISOs predate ARM64 support and carry no architecture in version.json
+ARCH="$(jq --raw-output '.architecture // "amd64"' "${ROOTFS}/version.json")"
 OCI_IMAGE="vyos-${VERSION}-oci-${ARCH}.tar"
 
 # fix locales for correct system configuration loading


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Generated OCI images are now named `vyos-<version>-oci-<arch>.tar` (e.g. `vyos-1.5.1-oci-amd64.tar`) so `amd64` and `arm64` artifacts no longer collide. The architecture is read from the ISO version.json, falling back to `amd64` for older ISOs built before `ARM64` support was added.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9265

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-build/pull/1282

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
