### PR TITLE
live-boot: T5475: replace the forked live-boot package with Debian's

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,6 @@ make generic                            # builds the generic flavor
   * `vyos-1x` CLI representation and all configure/op-mode scripts
   * `vyos-cloud-init` our Cloud-init handler
   * `vyos-http-api-tools` HTTP API RESTful and GraphQL
-  * `live-boot` fork with custom patches not yet upstreamed
   * `hvinfo` tool to get information from running Hypervisor
   * `vyatta-bash` fork of bash to implement CLI completion help
   * `vyatta-biosdevname` get NIC information also from Hypervisor platforms

--- a/data/live-build-config/archives/live-boot.pref.chroot
+++ b/data/live-build-config/archives/live-boot.pref.chroot
@@ -1,0 +1,10 @@
+# Always take live-boot from Debian, never from the VyOS repository.
+#
+# The VyOS delta on top of Debian's live-boot is shipped as drop-in files by
+# vyos-1x (/usr/lib/live/boot/9991-vyos.sh and the initramfs-tools hooks), so
+# the forked live-boot source package is no longer needed. vyos-dev.pref.chroot
+# pins the whole VyOS repository at priority 999, which would otherwise let a
+# stale forked live-boot win over Debian's regardless of version.
+Package: live-boot live-boot-initramfs-tools live-boot-doc
+Pin: release o=Debian
+Pin-Priority: 1001

--- a/data/live-build-config/archives/local-packages.pref.chroot
+++ b/data/live-build-config/archives/local-packages.pref.chroot
@@ -1,0 +1,15 @@
+# Make locally built packages in packages/*.deb actually override the ones from
+# the VyOS repository.
+#
+# live-build turns config/packages.chroot/*.deb into a plain apt repository
+# (Origin: config/packages.chroot) at the default priority of 500, while
+# vyos-dev.pref.chroot pins the VyOS repository at 999. Without this file the
+# repository always wins, so dropping a locally built package into packages/
+# has no effect - silently, and regardless of version.
+#
+# Priority above 1000 is required so that a locally built package is installed
+# even when the repository carries a *newer* version, which is the normal case
+# when building from a branch that is behind the repository.
+Package: *
+Pin: release o=config/packages.chroot
+Pin-Priority: 1001

