### PR TITLE
Testsuite: T7575: strip terminal escapes when parsing console output

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -87,6 +87,10 @@ macbase = '00:00:5E:00:53'
 
 test_timeout = 5 *3600 # 5 hours (in seconds) to complete individual testcases
 
+# Terminal control/escape sequences (e.g. bash bracketed-paste \x1b[?2004h)
+# emitted on the serial console - must be filtered before parsing command output
+ansi_escape = re.compile(r'\x1B[@-_][0-?]*[ -/]*[@-~]')
+
 op_mode_prompt = r'vyos@vyos:~\$'
 cfg_mode_prompt = r'vyos@vyos#'
 default_user = 'vyos'
@@ -199,14 +203,13 @@ class StreamToLogger(object):
         self.logger = logger
         self.log_level = log_level
         self.linebuf = b''
-        self.ansi_escape = re.compile(r'\x1B[@-_][0-?]*[ -/]*[@-~]')
 
     def write(self, buf):
         self.linebuf += buf
         while b'\n' in self.linebuf:
             f = self.linebuf.split(b'\n', 1)
             if len(f) == 2:
-                self.logger.debug(self.ansi_escape.sub('', f[0].decode(errors="replace").rstrip()))
+                self.logger.debug(ansi_escape.sub('', f[0].decode(errors="replace").rstrip()))
                 self.linebuf = f[1]
 
     def flush(self):
@@ -664,6 +667,16 @@ def BOOTLOADERchooseSerialConsole(child, live: bool, log=None) -> None:
 
     return None
 
+def get_cmd_output(c, cmd, prompt=op_mode_prompt):
+    """ Run cmd on the console and return its last line of output, stripped of
+        any terminal control sequences. """
+    c.sendline(cmd)
+    c.expect(prompt)
+    text = ansi_escape.sub('', c.before.decode(errors='replace'))
+    # Drop empty lines and the echoed command itself
+    lines = [l.strip() for l in text.splitlines() if l.strip() and l.strip() != cmd]
+    return lines[-1] if lines else ''
+
 def basic_cli_tests(c):
     # Repeating / shared basic CLI test between installed images and the
     # cloud-init test-case
@@ -698,35 +711,37 @@ def basic_cli_tests(c):
 
     # Get serial console interface name from flavor definition
     flavor_json = '/usr/share/vyos/flavor.json'
-    c.sendline(f'jq -r ".console_type" {flavor_json}')
-    c.expect(op_mode_prompt)
-    lines = [l.strip() for l in c.before.splitlines() if l.strip()]
-    console_type = lines[-1].decode('utf-8').strip() # e.g. ttyS
+    console_type = get_cmd_output(c, f'jq -r ".console_type" {flavor_json}') # e.g. ttyS
 
     # We do only care for ttyS or ttyAMA console types, exit early
     # for VGA consoles
     if console_type == 'tty':
         return
 
-    c.sendline(f'jq -r ".console_num" {flavor_json}')
-    c.expect(op_mode_prompt)
-    lines = [l.strip() for l in c.before.splitlines() if l.strip()]
-    console_num = lines[-1].decode('utf-8').strip() # e.g. 0
+    console_num = get_cmd_output(c, f'jq -r ".console_num" {flavor_json}') # e.g. 0
 
     # Get serial console speed from flavor definition
-    c.sendline(f'jq -r ".console_speed" {flavor_json}')
-    c.expect(op_mode_prompt)
-    lines = [l.strip() for l in c.before.splitlines() if l.strip()]
-    console_speed = lines[-1].decode('utf-8').strip() # e.g. 115200
+    console_speed = get_cmd_output(c, f'jq -r ".console_speed" {flavor_json}') # e.g. 115200
+
+    # Values are interpolated into regular expressions below - bail out with a
+    # meaningful error instead of a confusing re.error traceback if the console
+    # returned something unexpected
+    for name, value, pattern in [('console_type', console_type, r'tty[A-Za-z0-9]*'),
+                                 ('console_num', console_num, r'\d+'),
+                                 ('console_speed', console_speed, r'\d+')]:
+        if not re.fullmatch(pattern, value):
+            raise Exception(f'Invalid {name} "{value}" read from {flavor_json}')
+
+    console_dev = re.escape(f'{console_type}{console_num}')
 
     # Ensure serial console with kernel option is set in CLI, done automatically by image installer
     c.sendline('show configuration commands | match "system console"')
-    c.expect(rf'set system console device {console_type}{console_num} kernel\r\r\nset system console device {console_type}{console_num} speed \'{console_speed}\'')
+    c.expect(rf'set system console device {console_dev} kernel\r\r\nset system console device {console_dev} speed \'{re.escape(console_speed)}\'')
     c.expect(op_mode_prompt)
 
     # Validate GRUB has the right console_type defined
     c.sendline('cat /boot/grub/grub.cfg.d/20-vyos-defaults-autoload.cfg | grep "set console_type"')
-    c.expect(f'set console_type="{console_type}"')
+    c.expect(rf'set console_type="{re.escape(console_type)}"')
     c.expect(op_mode_prompt)
 
 def verify_eth_mac_mapping(c, log):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit c7eef9dd (`Testsuite: T8375: verify proper serial console settings`) read console_type/console_num/console_speed from flavor.json by taking the last non-empty line of the raw pexpect buffer, then interpolated those values unescaped into `c.expect()` patterns.

That stayed harmless until commit 0505dc09 (`vbash: T7575: vyatta-bash 5.2.37 using build system`) rebased vyatta-bash onto Debian bash 5.2.37, where readline enables bracketed-paste mode by default. The shell now emits `\x1b[?2004h` around every prompt, that sequence got parsed as console_type, and its "[" opened an unterminated character class:

    re.error: unterminated character set at position 27

