### PR TITLE
Testsuite: T9301: read the console type where GRUB keeps it

### DIFF
--- a/scripts/check-qemu-install
+++ b/scripts/check-qemu-install
@@ -739,8 +739,16 @@ def basic_cli_tests(c):
     c.expect(rf'set system console device {console_dev} kernel\r\r\nset system console device {console_dev} speed \'{re.escape(console_speed)}\'')
     c.expect(op_mode_prompt)
 
-    # Validate GRUB has the right console_type defined
-    c.sendline('cat /boot/grub/grub.cfg.d/20-vyos-defaults-autoload.cfg | grep "set console_type"')
+    # Validate GRUB has the right console_type defined. The GRUB configuration
+    # lives on the persistence partition, which is not the running image's
+    # /boot - resolve it the way vyos.system.grub does.
+    persistence = get_cmd_output(
+        c,
+        'python3 -c "from vyos.system.disk import find_persistence;'
+        ' print(find_persistence())"',
+    )
+    c.sendline(f'grep "set console_type" '
+               f'{persistence}/boot/grub/grub.cfg.d/20-vyos-defaults-autoload.cfg')
     c.expect(rf'set console_type="{re.escape(console_type)}"')
     c.expect(op_mode_prompt)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

`check-qemu-install` verifies the GRUB console type by reading

    /boot/grub/grub.cfg.d/20-vyos-defaults-autoload.cfg

on the installed system, and locally that file is never there. The installer
writes it with `grub.set_console_type(..., DIR_DST_ROOT)`
(`src/op_mode/image_installer.py`), i.e. onto the persistence partition, and on a
running image-based install `/boot` belongs to the booted image rather than to
that partition. `vyos.system.grub.set_console_type()` defaults `root_dir` to
`disk.find_persistence()` for the same reason.

The `cat` fails, `basic_cli_tests()` raises, and the harness aborts with
"The ISO image is not considered usable!" before a single smoketest runs.

Resolve the persistence directory the way `vyos.system.grub` does instead of
assuming `/`. The assertion itself is unchanged.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T9301

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Reproduced locally on amd64 with `console_type "ttyS"`, so it is not specific to
the ttyAMA0 platforms the check was written for. It appears with `c7eef9dd`
(Testsuite: T8375: verify proper serial console settings) in the tree; whether
upstream CI hits the same path has not been checked.

Before, after `install image` and reboot:

vyos@vyos:~$ cat /boot/grub/grub.cfg.d/20-vyos-defaults-autoload.cfg | grep "set console_type"
cat: /boot/grub/grub.cfg.d/20-vyos-defaults-autoload.cfg: No such file or directory

ERROR - Hmm... system got an exception while processing.
ERROR - The ISO image is not considered usable!
make: *** [Makefile:44: test] Error 1

After, same image and same QEMU invocation:

vyos@vyos:~$ persist=$(python3 -c "from vyos.system.disk import find_persistence; print(find_persistence())")
vyos@vyos:~$ grep "set console_type" $persist/boot/grub/grub.cfg.d/20-vyos-defaults-autoload.cfg
set console_type="ttyS"

The run then completes:

DEBUG - Ran 24 tests in 108.758s
DEBUG - OK

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