--- a/data/live-build-config/hooks/live/08-live-boot-vyos.chroot
+++ b/data/live-build-config/hooks/live/08-live-boot-vyos.chroot
@@ -1,0 +1,97 @@
+#!/bin/sh
+#
+# VyOS ships its live-boot delta as a drop-in component
+# (includes.chroot/usr/lib/live/boot/9991-vyos.sh) instead of forking the
+# live-boot source package. That drop-in redefines two upstream functions,
+# carrying a verbatim copy of each with a small, documented deviation.
+#
+# If Debian changes those functions, our copies silently go stale and the
+# persistence overlay may be assembled from the wrong directory - which
+# presents as "the router booted with an empty configuration", not as a build
+# failure. Pin the upstream implementations by hash and fail the build when
+# they move, so that the copies get re-synced deliberately.
+#
+# This hook runs after chroot_includes_after_packages, so both files are
+# present, and before 17-gen_initramfs.chroot bakes the initrd.
+
+set -e
+
+UPSTREAM="/usr/lib/live/boot/9990-misc-helpers.sh"
+OURS="/usr/lib/live/boot/9991-vyos.sh"
+
+LB_VERSION="$(dpkg-query -W -f '${Version}' live-boot)"
+
+for FILE in "${UPSTREAM}" "${OURS}"
+do
+	if [ ! -r "${FILE}" ]
+	then
+		echo "E: ${FILE} is missing - live-boot drop-in is not installed" >&2
+		exit 1
+	fi
+done
+
+# sha256 of the upstream function body, as shipped by live-boot 1:20230131.
+# Changing one of these means re-syncing the corresponding copy in
+# data/live-build-config/includes.chroot${OURS} - not just pasting a new hash.
+check_upstream()
+{
+	_fn="${1}"
+	_expected="${2}"
+	_actual="$(awk "/^${_fn} \(\)/,/^}\$/" "${UPSTREAM}" | sha256sum | cut -d' ' -f1)"
+
+	if [ -z "${_actual}" ] || [ "${_actual}" = "$(: | sha256sum | cut -d' ' -f1)" ]
+	then
+		echo "E: could not extract ${_fn}() from ${UPSTREAM}" >&2
+		exit 1
+	fi
+
+	if [ "${_actual}" != "${_expected}" ]
+	then
+		echo "E: ${_fn}() changed in live-boot ${LB_VERSION}." >&2
+		echo "E: expected ${_expected}" >&2
+		echo "E: got      ${_actual}" >&2
+		echo "E: Re-sync the copy in" >&2
+		echo "E: data/live-build-config/includes.chroot${OURS}" >&2
+		echo "E: then update the hash in this hook." >&2
+		exit 1
+	fi
+}
+
+check_upstream mount_persistence_media \
+	252b43bb0a0fccc93f5055a1b5c300b784c110b8c6d76b1c302063c4c8c97816
+check_upstream get_custom_mounts \
+	5891e66182c7cf770bfd3072e07c5906d44a562c244f9800a336979237df5e0a
+check_upstream what_is_mounted_on \
+	c0a5661a73a1cf38d6c0e543409d4571cb95478d094d33ac7dd4ae3c962dedb1
+
+# Assert the VyOS deviations are actually present, so that a careless re-sync
+# cannot quietly restore upstream behaviour.
+check_ours()
+{
+	if ! grep -q "${1}" "${OURS}"
+	then
+		echo "E: ${OURS} is missing the VyOS deviation: ${2}" >&2
+		exit 1
+	fi
+}
+
+check_ours '^	backing="/run/live/persistence"$' \
+	'flat persistence backing directory'
+check_ours '/sys/block/${raid_drive}/slaves' \
+	'MD RAID member guard'
+check_ours 'full_source="$(trim_path ${backing}/${PERSISTENCE_PATH}/${source})"' \
+	'persistence-path= aware custom mount source'
+check_ours 'vyos-union=\*|vyatta-union=\*' \
+	'vyos-union= command line parameter'
+check_ours '"${dir}" = "/run/live/medium"' \
+	'boot medium kept eligible for persistence'
+
+# The drop-in only takes effect if live-boot's frontend actually globs it up.
+if ! grep -q '/lib/live/boot/????-\*' /usr/bin/live-boot
+then
+	echo "E: /usr/bin/live-boot no longer globs /lib/live/boot/????-*;" >&2
+	echo "E: the VyOS drop-in mechanism is broken." >&2
+	exit 1
+fi
+
+echo "I: VyOS live-boot drop-in verified against live-boot ${LB_VERSION}"

--- a/data/live-build-config/hooks/live/09-live.chroot
+++ b/data/live-build-config/hooks/live/09-live.chroot
@@ -1,10 +1,6 @@
 #!/bin/sh
 
-# hack live script that tries to mount ext[23] floppies as root
 # remove user settings live config scripts
-
-sed -e '/ln -s "${devname}"/,/return 0/ s/^/: FIXME/' \
-    -i /usr/share/initramfs-tools/scripts/live
 
 rm -rf /lib/live/config/0030-live-debconfig_passwd
 rm -rf /lib/live/config/0030-user-setup

--- a/data/live-build-config/includes.chroot/etc/fstab
+++ b/data/live-build-config/includes.chroot/etc/fstab
@@ -1,0 +1,10 @@
+# /etc/fstab - static file system information
+#
+# live-boot appends the root overlay and the tmpfs for /tmp to this file while
+# booting, see /usr/lib/live/boot/9990-fstab.sh. Its appends are guarded by a
+# grep, so entries placed here are preserved.
+#
+# Keep /var/tmp on tmpfs so that it is emptied on every reboot instead of
+# accumulating in the persistence overlay. The retired VyOS live-boot fork used
+# to append this very line from the initramfs (T3990).
+tmpfs /var/tmp tmpfs nosuid,nodev 0 0

