### PR TITLE
Kernel: T9298: make linux-firmware package architecture aware

### DIFF
--- a/data/architectures/arm64.toml
+++ b/data/architectures/arm64.toml
@@ -1,6 +1,7 @@
 # Packages included in ARM64 images by default
 packages = [
   "grub-efi-arm64",
+  "vyos-linux-firmware",
   "vyos-ipt-netflow"
 ]
 bootloaders = "grub-efi"

--- a/scripts/package-build/linux-kernel/build-linux-firmware.sh
+++ b/scripts/package-build/linux-kernel/build-linux-firmware.sh
@@ -27,7 +27,10 @@ FW_FILES=$(find ${KERNEL_DIR}/debian/linux-image-${KERNEL_VERSION}${KERNEL_SUFFI
 # Debian package will use the descriptive Git commit as version
 GIT_COMMIT=$(cd ${CWD}/${LINUX_FIRMWARE}; git describe --always)
 VYOS_FIRMWARE_NAME="vyos-linux-firmware"
-VYOS_FIRMWARE_DIR="${VYOS_FIRMWARE_NAME}_${GIT_COMMIT}-0_all"
+# The firmware blobs are selected from the modules of the kernel built on this
+# host, so the package content differs per architecture - build it arch-dependent.
+BUILD_ARCH=$(dpkg --print-architecture)
+VYOS_FIRMWARE_DIR="${VYOS_FIRMWARE_NAME}_${GIT_COMMIT}-0_${BUILD_ARCH}"
 if [ -d ${VYOS_FIRMWARE_DIR} ]; then
     # remove Debian package folder and deb file from previous runs
     rm -rf ${VYOS_FIRMWARE_DIR}*
@@ -107,7 +110,7 @@ Standards-Version: 4.5.1
 Rules-Requires-Root: no
 
 Package: ${VYOS_FIRMWARE_NAME}
-Architecture: all
+Architecture: any
 Depends: \${misc:Depends}
 Description: Binary firmware for various drivers in the Linux kernel
  Firmware blobs assembled from linux-firmware.git for the drivers built
@@ -127,6 +130,24 @@ override_dh_auto_build:
 override_dh_auto_install:
 	mkdir -p \${PACKAGE_BUILD_DIR}
 	cp -a lib \${PACKAGE_BUILD_DIR}/
+
+# Firmware blobs must be shipped verbatim. Some of them are valid ELF objects,
+# so the binary mangling helpers - which only run for arch-dependent packages -
+# would happily strip them or try to resolve library dependencies on them.
+override_dh_strip:
+	@true
+
+override_dh_dwz:
+	@true
+
+override_dh_strip_nondeterminism:
+	@true
+
+override_dh_shlibdeps:
+	@true
+
+override_dh_makeshlibs:
+	@true
 EOF
 
 debuild


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Currently when the Kernel is build and creates the vyos-linux-firmware package, the Kernel modules are inspected and the firmware file string is extracted.

This is the case for years. Now with ARM64 on the doorstep, we would assemble the vyos-linux-firmware package twice, once for x86_64 and once for amd64.

The generated package is for CPU architecture all - as the package is build twice, the longer running build will win -> perfect race condition.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9298

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