Add `get_cmd_output()` helper that strips terminal control sequences and the echoed command before returning the last output line, hoist the ANSI regex to module scope for reuse, validate the parsed values, and re.escape() everything interpolated into a regular expression.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7575

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-build/pull/1285
* https://github.com/vyos/vyos-1x/pull/5412

## How to test / Smoketest result

### Before

```
260908121631.0fae2d08c  amd64        Vector Packet Processing--runtime core plugins
DEBUG - ii  vpp-plugin-dpdk                  25.10.0-56~vyos20260908121631.0fae2d08c  amd64        Vector Packet Processing--runtime dpdk plugin
DEBUG - ii  vyos-1x                          999.0-14869-gf226af1e4                   amd64        VyOS configuration scripts and data
DEBUG - ii  vyos-1x-smoketest                999.0-14869-gf226af1e4                   all          VyOS build sanity checking toolkit
DEBUG - vyos@vyos:~$ jq -r ".console_type" /usr/share/vyos/flavor.json
DEBUG - jq -r ".console_type" /usr/share/vyos/flavor.json
ttySG -
DEBUG - vyos@vyos:~$ jq -r ".console_num" /usr/share/vyos/flavor.json
DEBUG - jq -r ".console_num" /usr/share/vyos/flavor.json
0EBUG -
DEBUG - vyos@vyos:~$jq -r ".console_speed" /usr/share/vyos/flavor.json
DEBUG -  jq -r ".console_speed" /usr/share/vyos/flavor.json
115200-
DEBUG - vyos@vyos:~$show configuration commands | match "system console"
ERROR - Unknown error occurred!
Traceback (most recent call last):
  File "/vyos/vyos-build-rolling/scripts/check-qemu-install", line 1195, in <module>
    basic_cli_tests(c)
  File "/vyos/vyos-build-rolling/scripts/check-qemu-install", line 724, in basic_cli_tests
    c.expect(rf'set system console device {console_type}{console_num} kernel\r\r\nset system console device {console_type}{console_num} speed \'{console_speed}\'')
  File "/usr/lib/python3/dist-packages/pexpect/spawnbase.py", line 342, in expect
    compiled_pattern_list = self.compile_pattern_list(pattern)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pexpect/spawnbase.py", line 232, in compile_pattern_list
    compiled_pattern_list.append(re.compile(p, compile_flags))
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/__init__.py", line 227, in compile
    return _compile(pattern, flags)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/__init__.py", line 294, in _compile
    p = _compiler.compile(pattern, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_compiler.py", line 743, in compile
    p = _parser.parse(p, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_parser.py", line 980, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_parser.py", line 455, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_parser.py", line 563, in _parse
    raise source.error("unterminated character set",
re.error: unterminated character set at position 27
 INFO - Cleaning up
 INFO - Removing disk file: testinstall-20260912-065134-6ba1.raw
ERROR - Hmm... system got an exception while processing.
ERROR - The ISO image is not considered usable!
```

### After

```
DEBUG - ii  vpp-plugin-dpdk                  25.10.0-56~vyos20260908121631.0fae2d08c  amd64        Vector Packet Processing--runtime dpdk plugin
DEBUG - ii  vyos-1x                          999.0-14869-gf226af1e4                   amd64        VyOS configuration scripts and data
DEBUG - ii  vyos-1x-smoketest                999.0-14869-gf226af1e4                   all          VyOS build sanity checking toolkit
DEBUG - vyos@vyos:~$jq -r ".console_type" /usr/share/vyos/flavor.json
DEBUG -  jq -r ".console_type" /usr/share/vyos/flavor.json
ttySG -
DEBUG - vyos@vyos:~$ jq -r ".console_num" /usr/share/vyos/flavor.json
DEBUG - jq -r ".console_num" /usr/share/vyos/flavor.json
0EBUG -
DEBUG - vyos@vyos:~$ jq -r ".console_speed" /usr/share/vyos/flavor.json
DEBUG - jq -r ".console_speed" /usr/share/vyos/flavor.json
115200-
DEBUG - vyos@vyos:~$show configuration commands | match "system console"
DEBUG -  show configuration commands | match "system console"
set system console device ttyS0 kernel
DEBUG - set system console device ttyS0 speed '115200'
DEBUG - vyos@vyos:~$cat /boot/grub/grub.cfg.d/20-vyos-defaults-autoload.cfg | grep "set console_type"
DEBUG -  cat /boot/grub/grub.cfg.d/20-vyos-defaults-autoload.cfg | grep "set console_type"
set console_type="ttyS"
 INFO - Verify eth0..eth7 are enumerated in ascending MAC order
DEBUG - vyos@vyos:~$ip -json link show | jq -r '.[] | select(.ifname|test("^eth[0-9]+$")) | "\(.ifname) \(.address)"'
DEBUG -  ip -json link show | jq -r '.[] | select(.ifname|test("^eth[0-9]+$")) | "\(.ifname) \(.address)"'
eth6 00:00:5e:00:53:06
DEBUG - eth4 00:00:5e:00:53:04
DEBUG - eth7 00:00:5e:00:53:07
DEBUG - eth5 00:00:5e:00:53:05
DEBUG - eth0 00:00:5e:00:53:00
DEBUG - eth1 00:00:5e:00:53:01
DEBUG - eth2 00:00:5e:00:53:02
DEBUG - eth3 00:00:5e:00:53:03
 INFO - eth0..eth7 MAC mapping verified
DEBUG - vyos@vyos:~$lsb_release --short --id 2>/dev/null
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