--- a/data/live-build-config/includes.chroot/usr/lib/live/boot/9991-vyos.sh
+++ b/data/live-build-config/includes.chroot/usr/lib/live/boot/9991-vyos.sh
@@ -1,0 +1,316 @@
+#!/bin/sh
+# VyOS additions to Debian's live-boot.
+#
+# live-boot's frontend (/usr/bin/live-boot) sources /etc/live/boot.conf,
+# /etc/live/boot/* and then every /lib/live/boot/????-* component in glob
+# order. This file sorts after all upstream 9990-* components, so it is
+# sourced last and may both set variables and redefine functions.
+#
+# It exists so that VyOS does not have to fork the live-boot source package.
+# Everything below is either a translation of VyOS-specific kernel command
+# line parameters, or a copy of an upstream function with a clearly marked
+# deviation. The copies are taken verbatim from bookworm's
+# /usr/lib/live/boot/9990-misc-helpers.sh (live-boot 1:20230131) - when
+# bumping live-boot, re-sync them. The
+# hooks/live/08-live-boot-vyos.chroot build hook fails the ISO build if they
+# have drifted.
+#
+# Deviations that are candidates for upstreaming:
+#   * get_custom_mounts()        honour persistence-path= for source=
+#   * mount_persistence_media()  skip devices that are MD RAID members
+#   * what_is_mounted_on()       keep the boot medium eligible for persistence
+#
+# Note: this file is sourced *before* Live() runs, and Cmdline_old() only
+# assigns a variable when the matching token is absent from the kernel command
+# line, so plain assignment here is not overwritten later.
+
+# ---------------------------------------------------------------------------
+# VyOS kernel command line parameters
+# ---------------------------------------------------------------------------
+# vyos-union=<path> (and its pre-1.2 alias vyatta-union=) is shorthand for the
+# set of stock live-boot parameters that describe a VyOS image installed to
+# disk. It is still emitted by vyos-1x (python/vyos/system/grub.py,
+# BOOT_OPTS_STEM) and by grub entries written by older releases, so it has to
+# be understood indefinitely.
+for _PARAMETER in $(cat /proc/cmdline)
+do
+	case "${_PARAMETER}" in
+		vyos-union=*|vyatta-union=*)
+			LIVE_MEDIA_PATH="${_PARAMETER#*=}"
+			PERSISTENCE_PATH="${LIVE_MEDIA_PATH}/"
+			PERSISTENCE="true"
+			NONETWORKING="true"
+			UNIONTYPE="overlay"
+			export LIVE_MEDIA_PATH PERSISTENCE_PATH PERSISTENCE \
+			       NONETWORKING UNIONTYPE
+			;;
+	esac
+done
+unset _PARAMETER
+
+# ---------------------------------------------------------------------------
+# Overrides of upstream functions
+# ---------------------------------------------------------------------------
+
+# VyOS puts the boot medium and the persistence filesystem on the *same*
+# partition: /boot/<version>/<version>.squashfs is the medium content, and
+# boot/<version>/rw is the overlay upper directory.
+#
+# Upstream's find_persistence_media() blacklists whatever device is mounted at
+# /run/live/medium, on the reasoning that using it for persistence could union a
+# parent directory on top of one of its own sub-directories. VyOS avoids that by
+# scoping the union to ${PERSISTENCE_PATH} (see get_custom_mounts() above), so
+# the medium has to stay eligible - otherwise persistence is never found and the
+# system silently boots on a tmpfs overlay with an empty configuration.
+#
+# Debian live-boot 1:20151213, the base of the old VyOS fork, did not blacklist
+# the medium and also passed a literal "d" instead of "${d}" to this function,
+# so its blacklist was always empty. Both were fixed upstream; that fix is what
+# makes stock live-boot incompatible with the VyOS on-disk layout.
+#
+# Rather than copy the whole 60-line find_persistence_media(), keep upstream's
+# blacklist mechanism intact and make just the medium resolve to no device. The
+# only other callers pass a custom-mount destination below ${rootmnt}, which can
+# never be /run/live/medium - get_custom_mounts() rejects /run/live paths
+# outright.
+what_is_mounted_on ()
+{
+	local dir
+	dir="$(trim_path ${1})"
+
+	if [ "${dir}" = "/run/live/medium" ]
+	then
+		return 0
+	fi
+
+	grep -m1 "^[^ ]\+ ${dir} " /proc/mounts | cut -d' ' -f1
+}
+
+mount_persistence_media ()
+{
+	local device probe backing old_backing fstype mount_opts
+	local raid_drives raid_drive disks disk occupant
+	device=${1}
+	probe=${2}
+
+	# get_custom_mounts() might call this with a directory path instead
+	# of a block device path. This means we have found sub-directory path
+	# underneath /run/live/persistence, so we're done
+	if [ -d "${device}" ]
+	then
+		echo "${device}"
+		return 0
+	fi
+
+	if [ ! -b "${device}" ]
+	then
+		return 1
+	fi
+
+	# VyOS: never mount a member of an assembled MD RAID directly - doing so
+	# would give us a second, inconsistent view of the same filesystem.
+	raid_drives=$(awk '{ if ($4 != "name") { print $4 } }' /proc/partitions \
+			| grep "^md" || true)
+	for raid_drive in ${raid_drives}
+	do
+		disks=$(ls /sys/block/${raid_drive}/slaves 2>/dev/null || true)
+		for disk in ${disks}
+		do
+			if [ "/dev/${disk}" = "${device}" ]
+			then
+				return 1
+			fi
+		done
+	done
+
+	# VyOS: flat backing directory, without the per-device sub-directory that
+	# upstream uses. VyOS boots a single persistence partition and addresses
+	# every image below it as boot/<version>/rw; the persistence root must
+	# therefore be at a fixed, device-independent path.
+	backing="/run/live/persistence"
+
+	# A flat backing directory can hold only one device. Upstream's per-device
+	# sub-directory makes a second persistence device harmless; here it would
+	# be mounted straight on top of the first, shadowing it, and the custom
+	# mounts would then be read from whichever device happened to be scanned
+	# last. Refuse the later device instead and keep the first one.
+	occupant="$(what_is_mounted_on "${backing}")"
+	if [ -n "${occupant}" ] && [ "${occupant}" != "${device}" ]
+	then
+		[ -z "${probe}" ] && log_warning_msg \
+			"Ignoring persistence media ${device}: ${occupant} is already mounted on ${backing}"
+		return 1
+	fi
+
+	mkdir -p "${backing}"
+	old_backing="$(where_is_mounted ${device})"
+	if [ -z "${old_backing}" ]
+	then
+		fstype="$(get_fstype ${device})"
+		mount_opts="rw,noatime"
+		if [ -n "${PERSISTENCE_READONLY}" ]
+		then
+			mount_opts="ro,noatime"
+		fi
+		if mount -t "${fstype}" -o "${mount_opts}" "${device}" "${backing}" >/dev/null 2>&1
+		then
+			echo ${backing}
+			return 0
+		else
+			[ -z "${probe}" ] && log_warning_msg "Failed to mount persistence media ${device}"
+			rmdir "${backing}"
+			return 1
+		fi
+	elif [ "${backing}" != "${old_backing}" ]
+	then
+		if ! mount -o move ${old_backing} ${backing} >/dev/null
+		then
+			[ -z "${probe}" ] && log_warning_msg "Failed to move persistence media ${device}"
+			rmdir "${backing}"
+			return 1
+		fi
+		mount_opts="rw,noatime"
+		if [ -n "${PERSISTENCE_READONLY}" ]
+		then
+			mount_opts="ro,noatime"
+		fi
+		if ! mount -o "remount,${mount_opts}" "${backing}" >/dev/null
+		then
+			log_warning_msg "Failed to remount persistence media ${device} writable"
+			# Don't unmount or rmdir the new mountpoint in this case
+		fi
+		echo ${backing}
+		return 0
+	else
+		# This means that $device has already been mounted on
+		# the place expected by live-boot, so we're done.
+		echo ${backing}
+		return 0
+	fi
+}
+
+get_custom_mounts ()
+{
+	# Side-effect: leaves $devices with persistence.conf mounted in /run/live/persistence
+	# Side-effect: prints info to file $custom_mounts
+
+	local custom_mounts devices bindings links
+	custom_mounts=${1}
+	shift
+	devices=${@}
+
+	bindings="/tmp/bindings.list"
+	links="/tmp/links.list"
+	rm -rf ${bindings} ${links} 2> /dev/null
+
+	for device in ${devices}
+	do
+		local device_name backing include_list
+		device_name="$(basename ${device})"
+		backing=$(mount_persistence_media ${device})
+		if [ -z "${backing}" ]
+		then
+			continue
+		fi
+
+		if [ -r "${backing}/${persistence_list}" ]
+		then
+			include_list="${backing}/${persistence_list}"
+		else
+			continue
+		fi
+
+		if [ -n "${LIVE_BOOT_DEBUG}" ] && [ -e "${include_list}" ]
+		then
+			cp ${include_list} /run/live/persistence/${persistence_list}.${device_name}
+		fi
+
+		while read dir options # < ${include_list}
+		do
+			if echo ${dir} | grep -qe "^[[:space:]]*\(#.*\)\?$"
+			then
+				# skipping empty or commented lines
+				continue
+			fi
+
+			if trim_path ${dir} | grep -q -e "^[^/]" -e "^/lib" -e "^/run/live\(/.*\)\?$" -e "^/\(.*/\)\?\.\.\?\(/.*\)\?$"
+			then
+				log_warning_msg "Skipping unsafe custom mount ${dir}: must be an absolute path containing neither the \".\" nor \"..\" special dirs, and cannot be \"/lib\", or \"/run/live\" or any of its sub-directories."
+				continue
+			fi
+
+			local opt_source opt_link source full_source full_dest
+			opt_source=""
+			opt_link=""
+			for opt in $(echo ${options} | tr ',' ' ');
+			do
+				case "${opt}" in
+					source=*)
+						opt_source=${opt#source=}
+						;;
+					link)
+						opt_link="true"
+						;;
+					union|bind)
+						;;
+					*)
+						log_warning_msg "Skipping custom mount with unknown option: ${opt}"
+						continue 2
+						;;
+				esac
+			done
+
+			source="${dir}"
+			if [ -n "${opt_source}" ]
+			then
+				if echo ${opt_source} | grep -q -e "^/" -e "^\(.*/\)\?\.\.\?\(/.*\)\?$" && [ "${opt_source}" != "." ]
+				then
+					log_warning_msg "Skipping unsafe custom mount with option source=${opt_source}: must be either \".\" (the media root) or a relative path w.r.t. the media root that contains neither comas, nor the special \".\" and \"..\" path components"
+					continue
+				else
+					source="${opt_source}"
+				fi
+			fi
+
+			# VyOS: resolve source= relative to persistence-path=, so that
+			# a single persistence.conf at the partition root serves every
+			# installed image (boot/<version>/rw). Upstream ignores
+			# PERSISTENCE_PATH here; see the note at the top of this file.
+			full_source="$(trim_path ${backing}/${PERSISTENCE_PATH}/${source})"
+			full_dest="$(trim_path ${rootmnt}/${dir})"
+			if [ -n "${opt_link}" ]
+			then
+				echo "${device} ${full_source} ${full_dest} ${options}" >> ${links}
+			else
+				echo "${device} ${full_source} ${full_dest} ${options}" >> ${bindings}
+			fi
+		done < ${include_list}
+	done
+
+	# We sort the list according to destination so we're sure that
+	# we won't hide a previous mount. We also ignore duplicate
+	# destinations in a more or less arbitrary way.
+	[ -e "${bindings}" ] && sort -k3 -sbu ${bindings} >> ${custom_mounts} && rm ${bindings}
+
+	# After all mounts are considered we add symlinks so they
+	# won't be hidden by some mount.
+	[ -e "${links}" ] && cat ${links} >> ${custom_mounts} && rm ${links}
+
+	# We need to make sure that no two custom mounts have the same sources
+	# or are nested; if that is the case, too much weird stuff can happen.
+	local prev_source prev_dest
+	prev_source="impossible source" # first iteration must not match
+	prev_dest=""
+	# This sort will ensure that a source /a comes right before a source
+	# /a/b so we only need to look at the previous source
+	[ -e ${custom_mounts} ] && sort -k2 -b ${custom_mounts} |
+	while read device source dest options
+	do
+		if echo ${source} | grep -qe "^${prev_source}\(/.*\)\?$"
+		then
+			panic "Two persistence mounts have the same or nested sources: ${source} on ${dest}, and ${prev_source} on ${prev_dest}"
+		fi
+		prev_source=${source}
+		prev_dest=${dest}
+	done
+}

