### PR TITLE
T9014: install flavor.json before Debian packages are installed

### DIFF
--- a/scripts/image-build/build-vyos-image
+++ b/scripts/image-build/build-vyos-image
@@ -541,7 +541,13 @@ DOCUMENTATION_URL="{build_config['documentation_url']}"
         os.makedirs(vyos_data_dir, exist_ok=True)
         with open(os.path.join(vyos_data_dir, 'version.json'), 'w') as f:
             json.dump(version_data, f)
-        with open(os.path.join(vyos_data_dir, 'flavor.json'), 'w') as f:
+        # The flavor data is required by the maintainer scripts of the Debian
+        # packages we install, thus it must be in place before the packages are
+        # installed and not only afterwards
+        vyos_data_dir_early = os.path.join(defaults.CHROOT_INCLUDES_EARLY_DIR,
+                                           "usr/share/vyos")
+        os.makedirs(vyos_data_dir_early, exist_ok=True)
+        with open(os.path.join(vyos_data_dir_early, 'flavor.json'), 'w') as f:
             json.dump(flavor_data, f)
         with open(os.path.join(binary_includes_dir, 'version.json'), 'w') as f:
             json.dump(version_data, f)

--- a/scripts/image-build/defaults.py
+++ b/scripts/image-build/defaults.py
@@ -62,6 +62,9 @@ PBUILDER_DIR = 'pbuilder'
 LB_CONFIG_DIR = 'config'
 
 CHROOT_INCLUDES_DIR = 'config/includes.chroot'
+# Files that must already be present while the Debian packages are installed,
+# live-build copies this directory into the chroot before package installation
+CHROOT_INCLUDES_EARLY_DIR = 'config/includes.chroot_before_packages'
 BINARY_INCLUDES_DIR = 'config/includes.binary'
 ARCHIVES_DIR = 'config/archives/'
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The `vyos-1x-smoketest` maintainer script now queries the image flavor to implant the correct serial console device and speed into the configuration test data. This requires `/usr/share/vyos/flavor.json` to be present in the chroot before the Debian packages get installed, but `config/includes.chroot` is only copied into the chroot after package installation.

Write `flavor.json` to `config/includes.chroot_before_packages` instead, which live-build copies into the chroot prior to installing packages. version.json and the activation hints are unaffected and remain in config/includes.chroot.

Companion change to `vyos-1x` commit 2f9fe3e74 (`smoketest: T9014: make configtest serial console image flavor agnostic`).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9014

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/5449

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
