### PR TITLE
Testsuite: T9276: RAID1 test sporadically fails due to timeout violation

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -1603,24 +1603,35 @@ try:
         c.sendline('cat /proc/mdstat')
         c.expect(op_mode_prompt)
 
+        # Re-partitioning a disk and adding it back to the array can take
+        # significantly longer then the default pexpect timeout of 30 seconds
+        raid_timeout = 300
+        # Upper limit we wait for the array to be fully re-synced
+        raid_sync_timeout = 900
+
         log.info('Re-format new RAID member')
         c.sendline('format by-id disk drive-hd1 like drive-hd2')
         c.sendline('yes')
-        c.expect(op_mode_prompt)
+        c.expect(op_mode_prompt, timeout=raid_timeout)
 
         log.info('Add member to RAID1 (md0)')
         c.sendline('add raid md0 by-id member drive-hd1-part3')
-        c.expect(op_mode_prompt)
+        c.expect(op_mode_prompt, timeout=raid_timeout)
 
         log.info('Now we need to wait for re-sync to complete')
 
         start_time = time.time()
-        timeout = 60
         while True:
-            if (start_time + timeout) < time.time():
-                break
             c.sendline('cat /proc/mdstat')
-            c.expect(op_mode_prompt)
+            # Once both members are up and in sync, mdstat reports "[2/2] [UU]"
+            index = c.expect([r'\[2/2\]\s+\[UU\]', op_mode_prompt],
+                             timeout=raid_timeout)
+            if index == 0:
+                c.expect(op_mode_prompt, timeout=raid_timeout)
+                log.info('RAID1 re-sync completed')
+                break
+            if (start_time + raid_sync_timeout) < time.time():
+                raise Exception('Timeout waiting for RAID1 re-sync to complete')
             time.sleep(20)
 
         # Reboot system with new primary RAID1 disk


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Re-partitioning a disk and adding it back to the array can take significantly longer then the default pexpect timeout of 30 seconds.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9276

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