--- a/data/live-build-config/includes.chroot/usr/share/initramfs-tools/hooks/vyos-live
+++ b/data/live-build-config/includes.chroot/usr/share/initramfs-tools/hooks/vyos-live
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# live-boot's own initramfs-tools hook copies a handful of klibc dependencies
+# using a non-multiarch glob (/lib/libacl* and friends), which never matches on
+# a modern Debian system. Copy them from their real multiarch location instead,
+# and add libpcre, which live-boot's helpers need but upstream does not list
+# (T3641).
+
+set -e
+
+PREREQ="live"
+
+prereqs()
+{
+	echo "${PREREQ}"
+}
+
+case "${1}" in
+	prereqs)
+		prereqs
+		exit 0
+		;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+for FILE in /lib/*/libacl* /lib/*/libblkid* /lib/*/libuuid* \
+	    /lib/*/libdevmapper* /lib/*/libattr* /lib/*/libpcre*
+do
+	if [ -e "${FILE}" ] && [ ! -e "${DESTDIR}/${FILE}" ]
+	then
+		mkdir -p "${DESTDIR}/$(dirname ${FILE})"
+		cp -a "${FILE}" "${DESTDIR}/${FILE}"
+	fi
+done

--- a/data/live-build-config/includes.chroot/usr/share/initramfs-tools/scripts/live-top/mdadm
+++ b/data/live-build-config/includes.chroot/usr/share/initramfs-tools/scripts/live-top/mdadm
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# With boot=live, initramfs-tools hands control to live-boot's mountroot() and
+# so never runs the local-block retry loop that would normally give the mdadm
+# package's script a chance to re-trigger udev and scan for arrays. Arrays are
+# still assembled incrementally by mdadm's udev rules, but nothing forces a
+# rescan, so a member that appears late can leave live-boot searching for its
+# medium and persistence partition on an array that is not up yet. Give mdadm
+# one invocation from live-top to cover that.
+#
+# Debian ships the script as local-block; the 2015 release that the retired VyOS
+# live-boot fork was based on shipped it as local-top. Use whichever is present.
+
+PREREQ=""
+
+prereqs()
+{
+	echo "${PREREQ}"
+}
+
+case "${1}" in
+	prereqs)
+		prereqs
+		exit 0
+		;;
+esac
+
+for _script in /scripts/local-block/mdadm /scripts/local-top/mdadm
+do
+	if [ -x "${_script}" ]
+	then
+		"${_script}"
+		break
+	fi
+done

--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -1079,7 +1079,9 @@ try:
         c.sendline('y')
         c.expect('\nInstallation will delete all data on both drives. Continue?.*')
         c.sendline('y')
-        c.expect('\nWhich file would you like as boot config?.*')
+        # Creating the RAID array and the subsequent update-initramfs regularly
+        # take longer than the default expect timeout
+        c.expect('\nWhich file would you like as boot config?.*', timeout=300)
         c.sendline('')
     else:
         c.expect('\nWhich one should be used for installation?.*')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

VyOS carried a fork of Debian's live-boot, based on release 1:20151213, purely  to add a handful of VyOS specific behaviours. The fork is retired here in favour of Debian's own live-boot plus a drop-in component.

live-boot's frontend sources every `/lib/live/boot/????-*` file in glob order, so `9991-vyos.sh` is read after all upstream components and can both translate the `vyos-union=` kernel parameter and redefine three helpers. An `initramfs-tools` hook copies the multiarch klibc libraries that upstream's non-multiarch glob never matches, and a live-top shim runs mdadm, which `boot=live` otherwise skips entirely, leaving RAID arrays unassembled.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5475

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* Depends-on: https://github.com/vyos/vyos-1x/pull/5443

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
